### PR TITLE
fix: open fullscreen modal on Windows OS

### DIFF
--- a/packages/nextui/src/backdrop/index.tsx
+++ b/packages/nextui/src/backdrop/index.tsx
@@ -91,6 +91,10 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
               box-sizing: border-box;
               text-align: center;
             }
+            .backdrop.fullscreen {
+              display: inline-flex;
+              overflow: hidden;
+            }
             .content {
               position: relative;
               z-index: 999999;


### PR DESCRIPTION
## [fix]/[modal]
[GitHub ISSUE #93](https://github.com/nextui-org/nextui/issues/93)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Adding ``display: inline-flex`` when fullscreen and ``overflow: hidden`` to solve issue #93 on Windows OS.


### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->