### PR TITLE
fix(calendar): function components cannot be given refs

### DIFF
--- a/.changeset/nine-snails-sniff.md
+++ b/.changeset/nine-snails-sniff.md
@@ -1,0 +1,5 @@
+---
+"@heroui/calendar": patch
+---
+
+function components cannot be given refs in calendar (#4606)

--- a/packages/components/calendar/src/calendar-base.tsx
+++ b/packages/components/calendar/src/calendar-base.tsx
@@ -3,7 +3,7 @@ import type {As, HTMLHeroUIProps} from "@heroui/system";
 import type {ButtonProps} from "@heroui/button";
 import type {HTMLAttributes, ReactNode, RefObject} from "react";
 
-import {Fragment, useState} from "react";
+import {forwardRef, Fragment, useState} from "react";
 import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {Button} from "@heroui/button";
 import {chain, mergeProps} from "@react-aria/utils";
@@ -33,6 +33,21 @@ export interface CalendarBaseProps extends HTMLHeroUIProps<"div"> {
   calendarRef: RefObject<HTMLDivElement>;
   errorMessage?: ReactNode;
 }
+
+/**
+ * Avoid this framer-motion warning:
+ * Function components cannot be given refs.
+ * Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
+ *
+ * @see https://www.framer.com/motion/animate-presence/###mode
+ */
+const PopLayoutWrapper = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  (props, ref) => {
+    return <div ref={ref} {...props} />;
+  },
+);
+
+PopLayoutWrapper.displayName = "HeroUI - PopLayoutWrapper";
 
 export function CalendarBase(props: CalendarBaseProps) {
   const {
@@ -152,9 +167,11 @@ export function CalendarBase(props: CalendarBaseProps) {
           data-slot="content"
         >
           <AnimatePresence custom={direction} initial={false} mode="popLayout">
-            <MotionConfig transition={transition}>
-              <LazyMotion features={domAnimation}>{calendarContent}</LazyMotion>
-            </MotionConfig>
+            <PopLayoutWrapper>
+              <MotionConfig transition={transition}>
+                <LazyMotion features={domAnimation}>{calendarContent}</LazyMotion>
+              </MotionConfig>
+            </PopLayoutWrapper>
           </AnimatePresence>
         </ResizablePanel>
       )}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4606

## 📝 Description

<!--- Add a brief description -->

`PopLayoutWrapper` got removed in ripple in 2.3.0 while it should be kept in calendar since the ref will be passed. Previously it was using Fragment but ref cannot pass to it. Therefore, this PR is to use the old fix.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

![image](https://github.com/user-attachments/assets/48ef7ba4-34c4-407f-b310-4369d1e95619)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr-4614.webm](https://github.com/user-attachments/assets/a8a822a5-640e-4ec5-b099-2ec518c82fa2)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with ref handling in function components for the calendar package
  - Improved component compatibility with `framer-motion` library

- **New Features**
  - Introduced `PopLayoutWrapper` to enhance ref management in calendar component

The changes ensure smoother ref handling and animation functionality for the calendar component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->