### PR TITLE
fix: rename wrapper to tab wrapper

### DIFF
--- a/.changeset/dull-ladybugs-whisper.md
+++ b/.changeset/dull-ladybugs-whisper.md
@@ -2,4 +2,4 @@
 "@heroui/theme": patch
 ---
 
-Fix wrapper rename to tabWrapper (#4552)
+Fix tabs slots "tab" rename to "tabWrapper" -- Breaking Change (#4552)

--- a/.changeset/dull-ladybugs-whisper.md
+++ b/.changeset/dull-ladybugs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@heroui/theme": patch
+---
+
+Fix wrapper rename to tabWrapper (#4552)

--- a/.changeset/dull-ladybugs-whisper.md
+++ b/.changeset/dull-ladybugs-whisper.md
@@ -2,4 +2,4 @@
 "@heroui/theme": patch
 ---
 
-Fix tabs slots "tab" rename to "tabWrapper" -- Breaking Change (#4552)
+Fix tabs slots "wrapper" rename to "tabWrapper" -- Breaking Change (#4552)

--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -195,7 +195,7 @@ function AppTabs() {
 
 - **base**: The main tabs slot, it wraps the items and the panels.
 - **tabList**: The tab list slot, it wraps the tab items.
-- **tab**: The tab slot, it wraps the tab item.
+- **tabWrapper**: The tab wrapper slot, it wraps the tab item.
 - **tabContent**: The tab content slot, it wraps the tab content.
 - **cursor**: The cursor slot, it wraps the cursor. This is only visible when `disableAnimation=false`
 - **panel**: The panel slot, it wraps the tab panel (content).
@@ -343,7 +343,7 @@ You can customize the `Tabs` component by passing custom Tailwind CSS classes to
     },
     {
       attribute: "classNames",
-      type: "Partial<Record<\"base\"｜ \"tabList\"｜ \"tab\"｜ \"tabContent\"｜ \"cursor\" ｜ \"panel\", string>>",
+      type: "Partial<Record<\"base\"｜ \"tabList\"｜ \"tabWrapper\"｜ \"tabContent\"｜ \"cursor\" ｜ \"panel\", string>>",
       description: "Allows to set custom class names for the card slots.",
       default: "-"
     },

--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -195,10 +195,11 @@ function AppTabs() {
 
 - **base**: The main tabs slot, it wraps the items and the panels.
 - **tabList**: The tab list slot, it wraps the tab items.
-- **tabWrapper**: The tab wrapper slot, it wraps the tab item.
+- **tab**: The tab slot, it wraps the tab item.
 - **tabContent**: The tab content slot, it wraps the tab content.
 - **cursor**: The cursor slot, it wraps the cursor. This is only visible when `disableAnimation=false`
 - **panel**: The panel slot, it wraps the tab panel (content).
+- **tabWrapper**: The tab wrapper slot, it wraps the tab and the tab content.
 
 ### Custom Styles
 
@@ -343,7 +344,7 @@ You can customize the `Tabs` component by passing custom Tailwind CSS classes to
     },
     {
       attribute: "classNames",
-      type: "Partial<Record<\"base\"｜ \"tabList\"｜ \"tabWrapper\"｜ \"tabContent\"｜ \"cursor\" ｜ \"panel\", string>>",
+      type: "Partial<Record<\"base\"｜ \"tabList\"｜ \"tab\"｜ \"tabContent\"｜ \"cursor\" ｜ \"panel\" ｜ \"tabWrapper\", string>>",
       description: "Allows to set custom class names for the card slots.",
       default: "-"
     },

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -171,7 +171,7 @@ export function useTabs<T extends object>(originalProps: UseTabsProps<T>) {
   const getWrapperProps: PropGetter = useCallback(
     (props) => ({
       "data-slot": "tabWrapper",
-      className: slots.wrapper({class: clsx(classNames?.wrapper, props?.className)}),
+      className: slots.tabWrapper({class: clsx(classNames?.tabWrapper, props?.className)}),
       "data-placement": placement,
       "data-vertical":
         isVertical || placement === "start" || placement === "end" ? "vertical" : "horizontal",

--- a/packages/core/theme/src/components/tabs.ts
+++ b/packages/core/theme/src/components/tabs.ts
@@ -72,7 +72,7 @@ const tabs = tv({
       // focus ring
       ...dataFocusVisibleClasses,
     ],
-    wrapper: [],
+    tabWrapper: [],
   },
   variants: {
     variant: {
@@ -166,15 +166,15 @@ const tabs = tv({
       start: {
         tabList: "flex-col",
         panel: "py-0 px-3",
-        wrapper: "flex",
+        tabWrapper: "flex",
       },
       end: {
         tabList: "flex-col",
         panel: "py-0 px-3",
-        wrapper: "flex flex-row-reverse",
+        tabWrapper: "flex flex-row-reverse",
       },
       bottom: {
-        wrapper: "flex flex-col-reverse",
+        tabWrapper: "flex flex-col-reverse",
       },
     },
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4552 <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

`wrapper` will be renamed to `tabWrapper`

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated tab wrapper naming convention across components
  - Corrected slot references in tabs configuration

- **Chores**
  - Patched dependency `@heroui/theme`

- **Documentation**
  - Updated documentation for the `Tabs` component to reflect the renaming of the tab wrapper slot and updated type definitions.

These changes enhance consistency in the naming of tab wrapper slots while preserving the overall functionality of the tabs component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->