### PR TITLE
Fix: Added few missing imports

### DIFF
--- a/apps/docs/content/components/navbar/with-menu.ts
+++ b/apps/docs/content/components/navbar/with-menu.ts
@@ -9,7 +9,7 @@ const AcmeLogo = `export const AcmeLogo = () => (
   </svg>
 );`;
 
-const App = `import {Navbar, NavbarBrand, NavbarContent, NavbarItem, Link, Button} from "@nextui-org/react";
+const App = `import {Navbar, NavbarBrand, NavbarContent, NavbarItem, NavbarMenuToggle, NavbarMenu, NavbarMenuItem, Link, Button} from "@nextui-org/react";
 import {AcmeLogo} from "./AcmeLogo.jsx";
 
 export default function App() {


### PR DESCRIPTION
PR Type `docs`,`refactoring`

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

In the [Navbar With Menu example](https://nextui.org/docs/components/navbar#with-menu) example, there were a few missing imports
- `NavbarMenuToggle`
- `NavbarMenu`
- `NavbarMenuItem`

## ⛳️ Current behavior (updates)

Currently, when users copy the code example of Navbar WITH MENU few missing imports are used in the return (`elements`)

## 🚀 New behavior

Added the correct import statement.

## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information
