### PR TITLE
feat: Remove gradient options from document (fix #78)

### DIFF
--- a/packages/docs/content/docs/components/tooltip.mdx
+++ b/packages/docs/content/docs/components/tooltip.mdx
@@ -93,13 +93,6 @@ import { Tooltip } from '@nextui-org/react';
         </Tooltip>
     </Grid>
     <Grid>
-        <Tooltip text="Developers love Next.js" color="gradient">
-            <Button auto color="gradient">
-                Gradient
-            </Button>
-        </Tooltip>
-    </Grid>
-    <Grid>
         <Tooltip text="Developers love Next.js" color="#ff4ecd">
             <Button auto flat color="#ff4ecd">
                 Custom
@@ -154,13 +147,6 @@ import { Tooltip } from '@nextui-org/react';
         <Tooltip text="Developers love Next.js" textColor="error" color="white">
             <Button flat auto color="error">
                 Error
-            </Button>
-        </Tooltip>
-    </Grid>
-    <Grid>
-        <Tooltip text="Developers love Next.js" textColor="primary" color="white">
-            <Button auto color="gradient">
-                Gradient
             </Button>
         </Tooltip>
     </Grid>
@@ -390,8 +376,7 @@ type TooltipColors =
   | 'success'
   | 'warning'
   | 'error'
-  | 'invert'
-  | 'gradient';
+  | 'invert';
 ```
 
 #### Simple Colors


### PR DESCRIPTION
## [docs]/[tooltip]
**TASK**: https://github.com/nextui-org/nextui/issues/78


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Remove the gradient options from documents until the gradient development is completed.

### Screenshots - Animations
<img width="938" alt="Screen Shot 2021-10-10 at 22 48 00" src="https://user-images.githubusercontent.com/8071787/136710999-2a4c0ff6-aca4-42ff-9014-146775c140fc.png">

