### PR TITLE
fix: "Report a bug" button issue (fix #71)

### DIFF
--- a/packages/docs/src/components/playground/editor.tsx
+++ b/packages/docs/src/components/playground/editor.tsx
@@ -42,6 +42,17 @@ const Editor: React.FC = () => {
     }, 200);
   };
 
+  const linkHandler = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    
+    Object.assign(document.createElement('a'), {
+      target: '_blank',
+      rel: "noopener noreferrer",
+      href: `${ISSUE_REPORT_URL}${componentTitle}`,
+    }).click();
+  };
+
   return (
     <div className="editor">
       <details open={visible}>
@@ -83,6 +94,7 @@ const Editor: React.FC = () => {
                     title="Report a bug"
                     rel="noopener noreferrer"
                     target="_blank"
+                    onClick={linkHandler}
                     href={`${ISSUE_REPORT_URL}${componentTitle}`}
                   >
                     <BugIcon fill={theme.palette.accents_6} size={18} />


### PR DESCRIPTION
## [docs]/[playground]
**TASK**: https://github.com/nextui-org/nextui/issues/71


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The issue is caused by the event handler added for the live editor tab. I add a new handler for the "Report a bug" button. Now simulating anchor click for a virtual anchor.

While handling the anchor with stopPropagation in Chrome is sufficient, this solution does not work in Safari. So I used virtual anchor.
