### PR TITLE
docs(tooltip): remove shouldBlockScroll prop

### DIFF
--- a/apps/docs/content/docs/components/tooltip.mdx
+++ b/apps/docs/content/docs/components/tooltip.mdx
@@ -231,12 +231,6 @@ You can customize the `Tooltip` component by passing custom Tailwind CSS classes
       default: "true"
     },
     {
-      attribute: "shouldBlockScroll",
-      type: "boolean",
-      description: "Whether to block scrolling outside the tooltip.",
-      default: "true"
-    },
-    {
       attribute: "isKeyboardDismissDisabled",
       type: "boolean",
       description: "Whether pressing the escape key to close the tooltip should be disabled.",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3474

## 📝 Description

<!--- Add a brief description -->

The doc mentions `shouldBlockScroll` in Tooltip but the logic is not found. As suggested by Ryo, it's unnatural for a tooltip element that appears on hover to block scrolling. Hence, this PR is to remove it to avoid confusion.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Removed `shouldBlockScroll` property from Tooltip component documentation
  - No other changes to the component's documentation structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->