### PR TITLE
fix(input): missing clear button with file input type

### DIFF
--- a/.changeset/calm-seas-lie.md
+++ b/.changeset/calm-seas-lie.md
@@ -1,0 +1,5 @@
+---
+"@heroui/input": patch
+---
+
+fix clear button with file input type (#4592)

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -140,21 +140,26 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     handleValueChange,
   );
 
+  const isFileTypeInput = type === "file";
+  const hasUploadedFiles = ((domRef?.current as HTMLInputElement)?.files?.length ?? 0) > 0;
   const isFilledByDefault = ["date", "time", "month", "week", "range"].includes(type!);
-  const isFilled = !isEmpty(inputValue) || isFilledByDefault;
+  const isFilled = !isEmpty(inputValue) || isFilledByDefault || hasUploadedFiles;
   const isFilledWithin = isFilled || isFocusWithin;
   const isHiddenType = type === "hidden";
   const isMultiline = originalProps.isMultiline;
-  const isFileTypeInput = type === "file";
 
   const baseStyles = clsx(classNames?.base, className, isFilled ? "is-filled" : "");
 
   const handleClear = useCallback(() => {
-    setInputValue("");
+    if (isFileTypeInput) {
+      (domRef.current as HTMLInputElement).value = "";
+    } else {
+      setInputValue("");
+    }
 
     onClear?.();
     domRef.current?.focus();
-  }, [setInputValue, onClear]);
+  }, [setInputValue, onClear, isFileTypeInput]);
 
   // if we use `react-hook-form`, it will set the input value using the ref in register
   // i.e. setting ref.current.value to something which is uncontrolled


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4592

## 📝 Description

<!--- Add a brief description -->

When setting `isClearable` to input with file type, the button is in DOM but hidden. This PR is to add the missing logic.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr4599-demo.webm](https://github.com/user-attachments/assets/09b6f7f9-09d2-4b0b-8b1e-abe135247f06)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file input handling in the input component
  - Fixed clear button functionality for file input types
  - Ensured correct behavior when uploading and clearing files

The changes address an issue with file input handling, specifically improving the clear button's functionality and file upload management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->