### PR TITLE
fix: Tooltip props title is incorrect

### DIFF
--- a/packages/docs/content/docs/components/tooltip.mdx
+++ b/packages/docs/content/docs/components/tooltip.mdx
@@ -353,7 +353,7 @@ import { Tooltip } from '@nextui-org/react';
 
 <Spacer y={2} />
 
-#### Checkbox Props
+#### Tooltip Props
 
 | Attribute           | Type                       | Accepted values                                      | Description                                                | Default   |
 | ------------------- | -------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- | --------- |


### PR DESCRIPTION
## [docs]/[tooltip]


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The props title of the component page is wrong. The PR fix this issue.
