### PR TITLE
feat: replace framer-motion with motion

### DIFF
--- a/apps/docs/components/blog-post.tsx
+++ b/apps/docs/components/blog-post.tsx
@@ -5,7 +5,7 @@ import {Card, CardFooter, CardBody, CardHeader, Link, Avatar, Image} from "@next
 import Balancer from "react-wrap-balancer";
 import {format, parseISO} from "date-fns";
 import NextLink from "next/link";
-import {AnimatePresence, motion} from "framer-motion";
+import {AnimatePresence, motion} from "motion/react";
 import {usePostHog} from "posthog-js/react";
 
 import {useIsMounted} from "@/hooks/use-is-mounted";

--- a/apps/docs/components/blog/video-in-view.tsx
+++ b/apps/docs/components/blog/video-in-view.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 "use client";
 
-import {useInView} from "framer-motion";
+import {useInView} from "motion/react";
 import {useRef, FC, useEffect, useState, useCallback} from "react";
 import {Button, cn, Spinner, Tooltip} from "@nextui-org/react";
 

--- a/apps/docs/components/docs/components/code-demo/code-demo.tsx
+++ b/apps/docs/components/docs/components/code-demo/code-demo.tsx
@@ -3,7 +3,7 @@
 import React, {useCallback, useMemo, useRef} from "react";
 import dynamic from "next/dynamic";
 import {Skeleton, Tab, Tabs} from "@nextui-org/react";
-import {useInView} from "framer-motion";
+import {useInView} from "motion/react";
 
 import {useCodeDemo, UseCodeDemoProps} from "./use-code-demo";
 import WindowResizer, {WindowResizerProps} from "./window-resizer";

--- a/apps/docs/components/docs/components/code-demo/window-resizer.tsx
+++ b/apps/docs/components/docs/components/code-demo/window-resizer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {motion, useMotionValue, useTransform} from "framer-motion";
+import {motion, useMotionValue, useTransform} from "motion/react";
 import {tv} from "tailwind-variants";
 
 import {useIsMobile} from "@/hooks/use-media-query";

--- a/apps/docs/components/marketing/a11y-otb.tsx
+++ b/apps/docs/components/marketing/a11y-otb.tsx
@@ -11,7 +11,7 @@ import {
   DropdownItem,
   Tooltip,
 } from "@nextui-org/react";
