### PR TITLE
fix(theme): input height in innerWrapper in Select

### DIFF
--- a/.changeset/tiny-schools-hang.md
+++ b/.changeset/tiny-schools-hang.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/theme": patch
+"@heroui/theme": patch
 ---
 
 Fix input height of select to avoid clipping of label (#4321)

--- a/.changeset/tiny-schools-hang.md
+++ b/.changeset/tiny-schools-hang.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Fix input height (#4321)

--- a/.changeset/tiny-schools-hang.md
+++ b/.changeset/tiny-schools-hang.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-Fix input height of select (#4321)
+Fix input height of select to avoid clipping of label (#4321)

--- a/.changeset/tiny-schools-hang.md
+++ b/.changeset/tiny-schools-hang.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/select": patch
+"@nextui-org/theme": patch
 ---
 
-Fix input height (#4321)
+Fix input height of select (#4321)

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -22,7 +22,7 @@ const select = tv({
     trigger:
       "relative px-3 gap-3 w-full inline-flex flex-row items-center shadow-sm outline-none tap-highlight-transparent",
     innerWrapper:
-      "inline-flex h-full w-[calc(100%_-_theme(spacing.6))] min-h-4 items-center gap-1.5 box-border",
+      "inline-flex h-fit w-[calc(100%_-_theme(spacing.6))] min-h-4 items-center gap-1.5 box-border",
     selectorIcon: "absolute end-3 w-4 h-4",
     spinner: "absolute end-3",
     value: ["text-foreground-500", "font-normal", "w-full", "text-start"],


### PR DESCRIPTION
Closes #4321 

## 📝 Description
- Changed the input height from `h-full` to `h-fit`

## ⛳️ Current behavior (updates)
![image](https://github.com/user-attachments/assets/bcd2b7cb-eeed-4bda-a42d-ae0216ff4e34)


## 🚀 New behavior
![image](https://github.com/user-attachments/assets/92791270-72dc-452a-bc87-49805dddb999)


## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with input height in the NextUI Select component.
  - Adjusted inner wrapper styling to prevent clipping of the label.

- **Refactor**
  - Updated type definitions for Select component variants and slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->