### PR TITLE
fix(react-navbar)[#838]: firefox navbar issue

### DIFF
--- a/packages/react/src/navbar/navbar.styles.ts
+++ b/packages/react/src/navbar/navbar.styles.ts
@@ -237,6 +237,9 @@ export const StyledNavbarItem = styled(
     fontSize: "$$navbarItemFontSize",
     fontWeight: "$$navbarItemFontWeight",
     position: "relative",
+    "& *": {
+      maxW: "none !important",
+    },
     "> *": {
       zIndex: "$2",
       fontSize: "inherit !important",


### PR DESCRIPTION

Closes #838 

## 📝 Description

Firefox does not render expected

![스크린샷 2022-11-09 오전 12 50 54](https://user-images.githubusercontent.com/26461307/200611888-52dbb81e-1591-4cf9-a4b5-56d90134c12b.png)
> `firefox` in docs 

![스크린샷 2022-11-09 오전 12 52 09](https://user-images.githubusercontent.com/26461307/200612179-98263d80-8619-4ff7-a363-f631aa0bb743.png)
> `firefox` in storybook


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

This issue comes from [`link.styles.ts > maxW: max-content`](https://github.com/nextui-org/nextui/blob/f85a569b4782e99124c752269867272dc91f6313/packages/react/src/link/link.styles.ts#L26)

https://github.com/nextui-org/nextui/blob/f85a569b4782e99124c752269867272dc91f6313/packages/react/src/link/link.styles.ts#L26

> I do not know exactly why firefox does render this way

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

![스크린샷 2022-11-09 오전 12 55 36](https://user-images.githubusercontent.com/26461307/200613060-0ef60e31-00e7-45ed-8af1-7ad023856378.png)

> `firefox` in docs

![스크린샷 2022-11-09 오전 12 55 55](https://user-images.githubusercontent.com/26461307/200613157-44dd4106-57c9-49eb-9033-85df1a4ba201.png)

> `firefox` in storybook

![스크린샷 2022-11-09 오전 1 01 53](https://user-images.githubusercontent.com/26461307/200614663-7a691738-9203-4178-a50a-6817ce0f1194.png)


> `chrome` in docs

![스크린샷 2022-11-09 오전 1 02 28](https://user-images.githubusercontent.com/26461307/200614795-1a2e2bda-364f-4085-9f17-66f4cb12e079.png)

> `chrome` in storybook

set `maxW: none !important` where under the Navbar Item



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No. because same render result where chrome and other browsers.

## 📝 Additional Information

I thought diffrent way to disable `maxW: max-content` at `link.styles.ts`. but I think this way cause another issue. what do you think about it?