-import {useInView} from "framer-motion";
+import {useInView} from "motion/react";
 import {clsx} from "@nextui-org/shared-utils";
 import {
   AddNoteBulkIcon,

--- a/apps/docs/components/navbar.tsx
+++ b/apps/docs/components/navbar.tsx
@@ -25,7 +25,7 @@ import {isAppleDevice} from "@react-aria/utils";
 import {clsx} from "@nextui-org/shared-utils";
 import NextLink from "next/link";
 import {usePathname} from "next/navigation";
-import {motion, AnimatePresence} from "framer-motion";
+import {motion, AnimatePresence} from "motion/react";
 import {useEffect} from "react";
 import {usePress} from "@react-aria/interactions";
 import {useFocusRing} from "@react-aria/focus";

--- a/apps/docs/components/sandpack/use-sandpack.ts
+++ b/apps/docs/components/sandpack/use-sandpack.ts
@@ -70,7 +70,7 @@ export const useSandpack = ({
   }, {});
 
   let dependencies = {
-    "framer-motion": "11.9.0",
+    motion: "11.13.1",
     "@nextui-org/react": "latest",
   };
 
@@ -143,7 +143,7 @@ export const useSandpack = ({
 
   // const dependencies = useMemo(() => {
   //   let deps = {
-  //     "framer-motion": "11.9.0",
+  //     "motion": "11.11.12",
   //   };
 
   //   if (hasComponents) {

--- a/apps/docs/config/search-meta.json
+++ b/apps/docs/config/search-meta.json
@@ -10774,14 +10774,14 @@
     }
   },
   {
-    "content": "Why does NextUI use Framer Motion?",
+    "content": "Why does NextUI use Motion?",
     "objectID": "d76533f7-0ca8-40cd-b77a-80f708d8d744",
     "type": "lvl3",
-    "url": "/docs/guide/introduction#why-does-nextui-use-framer-motion",
+    "url": "/docs/guide/introduction#why-does-nextui-use-motion",
     "hierarchy": {
       "lvl1": "Introduction",
       "lvl2": "Can I use NextUI with other front-end frameworks or libraries, such as Vue or Angular?",
-      "lvl3": "Why does NextUI use Framer Motion?"
+      "lvl3": "Why does NextUI use Motion?"
     }
   },
   {
@@ -11096,7 +11096,7 @@
     "content": "Install Framer motion",
     "objectID": "ef778f69-5c80-44b6-a995-1385c7136cdf",
     "type": "lvl3",
-    "url": "/docs/guide/upgrade-to-v2#install-framer-motion",
+    "url": "/docs/guide/upgrade-to-v2#install-motion",
     "hierarchy": {
       "lvl1": "Upgrade to v2",
       "lvl2": "Upgrade React version",

--- a/apps/docs/content/docs/api-references/nextui-provider.mdx
+++ b/apps/docs/content/docs/api-references/nextui-provider.mdx
@@ -5,7 +5,7 @@ description: API References for NextUI Provider
 
 # NextUI Provider
 
-API reference for the `NextUIProvider`. 
+API reference for the `NextUIProvider`.
 
 ------
 
@@ -67,11 +67,11 @@ Here's the supported locales. By default, It is `en-US`.
 ```tsx
 const localeValues = [
   'fr-FR', 'fr-CA', 'de-DE', 'en-US', 'en-GB', 'ja-JP',
-  'da-DK', 'nl-NL', 'fi-FI', 'it-IT', 'nb-NO', 'es-ES', 
-  'sv-SE', 'pt-BR', 'zh-CN', 'zh-TW', 'ko-KR', 'bg-BG', 
-  'hr-HR', 'cs-CZ', 'et-EE', 'hu-HU', 'lv-LV', 'lt-LT', 
-  'pl-PL', 'ro-RO', 'ru-RU', 'sr-SP', 'sk-SK', 'sl-SI', 
-  'tr-TR', 'uk-UA', 'ar-AE', 'ar-DZ', 'AR-EG', 'ar-SA', 
+  'da-DK', 'nl-NL', 'fi-FI', 'it-IT', 'nb-NO', 'es-ES',
+  'sv-SE', 'pt-BR', 'zh-CN', 'zh-TW', 'ko-KR', 'bg-BG',
+  'hr-HR', 'cs-CZ', 'et-EE', 'hu-HU', 'lv-LV', 'lt-LT',
+  'pl-PL', 'ro-RO', 'ru-RU', 'sr-SP', 'sk-SK', 'sl-SI',
+  'tr-TR', 'uk-UA', 'ar-AE', 'ar-DZ', 'AR-EG', 'ar-SA',
   'el-GR', 'he-IL', 'fa-AF', 'am-ET', 'hi-IN', 'th-TH'
 ];
 ```
@@ -112,7 +112,7 @@ interface AppProviderProps {
 
 `createCalendar`
 
-- **Description**: 
+- **Description**:
     This function helps to reduce the bundle size by providing a custom calendar system.
 
     By default, this includes all calendar systems supported by `@internationalized/date`. However,
@@ -144,7 +144,7 @@ interface AppProviderProps {
 
 `disableAnimation`
 
-- **Description**: Disables animations globally. This will also avoid `framer-motion` features to be loaded in the bundle which can potentially reduce the bundle size.
+- **Description**: Disables animations globally. This will also avoid `motion` features to be loaded in the bundle which can potentially reduce the bundle size.
 - **Type**: `boolean`
 - **Default**: `false`
 
@@ -158,12 +158,12 @@ interface AppProviderProps {
 
 <Spacer y={2}/>
 
-`skipFramerMotionAnimations`
+`skipMotionAnimations`
 
 - **Description**:
-  Controls whether `framer-motion` animations are skipped within the application.
+  Controls whether `motion` animations are skipped within the application.
   This property is automatically enabled (`true`) when the `disableAnimation` prop is set to `true`,
-  effectively skipping all `framer-motion` animations. To retain `framer-motion` animations while
+  effectively skipping all `motion` animations. To retain `motion` animations while
   using the `disableAnimation` prop for other purposes, set this to `false`. However, note that
   animations in NextUI Components are still omitted if the `disableAnimation` prop is `true`.
 - **Type**: `boolean`
@@ -173,14 +173,14 @@ interface AppProviderProps {
 
 `validationBehavior`
 
-- **Description**: Whether to use native HTML form validation to prevent form submission when the value is missing or invalid, 
+- **Description**: Whether to use native HTML form validation to prevent form submission when the value is missing or invalid,
 or mark the field as required or invalid via ARIA.
 - **Type**: `native | aria`
 - **Default**: `aria`
 
 `reducedMotion`
 
-- **Description**: Controls the motion preferences for the entire application, allowing developers to respect user settings for reduced motion. 
+- **Description**: Controls the motion preferences for the entire application, allowing developers to respect user settings for reduced motion.
 The available options are:
   - `"user"`: Adapts to the user's device settings for reduced motion.
   - `"always"`: Disables all animations.

--- a/apps/docs/content/docs/frameworks/astro.mdx
+++ b/apps/docs/content/docs/frameworks/astro.mdx
@@ -31,10 +31,10 @@ In your Astro project, run one of the following command to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
-    bun: "bun add @nextui-org/react framer-motion"
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
+    bun: "bun add @nextui-org/react motion"
   }}
 />
 
@@ -55,7 +55,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/astro) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/astro) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.cjs` file:
 
 <Blockquote color="primary">

--- a/apps/docs/content/docs/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs.mdx
@@ -21,7 +21,7 @@ To use NextUI in your Next.js project, you need to follow the steps below, depen
 
 ## App Directory Setup
 
-Next.js 13 introduces a new `app/` directory structure. By default it uses Server Components. 
+Next.js 13 introduces a new `app/` directory structure. By default it uses Server Components.
 As NextUI components use React hooks, we added the `use client;` at build time, so you can import them
 directly in your React Server Components (RSC).
 
@@ -39,7 +39,7 @@ npm install -g nextui-cli
 nextui init -t app
 ```
 
-### create-next-app 
+### create-next-app
 
 If you are starting a new project, you can run one of the following commands to create a Next.js project pre-configured with NextUI:
 
@@ -146,10 +146,10 @@ In your Next.js project, run one of the following commands to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
-    bun: "bun add @nextui-org/react framer-motion"
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
+    bun: "bun add @nextui-org/react motion"
   }}
 />
 
@@ -170,7 +170,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.js` file:
 
 <Blockquote color="primary">
@@ -242,7 +242,7 @@ export default function RootLayout({children}: { children: React.ReactNode }) {
 }
 ```
 
-> **Note**: NextUI automatically adds two themes, `light` and `dark`, to your application. You can use any 
+> **Note**: NextUI automatically adds two themes, `light` and `dark`, to your application. You can use any
 of them by adding the `dark`/`light` class to the `html` tag. See the [theme docs](/docs/customization/customize-theme) for more details.
 
 
@@ -253,7 +253,7 @@ the `use client;` directive:
 
 ```jsx {2,7}
 // app/page.tsx
-import {Button} from '@nextui-org/button'; 
+import {Button} from '@nextui-org/button';
 
 export default function Page() {
   return (
@@ -263,11 +263,11 @@ export default function Page() {
   )
 }
 ```
-> **Important 🚨**: Note that you need to import the component from the individual package, not from `@nextui-org/react`. 
+> **Important 🚨**: Note that you need to import the component from the individual package, not from `@nextui-org/react`.
 
 </Steps>
 
-## Pages Directory Setup 
+## Pages Directory Setup
 
 ### NextUI CLI (recommended)
 
@@ -285,7 +285,7 @@ nextui init -t pages
 
 If you are using the `/pages` Next.js project structure, you need to follow the steps below.
 
-### create-next-app 
+### create-next-app
 
 If you are starting a new project, you can run one of the following commands to create a Next.js project pre-configured with NextUI:
 
@@ -392,10 +392,10 @@ In your Next.js project, run one of the following commands to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
-    bun: "bun add @nextui-org/react framer-motion"
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
+    bun: "bun add @nextui-org/react motion"
   }}
 />
 
@@ -416,7 +416,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.js` file:
 
 <Blockquote color="primary">

--- a/apps/docs/content/docs/frameworks/remix.mdx
+++ b/apps/docs/content/docs/frameworks/remix.mdx
@@ -25,10 +25,10 @@ In your Remix project, run one of the following command to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
-    bun: "bun add @nextui-org/react framer-motion"
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
+    bun: "bun add @nextui-org/react motion"
   }}
 />
 
@@ -49,7 +49,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/remix) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/remix) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.js` file:
 
 <Blockquote color="primary">

--- a/apps/docs/content/docs/frameworks/vite.mdx
+++ b/apps/docs/content/docs/frameworks/vite.mdx
@@ -26,10 +26,10 @@ In your Vite React project, run one of the following command to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
-    bun: "bun add @nextui-org/react framer-motion"
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
+    bun: "bun add @nextui-org/react motion"
   }}
 />
 
