### PR TITLE
fix: deprecation warning triggered by internal onClick 

### DIFF
--- a/.changeset/stale-moose-hear.md
+++ b/.changeset/stale-moose-hear.md
@@ -1,6 +1,6 @@
 ---
-"@nextui-org/use-aria-button": patch
-"@nextui-org/use-aria-link": patch
+"@heroui/use-aria-button": patch
+"@heroui/use-aria-link": patch
 ---
 
 avoid showing onClick deprecation warning for internal onClick (#4549, #4546)

--- a/.changeset/stale-moose-hear.md
+++ b/.changeset/stale-moose-hear.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/use-aria-button": patch
+"@nextui-org/use-aria-link": patch
+---
+
+avoid showing onClick deprecation warning for internal onClick (#4549, #4546)

--- a/packages/hooks/use-aria-button/src/index.ts
+++ b/packages/hooks/use-aria-button/src/index.ts
@@ -113,7 +113,7 @@ export function useAriaButton(
     // bypass since onClick is passed from <Link as={Button} /> internally
     role !== "link" &&
     // bypass since onClick is passed from useDisclosure's `getButtonProps` internally
-    !(props.hasOwnProperty("aria-controls") && props.hasOwnProperty("aria-controls"))
+    !(props.hasOwnProperty("aria-expanded") && props.hasOwnProperty("aria-controls"))
   ) {
     warn(
       "onClick is deprecated, please use onPress instead. See: https://github.com/nextui-org/nextui/issues/4292",

--- a/packages/hooks/use-aria-button/src/index.ts
+++ b/packages/hooks/use-aria-button/src/index.ts
@@ -19,6 +19,8 @@ import {usePress} from "@react-aria/interactions";
 export type AriaButtonProps<T extends ElementType = "button"> = BaseAriaButtonProps<T> & {
   /** Whether text selection should be enabled on the pressable element. */
   allowTextSelectionOnPress?: boolean;
+  /** The role of the button element. */
+  role?: string;
 };
 
 export interface ButtonAria<T> {
@@ -81,6 +83,7 @@ export function useAriaButton(
     rel,
     type = "button",
     allowTextSelectionOnPress,
+    role,
   } = props;
   let additionalProps;
 
@@ -104,7 +107,14 @@ export function useAriaButton(
 
   let isMobile = isIOS() || isAndroid();
 
-  if (deprecatedOnClick && typeof deprecatedOnClick === "function") {
+  if (
+    deprecatedOnClick &&
+    typeof deprecatedOnClick === "function" &&
+    // bypass since onClick is passed from <Link as={Button} /> internally
+    role !== "link" &&
+    // bypass since onClick is passed from useDisclosure's `getButtonProps` internally
+    !(props.hasOwnProperty("aria-controls") && props.hasOwnProperty("aria-controls"))
+  ) {
     warn(
       "onClick is deprecated, please use onPress instead. See: https://github.com/nextui-org/nextui/issues/4292",
       "useButton",

--- a/packages/hooks/use-aria-link/src/index.ts
+++ b/packages/hooks/use-aria-link/src/index.ts
@@ -21,6 +21,8 @@ export interface AriaLinkOptions extends AriaLinkProps {
   isDisabled?: boolean;
   /** The role of the element */
   role?: string;
+  /** The type of the element, e.g. 'button' */
+  type?: string;
   /**
    * The HTML element used to render the link, e.g. 'a', or 'span'.
    * @default 'a'
@@ -50,6 +52,7 @@ export function useAriaLink(props: AriaLinkOptions, ref: RefObject<FocusableElem
     onClick: deprecatedOnClick,
     role,
     isDisabled,
+    type,
     ...otherProps
   } = props;
 
@@ -64,7 +67,14 @@ export function useAriaLink(props: AriaLinkOptions, ref: RefObject<FocusableElem
 
   let isMobile = isIOS() || isAndroid();
 
-  if (deprecatedOnClick && typeof deprecatedOnClick === "function" && role !== "button") {
+  if (
+    deprecatedOnClick &&
+    typeof deprecatedOnClick === "function" &&
+    // bypass since onClick is passed from <Link as="button" /> internally
+    type !== "button" &&
+    // bypass since onClick is passed from <Button as={Link} /> internally
+    role !== "button"
+  ) {
     warn(
       "onClick is deprecated, please use onPress instead. See: https://github.com/nextui-org/nextui/issues/4292",
       "useLink",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #4549
- Closes #4546

## 📝 Description

<!--- Add a brief description -->

Internal `onClick` triggers the deprecation warning while users have no control of it. This PR is to handle the following case

- Link as button
- Link as Button
- useDisclosure's getButtonProps to Button

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved deprecation warnings for internal `onClick` function in `@nextui-org/use-aria-button` and `@nextui-org/use-aria-link` packages.
  - Improved handling of button and link component behaviors, ensuring better compatibility with internal usage.

- **Enhancements**
  - Added optional `role` property to `AriaButtonProps`, allowing specification of button semantics.
  - Added optional `type` property to `AriaLinkOptions`, enhancing flexibility for element types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->