### PR TITLE
fix: Table of contents duplication

### DIFF
--- a/packages/docs/src/components/table-of-content/index.tsx
+++ b/packages/docs/src/components/table-of-content/index.tsx
@@ -28,9 +28,9 @@ const TableOfContent: React.FC<TableOfContentProps> = ({
     <div className="container" {...props}>
       <h4 className="title">Contents</h4>
       <ul className="list">
-        {headings.map((heading) => (
+        {headings.map((heading, i) => (
           <li
-            key={heading.id}
+            key={i}
             className={cn('list-item', {
               active: activeId == heading.id,
             })}


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
On the docs page, the "TableOfContent" component shows the list of headings and that's ok. But on the "Input" component page there are two "Input Types" heading and that causes the problem.

#### Steps to reproduce

1. Go Theme/Palette page
2. Go Input page
3. Go Theme/Palette page and you will see "Input Types" in the content list. If you repeat this circle it will add more "Input Types" 

### Screenshots - Animations
<img width="216" alt="Screen Shot 2021-10-10 at 00 08 17" src="https://user-images.githubusercontent.com/8071787/136673936-ad7512f9-8ad9-4b0e-b237-893031b6bd98.png">