### PR TITLE
feat: add props format to change format easily in date-input

### DIFF
--- a/.changeset/unlucky-trainers-fetch.md
+++ b/.changeset/unlucky-trainers-fetch.md
@@ -1,0 +1,18 @@
+---
+"@nextui-org/date-input": major
+---
+
+Summary : Add format props to component date-input
+
+WHY
+If a user wanted to change the date format into this component, he had to use the i18n provider.
+The solution is added to format props like "dd/mm/yyyy" to change it easily.
+
+HOW
+Add props `format` to change it into date-input component like this.
+
+```
+<DateInput {...props} format="dd/mm/yyyy"/>
+```
+
+The `format` props is not simple string. Is type with determinated format.

--- a/packages/components/date-input/stories/date-input.stories.tsx
+++ b/packages/components/date-input/stories/date-input.stories.tsx
@@ -62,11 +62,18 @@ export default {
       },
       options: ["aria", "native"],
     },
+    format: {
+      control: {
+        type: "select",
+      },
+      options: ["mm/dd/yyyy", "dd/mm/yyyy", "yyyy/mm/dd", "yyyy/dd/mm"],
+    },
   },
 } as Meta<typeof DateInput>;
 
 const defaultProps = {
   label: "Birth date",
+  format: "mm/dd/yyyy",
   ...dateInput.defaultVariants,
 };
 
@@ -170,6 +177,7 @@ export const Default = {
   render: Template,
   args: {
     ...defaultProps,
+    formattedDate: "dd/mm/yyyy",
   },
 };
 


### PR DESCRIPTION
Closes #3286 

## 📝 Description
Add `format` props in date-input component to change format easily.

## ⛳️ Current behavior (updates)

The component's behavior is to display the "mm/dd/yyyy" format, and it's not possible to change it unless you use an i18n provider.

## 🚀 New behavior

### Behavior
Add optional `format` to `<DateInput />` to change easily format. The `format` props is not simple string. Is type of 4 format `dd/mm/yyyy`, `mm/dd/yyyy`, `yyyy/dd/mm`, `yyyy/mm/dd`.

### Codes
Add some functions to manage the state of `DateSegments` and add enum to manage easily a list of available format.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

A video to explain new behavior in Storybook.

https://github.com/nextui-org/nextui/assets/21367485/b72ddf34-e12a-4dec-8f0d-47084e9a1d18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added a `format` prop to the `DateInput` component, allowing users to easily change the date format.
    - Enhanced the `DateInput` component story to include a `format` control with selectable date format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->