### PR TITLE
fix(tooltip): accessing element.ref was removed in React 19 issue

### DIFF
--- a/.changeset/great-feet-lay.md
+++ b/.changeset/great-feet-lay.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tooltip": patch
+---
+
+fix "Accessing element.ref was removed in React 19" issue (#4526)

--- a/.changeset/great-feet-lay.md
+++ b/.changeset/great-feet-lay.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/tooltip": patch
+"@heroui/tooltip": patch
 ---
 
 fix "Accessing element.ref was removed in React 19" issue (#4526)

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -48,7 +48,11 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, ref) => {
         ref?: React.Ref<any>;
       };
 
-      trigger = cloneElement(child, getTriggerProps(child.props, child.ref));
+      // Accessing the ref from props, else fallback to element.ref
+      // https://github.com/facebook/react/pull/28348
+      const childRef = child.props.ref ?? (child as any).ref;
+
+      trigger = cloneElement(child, getTriggerProps(child.props, childRef));
     }
   } catch (error) {
     trigger = <span />;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #4526
- Closes #4654
- Closes #4454

## 📝 Description

<!--- Add a brief description -->

As titled. Applied the same fix as https://github.com/nextui-org/nextui/commit/3f9e0ffb211a0e43e88d89ca47a91d5f0162c72e.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

![image](https://github.com/user-attachments/assets/c5ee831e-01ed-42e4-bd23-1e2fa60a2d2c)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

No such error

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `@nextui-org/tooltip` package to resolve a `ref` access issue in React 19
  - Improved `Tooltip` component's ref handling to ensure compatibility with newer React versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->