### PR TITLE
ci: added RTL eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,6 +87,13 @@
         "prev": ["const", "let", "var"],
         "next": ["const", "let", "var"]
       }
+    ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "Literal[value=/(left|right|[mptb-][rl])-/]",
+        "message": "Try to use start and end instead of left and right for better RTL support. https://tailwindcss.com/blog/tailwindcss-v3-3#simplified-rtl-support-with-logical-properties"
+      }
     ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,7 +91,7 @@
     "no-restricted-syntax": [
       "error",
       {
-        "selector": "Literal[value=/(left|right|[mptb-][rl])-/]",
+        "selector": "Literal[value=/(left|right|[mptb-][rl])-/],TemplateElement[value.raw=/(left|right|[mptb-][rl])-/]",
         "message": "Try to use start and end instead of left and right for better RTL support. https://tailwindcss.com/blog/tailwindcss-v3-3#simplified-rtl-support-with-logical-properties"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jest --verbose --config ./jest.config.js",
     "typecheck": "turbo typecheck",
     "lint": "pnpm lint:pkg && pnpm lint:docs",
-    "lint:pkg": "eslint -c .eslintrc.json ./packages/**/**/*.{ts,tsx}",
+    "lint:pkg": "eslint -c .eslintrc.json ./packages/**/*.{ts,tsx}",
     "lint:docs": "eslint -c .eslintrc.json ./apps/docs/**/*.{ts,tsx}",
     "lint:fix": "eslint --fix -c .eslintrc.json ./packages/**/**/*.{ts,tsx}",
     "lint:docs-fix": "eslint --fix -c .eslintrc.json ./apps/docs/**/*.{ts,tsx}",


### PR DESCRIPTION
A simple check that we don't use the tailwind classes that are direction dependend.

This also fails for dropdown where you can use `left-start` for example as a position, which IMO is a good thing, we should have named it `start-start` instead.

But for now we probably just have to add an eslint ignore for the placement failure, due to changing it being a breaking change.