### PR TITLE
docs(sidebar): updated badge color for better appearance and contrast

### DIFF
--- a/apps/docs/components/docs/sidebar.tsx
+++ b/apps/docs/components/docs/sidebar.tsx
@@ -170,12 +170,7 @@ function TreeItem<T>(props: TreeItemProps<T>) {
           {rendered}
         </span>
         {isUpdated && (
-          <Chip
-            className="ml-1 py-1 text-tiny text-default-400 bg-default-100/50"
-            color="default"
-            size="sm"
-            variant="flat"
-          >
+          <Chip className="ml-1 py-1 text-tiny" color="success" size="sm" variant="flat">
             Updated
           </Chip>
         )}
@@ -185,7 +180,7 @@ function TreeItem<T>(props: TreeItemProps<T>) {
           </Chip>
         )}
         {item.props?.comingSoon && (
-          <Chip className="ml-1 py-1 text-tiny" color="default" size="sm" variant="flat">
+          <Chip className="ml-1 py-1 text-tiny" color="secondary" size="sm" variant="flat">
             Coming soon
           </Chip>
         )}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

Updated the color badge from `default` to `success` for a better appearance

## ⛳️ Current behavior (updates)

<img width="237" alt="Screenshot 2024-07-11 at 5 11 13 PM" src="https://github.com/nextui-org/nextui/assets/147910430/8ceb2ad2-8309-470e-99ff-dac71c1d62ef">


## 🚀 New behavior

<img width="233" alt="Screenshot 2024-07-11 at 5 10 20 PM" src="https://github.com/nextui-org/nextui/assets/147910430/ae8df48e-2767-4d77-9404-ecb15d80036e">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated the "Updated" label color to green.
  - Updated the "Coming soon" label color to blue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->