### PR TITLE
docs: update DatePicker example to remove "time" label

### DIFF
--- a/apps/docs/content/components/date-picker/min-and-max-date.raw.jsx
+++ b/apps/docs/content/components/date-picker/min-and-max-date.raw.jsx
@@ -8,7 +8,7 @@ export default function App() {
         <h3>Min date</h3>
         <DatePicker
           defaultValue={today(getLocalTimeZone()).subtract({days: 1})}
-          label="Date and time"
+          label="Date"
           minValue={today(getLocalTimeZone())}
         />
       </div>
@@ -16,7 +16,7 @@ export default function App() {
         <h3>Max date</h3>
         <DatePicker
           defaultValue={today(getLocalTimeZone()).add({days: 1})}
-          label="Date and time"
+          label="Date"
           maxValue={today(getLocalTimeZone())}
         />
       </div>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
This PR updates the DatePicker example in the official documentation. The "time" label in the example is removed as the DatePicker component does not support time selection.


<!--- Add a brief description -->

## ⛳️ Current behavior (updates)
The documentation example uses a "Date and time" label, which might mislead users into thinking that the DatePicker component supports time selection.


<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior
The example now uses "Date" as the label, aligning with the DatePicker component's functionality and avoiding any confusion.


<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the label for the DatePicker components from "Date and time" to "Date" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->