### PR TITLE
fix(switch): focus access

### DIFF
--- a/packages/nextui/src/switch/switch.tsx
+++ b/packages/nextui/src/switch/switch.tsx
@@ -144,10 +144,9 @@ const Switch: React.FC<SwitchProps> = ({
         }
         input {
           overflow: hidden;
-          visibility: hidden;
-          height: 0;
+          height: ${height};
           opacity: 0;
-          width: 0;
+          width: 100%;
           position: absolute;
           background: transparent;
           z-index: -1;


### PR DESCRIPTION
## Switch

#32 

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Switches weren't accessible by focus, so I change a little bit the CSS to be able to do it. However, the focus continues not to show anything by design. We should find a way to show the focus stage in a visible way without breaking the system design

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->