@@ -50,7 +50,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/vite#react) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/vite#react) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.js` file:
 
 <Blockquote color="primary">

--- a/apps/docs/content/docs/guide/installation.mdx
+++ b/apps/docs/content/docs/guide/installation.mdx
@@ -21,7 +21,7 @@ Using the CLI is now the easiest way to start a NextUI project. You can initiali
 
 <Steps>
 
-### Installation 
+### Installation
 Execute one of the following commands in your terminal:
 <PackageManagers
   commands={{
@@ -33,7 +33,7 @@ Execute one of the following commands in your terminal:
 />
 
 ### Initialization and Starting the App
-Initialize the project by using the `init` command. 
+Initialize the project by using the `init` command.
 ```codeBlock bash
 nextui init my-nextui-app
 ```
@@ -133,10 +133,10 @@ To install NextUI, run one of the following commands in your terminal:
 
 <PackageManagers
   commands={{
-    npm: "npm install @nextui-org/react framer-motion",
-    yarn: "yarn add @nextui-org/react framer-motion",
-    pnpm: "pnpm add @nextui-org/react framer-motion",
-    bun: "bun add @nextui-org/react framer-motion"
+    npm: "npm install @nextui-org/react motion",
+    yarn: "yarn add @nextui-org/react motion",
+    pnpm: "pnpm add @nextui-org/react motion",
+    bun: "bun add @nextui-org/react motion"
   }}
 />
 
@@ -228,10 +228,10 @@ Run one of the following commands in your terminal to install the core packages:
 
 <PackageManagers
   commands={{
-    npm: "npm install @nextui-org/theme @nextui-org/system framer-motion",
-    yarn: "yarn add @nextui-org/theme @nextui-org/system framer-motion",
-    pnpm: "pnpm add @nextui-org/theme @nextui-org/system framer-motion",
-    bun: "bun add @nextui-org/theme @nextui-org/system framer-motion"
+    npm: "npm install @nextui-org/theme @nextui-org/system motion",
+    yarn: "yarn add @nextui-org/theme @nextui-org/system motion",
+    pnpm: "pnpm add @nextui-org/theme @nextui-org/system motion",
+    bun: "bun add @nextui-org/theme @nextui-org/system motion"
   }}
 />
 

--- a/apps/docs/content/docs/guide/upgrade-to-v2.mdx
+++ b/apps/docs/content/docs/guide/upgrade-to-v2.mdx
@@ -12,7 +12,7 @@ Requirements:
 - [Tailwind CSS 3.4](https://tailwindcss.com/) or later
 - [Framer Motion 11.9](https://www.framer.com/motion/) or later
 
------ 
+-----
 
 <CarbonAd/>
 
@@ -23,7 +23,7 @@ Make sure to follow the previous steps since they are required to upgrade to v2.
 
 ## App directory Setup
 
-Next.js 13 introduces a new `app/` directory structure. By default it uses Server Components. 
+Next.js 13 introduces a new `app/` directory structure. By default it uses Server Components.
 As NextUI components use React hooks, we added the `use client;` at build time, so you can import them
 directly in your React Server Components (RSC).
 
@@ -36,9 +36,9 @@ In your Next.js project, run one of the following command to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
   }}
 />
 
@@ -59,7 +59,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.js` file:
 
 
@@ -122,7 +122,7 @@ export default function RootLayout({children}: { children: React.ReactNode }) {
 }
 ```
 
-> **Note**: NextUI automatically add two themes `light` and `dark` to your application. You can use any 
+> **Note**: NextUI automatically add two themes `light` and `dark` to your application. You can use any
 of them by adding the `dark`/`light` class to the `html` tag. See the [theme docs](/docs/customization/customize-theme) for more details.
 
 
@@ -144,13 +144,13 @@ export default function Page() {
 }
 ```
 
-> **Important 🚨**: Note that you need to import the component from the individual package, not the from `@nextui-org/react`. 
+> **Important 🚨**: Note that you need to import the component from the individual package, not the from `@nextui-org/react`.
 
 </Steps>
 
 <Spacer y={8} />
 
-## Pages Directory Setup 
+## Pages Directory Setup
 
 <Steps>
 
@@ -161,9 +161,9 @@ In your Next.js project, run one of the following command to install NextUI:
 
 <PackageManagers
   commands={{
-    npm: 'npm i @nextui-org/react framer-motion',
-    yarn: 'yarn add @nextui-org/react framer-motion',
-    pnpm: 'pnpm add @nextui-org/react framer-motion',
+    npm: 'npm i @nextui-org/react motion',
+    yarn: 'yarn add @nextui-org/react motion',
+    pnpm: 'pnpm add @nextui-org/react motion',
   }}
 />
 
@@ -184,7 +184,7 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 ### Tailwind CSS Setup
 
 NextUI is built on top of Tailwind CSS, so you need to install Tailwind CSS first. You can follow the official
-[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add 
+[installation guide](https://tailwindcss.com/docs/guides/nextjs) to install Tailwind CSS. Then you need to add
 the following code to your `tailwind.config.js` file:
 
 
@@ -260,15 +260,15 @@ NextUI v2 requires React 18 or later. To upgrade React, run the following comman
   }}
 />
 
-### Install Framer motion
+### Install Motion
 
-In v2, NextUI now requires `framer-motion` as a dependency. To install both, use the following command:
+In v2, NextUI now requires `motion` as a dependency. To install both, use the following command:
 
 <PackageManagers
   commands={{
-    npm: 'npm i framer-motion',
-    yarn: 'yarn add framer-motion',
-    pnpm: 'pnpm add framer-motion',
+    npm: 'npm i motion',
+    yarn: 'yarn add motion',
+    pnpm: 'pnpm add motion',
   }}
 />
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -58,7 +58,7 @@
     "color2k": "2.0.3",
     "contentlayer2": "0.5.3",
     "date-fns": "4.1.0",
-    "framer-motion": "11.11.13",
+    "motion": "11.13.1",
     "geist": "1.3.1",
     "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -70,8 +70,8 @@
     "@nextui-org/avatar": "workspace:*",
     "@nextui-org/input": "workspace:*",
     "@nextui-org/test-utils": "workspace:*",
-    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/accordion/src/accordion-item.tsx
+++ b/packages/components/accordion/src/accordion-item.tsx
@@ -1,9 +1,9 @@
-import type {Variants} from "framer-motion";
+import type {Variants} from "motion/react";
 
 import {forwardRef} from "@nextui-org/system";
 import {useMemo, ReactNode} from "react";
 import {ChevronIcon} from "@nextui-org/shared-icons";
-import {AnimatePresence, LazyMotion, m, useWillChange} from "framer-motion";
+import {AnimatePresence, LazyMotion, m, useWillChange} from "motion/react";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
 
 import {UseAccordionItemProps, useAccordionItem} from "./use-accordion-item";

--- a/packages/components/accordion/src/accordion.tsx
+++ b/packages/components/accordion/src/accordion.tsx
@@ -1,5 +1,5 @@
 import {forwardRef} from "@nextui-org/system";
-import {LayoutGroup} from "framer-motion";
+import {LayoutGroup} from "motion/react";
 import {Divider} from "@nextui-org/divider";
 import {Fragment, Key, useCallback, useMemo} from "react";
 

--- a/packages/components/accordion/src/base/accordion-item-base.tsx
+++ b/packages/components/accordion/src/base/accordion-item-base.tsx
@@ -8,7 +8,7 @@ import {As} from "@nextui-org/system";
 import {ItemProps, BaseItem} from "@nextui-org/aria-utils";
 import {FocusableProps, PressEvents} from "@react-types/shared";
 import {ReactNode, MouseEventHandler} from "react";
-import {HTMLMotionProps} from "framer-motion";
+import {HTMLMotionProps} from "motion/react";
 
 export type AccordionItemIndicatorProps = {
   /**

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
     "@nextui-org/theme": ">=2.4.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -73,7 +73,7 @@
     "@nextui-org/use-infinite-scroll": "workspace:*",
     "@react-stately/data": "3.11.7",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hook-form": "^7.51.3"

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -6,7 +6,7 @@ import {Listbox} from "@nextui-org/listbox";
 import {Button} from "@nextui-org/button";
 import {Input} from "@nextui-org/input";
 import {ForwardedRef, ReactElement} from "react";
-import {AnimatePresence} from "framer-motion";
+import {AnimatePresence} from "motion/react";
 
 import {UseAutocompleteProps, useAutocomplete} from "./use-autocomplete";
 

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -57,8 +57,8 @@
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/system": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
-    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/calendar/package.json
+++ b/packages/components/calendar/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
     "@nextui-org/theme": ">=2.4.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -68,7 +68,7 @@
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/radio": "workspace:*",
     "@nextui-org/test-utils": "workspace:*",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/components/calendar/src/calendar-base.tsx
+++ b/packages/components/calendar/src/calendar-base.tsx
@@ -7,7 +7,7 @@ import {Fragment, useState} from "react";
 import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {Button} from "@nextui-org/button";
 import {chain, mergeProps} from "@react-aria/utils";
-import {AnimatePresence, LazyMotion, MotionConfig} from "framer-motion";
+import {AnimatePresence, LazyMotion, MotionConfig} from "motion/react";
 import {ResizablePanel} from "@nextui-org/framer-utils";
 
 import {ChevronLeftIcon} from "./chevron-left";

--- a/packages/components/calendar/src/calendar-header.tsx
+++ b/packages/components/calendar/src/calendar-header.tsx
@@ -3,7 +3,7 @@ import type {CalendarDate} from "@internationalized/date";
 
 import {HTMLNextUIProps} from "@nextui-org/system";
 import {useDateFormatter} from "@react-aria/i18n";
-import {m} from "framer-motion";
+import {m} from "motion/react";
 import {Button} from "@nextui-org/button";
 import {useCallback} from "react";
 

--- a/packages/components/calendar/src/calendar-month.tsx
+++ b/packages/components/calendar/src/calendar-month.tsx
@@ -3,7 +3,7 @@ import {CalendarPropsBase} from "@react-types/calendar";
 import {HTMLNextUIProps} from "@nextui-org/system";
 import {useLocale} from "@react-aria/i18n";
 import {useCalendarGrid} from "@react-aria/calendar";
-import {m} from "framer-motion";
+import {m} from "motion/react";
 import {dataAttr, getInertValue} from "@nextui-org/shared-utils";
 
 import {CalendarCell} from "./calendar-cell";

--- a/packages/components/calendar/src/calendar-transitions.ts
+++ b/packages/components/calendar/src/calendar-transitions.ts
@@ -1,4 +1,4 @@
-import {Variants} from "framer-motion";
+import {Variants} from "motion/react";
 
 export const transition = {
   type: "spring",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -59,8 +59,8 @@
     "@nextui-org/button": "workspace:*",
     "@nextui-org/avatar": "workspace:*",
     "@nextui-org/image": "workspace:*",
-    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
     "@nextui-org/theme": ">=2.4.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -65,8 +65,8 @@
     "@nextui-org/system": "workspace:*",
     "@nextui-org/test-utils": "workspace:*",
     "@nextui-org/theme": "workspace:*",
-    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/date-picker/src/date-picker.tsx
+++ b/packages/components/date-picker/src/date-picker.tsx
@@ -7,7 +7,7 @@ import {Button} from "@nextui-org/button";
 import {DateInput, TimeInput} from "@nextui-org/date-input";
 import {FreeSoloPopover} from "@nextui-org/popover";
 import {Calendar} from "@nextui-org/calendar";
-import {AnimatePresence} from "framer-motion";
+import {AnimatePresence} from "motion/react";
 import {CalendarBoldIcon} from "@nextui-org/shared-icons";
 
 import {UseDatePickerProps, useDatePicker} from "./use-date-picker";

--- a/packages/components/date-picker/src/date-range-picker.tsx
+++ b/packages/components/date-picker/src/date-range-picker.tsx
@@ -7,7 +7,7 @@ import {Button} from "@nextui-org/button";
 import {TimeInput, DateInputGroup} from "@nextui-org/date-input";
 import {FreeSoloPopover} from "@nextui-org/popover";
 import {RangeCalendar} from "@nextui-org/calendar";
-import {AnimatePresence} from "framer-motion";
+import {AnimatePresence} from "motion/react";
 import {CalendarBoldIcon} from "@nextui-org/shared-icons";
 
 import DateRangePickerField from "./date-range-picker-field";

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
     "@nextui-org/theme": ">=2.4.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -62,7 +62,7 @@
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/user": "workspace:*",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -67,7 +67,7 @@
     "@nextui-org/link": "workspace:*",
     "@nextui-org/switch": "workspace:*",
     "react-lorem-component": "0.13.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -1,11 +1,11 @@
 import type {AriaDialogProps} from "@react-aria/dialog";
-import type {HTMLMotionProps} from "framer-motion";
+import type {HTMLMotionProps} from "motion/react";
 
 import {cloneElement, isValidElement, ReactNode, useMemo, useCallback} from "react";
 import {DismissButton} from "@react-aria/overlays";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
 import {CloseIcon} from "@nextui-org/shared-icons";
-import {LazyMotion, m} from "framer-motion";
+import {LazyMotion, m} from "motion/react";
 import {useDialog} from "@react-aria/dialog";
 import {chain, mergeProps, useViewportSize} from "@react-aria/utils";
 import {HTMLNextUIProps} from "@nextui-org/system";

--- a/packages/components/modal/src/modal.tsx
+++ b/packages/components/modal/src/modal.tsx
@@ -1,5 +1,5 @@
 import {ReactNode} from "react";
-import {AnimatePresence} from "framer-motion";
+import {AnimatePresence} from "motion/react";
 import {Overlay} from "@react-aria/overlays";
 import {forwardRef} from "@nextui-org/system";
 

--- a/packages/components/modal/src/use-modal.ts
+++ b/packages/components/modal/src/use-modal.ts
@@ -1,5 +1,5 @@
 import type {ModalVariantProps, SlotsToClasses, ModalSlots} from "@nextui-org/theme";
-import type {HTMLMotionProps} from "framer-motion";
+import type {HTMLMotionProps} from "motion/react";
 
 import {AriaModalOverlayProps} from "@react-aria/overlays";
 import {useAriaModalOverlay} from "@nextui-org/use-aria-modal-overlay";

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -63,7 +63,7 @@
     "@nextui-org/input": "workspace:*",
     "@nextui-org/link": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react-lorem-component": "0.13.0",
     "clean-package": "2.2.0",
     "react": "^18.0.0",

--- a/packages/components/navbar/src/navbar-menu-transitions.ts
+++ b/packages/components/navbar/src/navbar-menu-transitions.ts
@@ -1,4 +1,4 @@
-import {Variants} from "framer-motion";
+import {Variants} from "motion/react";
 
 export const menuVariants: Variants = {
   enter: {

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -1,7 +1,7 @@
 import {forwardRef, HTMLNextUIProps} from "@nextui-org/system";
 import {useDOMRef} from "@nextui-org/react-utils";
 import {clsx, dataAttr} from "@nextui-org/shared-utils";
-import {AnimatePresence, HTMLMotionProps, LazyMotion, m} from "framer-motion";
+import {AnimatePresence, HTMLMotionProps, LazyMotion, m} from "motion/react";
 import {mergeProps} from "@react-aria/utils";
 import {Overlay} from "@react-aria/overlays";
 

--- a/packages/components/navbar/src/navbar-transitions.ts
+++ b/packages/components/navbar/src/navbar-transitions.ts
@@ -1,4 +1,4 @@
-import {Variants} from "framer-motion";
+import {Variants} from "motion/react";
 import {TRANSITION_EASINGS} from "@nextui-org/framer-utils";
 
 export const hideOnScrollVariants: Variants = {

--- a/packages/components/navbar/src/navbar.tsx
+++ b/packages/components/navbar/src/navbar.tsx
@@ -1,6 +1,6 @@
 import {forwardRef} from "@nextui-org/system";
 import {pickChildren} from "@nextui-org/react-utils";
-import {LazyMotion, m} from "framer-motion";
+import {LazyMotion, m} from "motion/react";
 import {mergeProps} from "@react-aria/utils";
 
 import {hideOnScrollVariants} from "./navbar-transitions";

--- a/packages/components/navbar/src/use-navbar.ts
+++ b/packages/components/navbar/src/use-navbar.ts
@@ -14,7 +14,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {mergeProps, useResizeObserver} from "@react-aria/utils";
 import {useScrollPosition} from "@nextui-org/use-scroll-position";
 import {useControlledState} from "@react-stately/utils";
-import {HTMLMotionProps} from "framer-motion";
+import {HTMLMotionProps} from "motion/react";
 import {usePreventScroll} from "@react-aria/overlays";
 
 interface Props extends HTMLNextUIProps<"nav"> {

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
     "@nextui-org/theme": ">=2.4.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -64,7 +64,7 @@
     "@nextui-org/system": "workspace:*",
     "@nextui-org/theme": "workspace:*",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/popover/src/free-solo-popover.tsx
+++ b/packages/components/popover/src/free-solo-popover.tsx
@@ -10,7 +10,7 @@
 import * as React from "react";
 import {DismissButton, Overlay} from "@react-aria/overlays";
 import {forwardRef} from "@nextui-org/system";
-import {HTMLMotionProps, LazyMotion, m} from "framer-motion";
+import {HTMLMotionProps, LazyMotion, m} from "motion/react";
 import {mergeProps} from "@react-aria/utils";
 import {getTransformOrigins} from "@nextui-org/aria-utils";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -1,10 +1,10 @@
 import type {AriaDialogProps} from "@react-aria/dialog";
-import type {HTMLMotionProps} from "framer-motion";
+import type {HTMLMotionProps} from "motion/react";
 
 import {DOMAttributes, ReactNode, useMemo, useRef} from "react";
 import {DismissButton} from "@react-aria/overlays";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
-import {m, LazyMotion} from "framer-motion";
+import {m, LazyMotion} from "motion/react";
 import {HTMLNextUIProps} from "@nextui-org/system";
 import {getTransformOrigins} from "@nextui-org/aria-utils";
 import {useDialog} from "@react-aria/dialog";

--- a/packages/components/popover/src/popover.tsx
+++ b/packages/components/popover/src/popover.tsx
@@ -1,7 +1,7 @@
 import {Children, ReactNode} from "react";
 import {forwardRef} from "@nextui-org/system";
 import {Overlay} from "@react-aria/overlays";
-import {AnimatePresence} from "framer-motion";
+import {AnimatePresence} from "motion/react";
 
 import {UsePopoverProps, usePopover} from "./use-popover";
 import {PopoverProvider} from "./popover-context";

--- a/packages/components/popover/src/use-popover.ts
+++ b/packages/components/popover/src/use-popover.ts
@@ -1,5 +1,5 @@
 import type {PopoverVariantProps, SlotsToClasses, PopoverSlots} from "@nextui-org/theme";
-import type {HTMLMotionProps} from "framer-motion";
+import type {HTMLMotionProps} from "motion/react";
 import type {PressEvent} from "@react-types/shared";
 
 import {RefObject, Ref, useEffect} from "react";

--- a/packages/components/ripple/package.json
+++ b/packages/components/ripple/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -49,7 +49,7 @@
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/system": "workspace:*",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/ripple/src/ripple.tsx
+++ b/packages/components/ripple/src/ripple.tsx
@@ -1,9 +1,9 @@
 import type {RippleType} from "./use-ripple";
 import type {FC} from "react";
-import type {HTMLMotionProps} from "framer-motion";
+import type {HTMLMotionProps} from "motion/react";
 import type {HTMLNextUIProps} from "@nextui-org/system";
 
-import {AnimatePresence, m, LazyMotion} from "framer-motion";
+import {AnimatePresence, m, LazyMotion} from "motion/react";
 import {clamp} from "@nextui-org/shared-utils";
 
 export interface RippleProps extends HTMLNextUIProps<"span"> {

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
     "@nextui-org/theme": ">=2.4.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -73,7 +73,7 @@
     "@react-aria/i18n": "3.12.3",
     "@react-stately/data": "3.11.7",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hook-form": "^7.51.3"

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -9,7 +9,7 @@ import {forwardRef} from "@nextui-org/system";
 import {ScrollShadow} from "@nextui-org/scroll-shadow";
 import {cloneElement} from "react";
 import {VisuallyHidden} from "@react-aria/visually-hidden";
-import {AnimatePresence} from "framer-motion";
+import {AnimatePresence} from "motion/react";
 
 import {HiddenSelect} from "./hidden-select";
 import {UseSelectProps, useSelect} from "./use-select";

--- a/packages/components/snippet/package.json
+++ b/packages/components/snippet/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -53,8 +53,8 @@
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/system": "workspace:*",
-    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/system": "workspace:*",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react-lorem-component": "0.13.0",
     "@nextui-org/card": "workspace:*",
     "@nextui-org/input": "workspace:*",

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -9,7 +9,7 @@ import {useFocusRing} from "@react-aria/focus";
 import {Node} from "@react-types/shared";
 import {useTab} from "@react-aria/tabs";
 import {useHover} from "@react-aria/interactions";
-import {m, domMax, LazyMotion} from "framer-motion";
+import {m, domMax, LazyMotion} from "motion/react";
 import {useIsMounted} from "@nextui-org/use-is-mounted";
 
 import {ValuesType} from "./use-tabs";

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -1,5 +1,5 @@
 import {ForwardedRef, ReactElement, useId} from "react";
-import {LayoutGroup} from "framer-motion";
+import {LayoutGroup} from "motion/react";
 import {forwardRef} from "@nextui-org/system";
 
 import {UseTabsProps, useTabs} from "./use-tabs";

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -16,7 +16,7 @@ import {AriaTabListProps, useTabList} from "@react-aria/tabs";
 import {mergeProps} from "@react-aria/utils";
 import {CollectionProps} from "@nextui-org/aria-utils";
 import {CollectionChildren} from "@react-types/shared";
-import {HTMLMotionProps} from "framer-motion";
+import {HTMLMotionProps} from "motion/react";
 
 export interface Props extends Omit<HTMLNextUIProps, "children"> {
   /**

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.4.0",
     "@nextui-org/system": ">=2.4.0"
   },
@@ -60,7 +60,7 @@
     "@nextui-org/system": "workspace:*",
     "@nextui-org/theme": "workspace:*",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0"
+    "motion": "11.11.12"
   },
   "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -1,6 +1,6 @@
 import {forwardRef} from "@nextui-org/system";
 import {OverlayContainer} from "@react-aria/overlays";
-import {AnimatePresence, m, LazyMotion} from "framer-motion";
+import {AnimatePresence, m, LazyMotion} from "motion/react";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
 import {warn} from "@nextui-org/shared-utils";
 import {Children, cloneElement, isValidElement} from "react";

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -1,7 +1,7 @@
 import type {PopoverVariantProps, SlotsToClasses} from "@nextui-org/theme";
 import type {AriaTooltipProps} from "@react-types/tooltip";
 import type {OverlayTriggerProps} from "@react-types/overlays";
-import type {HTMLMotionProps} from "framer-motion";
+import type {HTMLMotionProps} from "motion/react";
 import type {OverlayOptions} from "@nextui-org/aria-utils";
 
 import {ReactNode, Ref, useId, useImperativeHandle} from "react";

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -93,7 +93,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1"
   },
   "devDependencies": {
     "react": "^18.0.0",

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -34,13 +34,13 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
   "devDependencies": {
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0",
+    "motion": "11.11.12",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/core/system/src/provider.tsx
+++ b/packages/core/system/src/provider.tsx
@@ -6,7 +6,7 @@ import {I18nProvider, I18nProviderProps} from "@react-aria/i18n";
 import {RouterProvider} from "@react-aria/utils";
 import {OverlayProvider} from "@react-aria/overlays";
 import {useMemo} from "react";
-import {MotionConfig, MotionGlobalConfig} from "framer-motion";
+import {MotionConfig, MotionGlobalConfig} from "motion/react";
 
 import {ProviderContext} from "./provider-context";
 

--- a/packages/utilities/dom-animation/package.json
+++ b/packages/utilities/dom-animation/package.json
@@ -34,11 +34,11 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1"
   },
   "devDependencies": {
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0"
+    "motion": "11.11.12"
   },
   "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/dom-animation/src/index.ts
+++ b/packages/utilities/dom-animation/src/index.ts
@@ -1,3 +1,3 @@
-import {domAnimation} from "framer-motion";
+import {domAnimation} from "motion/react";
 
 export default domAnimation;

--- a/packages/utilities/framer-utils/package.json
+++ b/packages/utilities/framer-utils/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+    "motion": ">=11.11.12 || >=12.0.0-alpha.1"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",
@@ -47,7 +47,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "clean-package": "2.2.0",
-    "framer-motion": "11.9.0"
+    "motion": "11.11.12"
   },
   "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/framer-utils/src/resizable-panel.tsx
+++ b/packages/utilities/framer-utils/src/resizable-panel.tsx
@@ -1,7 +1,7 @@
 import type {Ref} from "react";
 
 import {forwardRef} from "react";
-import {domAnimation, LazyMotion, m} from "framer-motion";
+import {domAnimation, LazyMotion, m} from "motion/react";
 import {useMeasure} from "@nextui-org/use-measure";
 import {HTMLNextUIProps} from "@nextui-org/system";
 

--- a/packages/utilities/framer-utils/src/transition-utils.ts
+++ b/packages/utilities/framer-utils/src/transition-utils.ts
@@ -1,4 +1,4 @@
-import type {Target, TargetAndTransition, Transition} from "framer-motion";
+import type {Target, TargetAndTransition, Transition} from "motion/react";
 
 type WithMotionState<P> = Partial<Record<"enter" | "exit", P>>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,16 +123,16 @@ importers:
         version: 7.32.0
       eslint-config-airbnb:
         specifier: ^18.2.1
-        version: 18.2.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)
+        version: 18.2.1(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)
       eslint-config-airbnb-typescript:
         specifier: ^12.3.1
-        version: 12.3.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5)
+        version: 12.3.1(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5)
       eslint-config-prettier:
         specifier: ^8.2.0
         version: 8.10.0(eslint@7.32.0)
       eslint-config-react-app:
         specifier: ^6.0.0
-        version: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5)
+        version: 6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0)(eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5)
       eslint-config-ts-lambdas:
         specifier: ^1.2.3
         version: 1.2.3(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)
@@ -141,7 +141,7 @@ importers:
         version: 2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0)
       eslint-loader:
         specifier: ^4.0.2
-        version: 4.0.2(eslint@7.32.0)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack-cli@3.3.12))
+        version: 4.0.2(eslint@7.32.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: ^2.26.0
         version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
@@ -195,13 +195,13 @@ importers:
         version: 10.7.7
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+        version: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
       jest-watch-typeahead:
         specifier: 2.2.2
-        version: 2.2.2(jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)))
+        version: 2.2.2(jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)))
       lint-staged:
         specifier: ^13.0.3
         version: 13.3.0(enquirer@2.4.1)
@@ -394,9 +394,6 @@ importers:
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
-      framer-motion:
-        specifier: 11.11.13
-        version: 11.11.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       geist:
         specifier: 1.3.1
         version: 1.3.1(next@14.3.0-canary.43(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -421,6 +418,9 @@ importers:
       mitt:
         specifier: 3.0.1
         version: 3.0.1
+      motion:
+        specifier: 11.13.1
+        version: 11.13.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next:
         specifier: 14.3.0-canary.43
         version: 14.3.0-canary.43(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -520,7 +520,7 @@ importers:
     devDependencies:
       '@docusaurus/utils':
         specifier: 2.0.0-beta.3
-        version: 2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))
+        version: 2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12)
       '@next/bundle-analyzer':
         specifier: 14.3.0-canary.43
         version: 14.3.0-canary.43
@@ -690,9 +690,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -830,9 +830,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1020,9 +1020,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1111,9 +1111,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1175,9 +1175,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1456,9 +1456,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1618,9 +1618,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2098,9 +2098,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2177,9 +2177,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2305,9 +2305,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2437,9 +2437,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2571,9 +2571,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2706,9 +2706,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2978,9 +2978,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -3051,9 +3051,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   packages/components/user:
     dependencies:
@@ -3238,9 +3238,9 @@ importers:
       '@react-aria/visually-hidden':
         specifier: 3.8.17
         version: 3.8.17(react@18.2.0)
-      framer-motion:
-        specifier: '>=11.5.6 || >=12.0.0-alpha.1'
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: '>=11.11.12 || >=12.0.0-alpha.1'
+        version: 11.13.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3282,9 +3282,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -3318,7 +3318,7 @@ importers:
         version: 18.2.0
       tailwind-variants:
         specifier: ^0.1.20
-        version: 0.1.20(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)))
+        version: 0.1.20(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@5.6.3)))
 
   packages/core/theme:
     dependencies:
@@ -3345,7 +3345,7 @@ importers:
         version: 2.5.4
       tailwind-variants:
         specifier: ^0.1.20
-        version: 0.1.20(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)))
+        version: 0.1.20(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@5.6.3)))
     devDependencies:
       '@types/color':
         specifier: ^3.0.3
@@ -3358,7 +3358,7 @@ importers:
         version: 2.2.0
       tailwindcss:
         specifier: ^3.4.0
-        version: 3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
+        version: 3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@5.6.3))
 
   packages/hooks/use-aria-accordion:
     dependencies:
@@ -3964,9 +3964,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   packages/utilities/framer-utils:
     dependencies:
@@ -3983,9 +3983,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
-      framer-motion:
-        specifier: 11.9.0
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      motion:
+        specifier: 11.11.12
+        version: 11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -10253,8 +10253,8 @@ packages:
       react-dom:
         optional: true
 
-  framer-motion@11.9.0:
-    resolution: {integrity: sha512-nCfGxvsQecVLjjYDu35G2F5ls+ArE3FBfhxV0RSiisMaUKqteq5DMBFNRKwMyVj+VqKTNhawt+BV480YCHKFlQ==}
+  framer-motion@11.13.1:
+    resolution: {integrity: sha512-F40tpGTHByhn9h3zdBQPcEro+pSLtzARcocbNqAyfBI+u9S+KZuHH/7O9+z+GEkoF3eqFxfvVw0eBDytohwqmQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: 18.2.0
@@ -12207,6 +12207,40 @@ packages:
 
   mlly@1.7.3:
     resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+
+  motion-dom@11.13.0:
+    resolution: {integrity: sha512-Oc1MLGJQ6nrvXccXA89lXtOqFyBmvHtaDcTRGT66o8Czl7nuA8BeHAd9MQV1pQKX0d2RHFBFaw5g3k23hQJt0w==}
+
+  motion-utils@11.13.0:
+    resolution: {integrity: sha512-lq6TzXkH5c/ysJQBxgLXgM01qwBH1b4goTPh57VvZWJbVJZF/0SB31UWEn4EIqbVPf3au88n2rvK17SpDTja1A==}
+
+  motion@11.11.12:
+    resolution: {integrity: sha512-MdOqCS3cgXFTKsoRcSX5DhkfA95UYCa0JOe/0sXzMg1kgMr6MmdqVBknbaMBsOzTXXvuGNgqo1adM9/maj2klA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: 18.2.0
+      react-dom: 18.2.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  motion@11.13.1:
+    resolution: {integrity: sha512-64+QpZQv8WJJFn+tEEzX04il9s6ReA6lhKRZaxzD6SunGqoaq5g+AFVfcKWme8N83eytUOpGp7mpfJ9cyZlhAA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: 18.2.0
+      react-dom: 18.2.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -16411,7 +16445,7 @@ snapshots:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)
+      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -16565,12 +16599,12 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@docusaurus/types@2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))':
+  '@docusaurus/types@2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12)':
     dependencies:
       commander: 5.1.0
       joi: 17.13.3
       querystring: 0.2.0
-      webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))
+      webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -16578,9 +16612,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))':
+  '@docusaurus/utils@2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12)':
     dependencies:
-      '@docusaurus/types': 2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))
+      '@docusaurus/types': 2.0.0-beta.3(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12)
       '@types/github-slugger': 1.3.0
       chalk: 4.1.2
       escape-string-regexp: 4.0.0
@@ -16988,7 +17022,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -17002,7 +17036,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -21551,7 +21585,7 @@ snapshots:
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@4.9.5)
-      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)
+      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)
       typescript: 4.9.5
 
   cosmiconfig@8.3.6(typescript@4.9.5):
@@ -21572,13 +21606,13 @@ snapshots:
     optionalDependencies:
       typescript: 4.9.5
 
-  create-jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)):
+  create-jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -22258,7 +22292,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-airbnb-base@14.2.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint@7.32.0):
+  eslint-config-airbnb-base@14.2.1(eslint-plugin-import@2.31.0)(eslint@7.32.0):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
@@ -22266,11 +22300,11 @@ snapshots:
       object.assign: 4.1.5
       object.entries: 1.1.8
 
-  eslint-config-airbnb-typescript@12.3.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5):
+  eslint-config-airbnb-typescript@12.3.1(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5):
     dependencies:
       '@typescript-eslint/parser': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
-      eslint-config-airbnb: 18.2.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)
-      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-config-airbnb: 18.2.1(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)
+      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.31.0)(eslint@7.32.0)
     transitivePeerDependencies:
       - eslint
       - eslint-plugin-import
@@ -22280,10 +22314,10 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-config-airbnb@18.2.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0):
+  eslint-config-airbnb@18.2.1(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0):
     dependencies:
       eslint: 7.32.0
-      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.31.0)(eslint@7.32.0)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.2(eslint@7.32.0)
@@ -22300,7 +22334,7 @@ snapshots:
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@7.32.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
       eslint-plugin-react: 7.37.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 5.0.0(eslint@7.32.0)
@@ -22315,7 +22349,7 @@ snapshots:
     dependencies:
       eslint: 7.32.0
 
-  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0))(eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5):
+  eslint-config-react-app@6.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(babel-eslint@10.1.0(eslint@7.32.0))(eslint-plugin-flowtype@5.10.0(eslint@7.32.0))(eslint-plugin-import@2.31.0)(eslint-plugin-jest@24.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5))(eslint-plugin-jsx-a11y@6.10.2(eslint@7.32.0))(eslint-plugin-react-hooks@4.6.2(eslint@7.32.0))(eslint-plugin-react@7.37.2(eslint@7.32.0))(eslint@7.32.0)(typescript@4.9.5):
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
@@ -22364,20 +22398,20 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 7.32.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@7.32.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-loader@4.0.2(eslint@7.32.0)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack-cli@3.3.12)):
+  eslint-loader@4.0.2(eslint@7.32.0)(webpack@5.96.1):
     dependencies:
       eslint: 7.32.0
       find-cache-dir: 3.3.2
@@ -22387,7 +22421,7 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack-cli@3.3.12)
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -22398,7 +22432,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -22409,7 +22443,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@7.32.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -22443,7 +22477,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -22461,7 +22495,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -22472,7 +22506,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@7.32.0))(eslint@7.32.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -23110,8 +23144,10 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  framer-motion@11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  framer-motion@11.13.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
+      motion-dom: 11.13.0
+      motion-utils: 11.13.0
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.3.1
@@ -24162,16 +24198,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)):
+  jest-cli@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      create-jest: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      jest-config: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -24181,7 +24217,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)):
+  jest-config@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -24207,7 +24243,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 15.14.9
-      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)
+      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -24424,11 +24460,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.3.0
-      jest: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -24459,12 +24495,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)):
+  jest@29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5))
+      jest-cli: 29.7.0(@types/node@15.14.9)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25686,6 +25722,28 @@ snapshots:
       pkg-types: 1.2.1
       ufo: 1.5.4
 
+  motion-dom@11.13.0: {}
+
+  motion-utils@11.13.0: {}
+
+  motion@11.11.12(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      framer-motion: 11.11.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.3.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  motion@11.13.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      framer-motion: 11.13.1(@emotion/is-prop-valid@1.3.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.3.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   mri@1.2.0: {}
 
   mrmime@2.0.0: {}
@@ -26475,15 +26533,7 @@ snapshots:
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)
-
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.6.1
-    optionalDependencies:
-      postcss: 8.4.49
-      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)
+      ts-node: 10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5)
 
   postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.2.5)(typescript@5.6.3)):
     dependencies:
@@ -28036,10 +28086,10 @@ snapshots:
       tailwind-merge: 1.14.0
       tailwindcss: 3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.2.5)(typescript@5.6.3))
 
-  tailwind-variants@0.1.20(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))):
+  tailwind-variants@0.1.20(tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@5.6.3))):
     dependencies:
       tailwind-merge: 1.14.0
-      tailwindcss: 3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
+      tailwindcss: 3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@5.6.3))
 
   tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.2.5)(typescript@5.6.3)):
     dependencies:
@@ -28061,33 +28111,6 @@ snapshots:
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
       postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.2.5)(typescript@5.6.3))
-      postcss-nested: 6.2.0(postcss@8.4.49)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.8
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
-  tailwindcss@3.4.15(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.6
-      lilconfig: 2.1.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.4.49
-      postcss-import: 15.1.0(postcss@8.4.49)
-      postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -28170,7 +28193,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack-cli@3.3.12)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack@5.96.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -28182,14 +28205,14 @@ snapshots:
       '@swc/core': 1.9.2(@swc/helpers@0.5.15)
       esbuild: 0.15.18
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))):
+  terser-webpack-plugin@5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack@5.96.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1))
+      webpack: 5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack-cli@3.3.12)
     optionalDependencies:
       '@swc/core': 1.9.2(@swc/helpers@0.5.15)
       esbuild: 0.21.5
@@ -28310,26 +28333,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@15.14.9)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 15.14.9
-      acorn: 8.14.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.9.2(@swc/helpers@0.5.15)
-
   ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.2.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -28350,6 +28353,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.9.2(@swc/helpers@0.5.15)
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.5.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.9.2(@swc/helpers@0.5.15)
 
   ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.5.1)(typescript@5.6.3):
     dependencies:
@@ -28964,7 +28987,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack-cli@3.3.12))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.15.18)(webpack@5.96.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -28974,7 +28997,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1)):
+  webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -28996,7 +29019,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack@5.96.1(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack-cli@3.3.12(webpack@5.96.1)))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.9.2(@swc/helpers@0.5.15))(esbuild@0.21.5)(webpack@5.96.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

framer-motion changed to motion https://motion.dev/blog/framer-motion-is-now-independent-introducing-motion

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

This changes the framer-motion occurences to motion.

## 💣 Is this a breaking change (Yes/No):

I'm not sure how to proceed with BC here. Tell users to install motion since v2.7+?

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated animation library from `framer-motion` to `motion/react` across various components, enhancing animation capabilities.
  
- **Documentation**
	- Revised installation instructions and dependency details to reflect the transition from `framer-motion` to `motion`.
	- Updated prop descriptions and examples to clarify usage with the new animation library.

- **Chores**
	- Adjusted package.json files across multiple components to replace `framer-motion` with `motion`, ensuring consistency in dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->