### PR TITLE
fix(accordion): add missing ref to AccordionItem

### DIFF
--- a/.changeset/neat-trains-sit.md
+++ b/.changeset/neat-trains-sit.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/accordion": patch
+---
+
+Added ref to AccordionItem

--- a/packages/components/accordion/__tests__/accordion.test.tsx
+++ b/packages/components/accordion/__tests__/accordion.test.tsx
@@ -375,4 +375,15 @@ describe("Accordion", () => {
 
     expect(getByRole("separator")).toHaveClass("bg-rose-500");
   });
+
+  it("AccordionItem ref should be forwarded", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+
+    render(
+      <Accordion>
+        <AccordionItem ref={ref}>Accordion Item</AccordionItem>
+      </Accordion>,
+    );
+    expect(ref.current).not.toBeNull();
+  });
 });

--- a/packages/components/accordion/src/accordion.tsx
+++ b/packages/components/accordion/src/accordion.tsx
@@ -36,6 +36,7 @@ const AccordionGroup = forwardRef<"div", AccordionProps>((props, ref) => {
       return (
         <Fragment key={item.key}>
           <AccordionItem
+            ref={(props.children[index] || props.children).ref}
             item={item}
             variant={props.variant}
             onFocusChange={handleFocusChanged}

--- a/packages/components/accordion/src/base/accordion-item-base.tsx
+++ b/packages/components/accordion/src/base/accordion-item-base.tsx
@@ -7,7 +7,7 @@ import type {
 import {As} from "@nextui-org/system";
 import {ItemProps, BaseItem} from "@nextui-org/aria-utils";
 import {FocusableProps, PressEvents} from "@react-types/shared";
-import {ReactNode, MouseEventHandler} from "react";
+import {ReactNode, MouseEventHandler, Ref} from "react";
 import {HTMLMotionProps} from "framer-motion";
 
 export type AccordionItemIndicatorProps = {
@@ -94,7 +94,8 @@ export interface Props<T extends object = {}>
   HeadingComponent?: As;
 }
 
-export type AccordionItemBaseProps<T extends object = {}> = Props<T> & AccordionItemVariantProps;
+export type AccordionItemBaseProps<T extends object = {}> = Props<T> &
+  AccordionItemVariantProps & {ref?: Ref<HTMLButtonElement>};
 
 const AccordionItemBase = BaseItem as (props: AccordionItemBaseProps) => JSX.Element;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3498 

## 📝 Description

Fix issue where AccordionItem ref is not properly implemented, add typescript typing

## ⛳️ Current behavior (updates)

AccordionItem does not currently support ref.

## 🚀 New behavior

AccordionItem now implements ref.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

<img width="1080" alt="Accordion Ref Bug Fixed" src="https://github.com/user-attachments/assets/c458e2cd-107a-4e1b-9ef3-4814372335a8">

<img width="766" alt="Accordion Ref Bug Test Pass" src="https://github.com/user-attachments/assets/2e5ed3cd-3ed1-4cd7-b062-390c1d36aa7a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `AccordionItem` component to support ref forwarding, improving focus management and interactivity.
	- Added a reference to `AccordionItem` within the accordion package for better organization and accessibility.

- **Tests**
	- Added a new test case to verify the correct forwarding of refs in the `AccordionItem`, increasing test coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->