### PR TITLE
docs(table): include TS examples to show Selection type usage

### DIFF
--- a/apps/docs/content/components/table/controlled-selection.raw.tsx
+++ b/apps/docs/content/components/table/controlled-selection.raw.tsx
@@ -1,0 +1,78 @@
+import type {Selection} from "@heroui/react";
+
+import React from "react";
+import {
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  getKeyValue,
+} from "@heroui/react";
+
+const rows = [
+  {
+    key: "1",
+    name: "Tony Reichert",
+    role: "CEO",
+    status: "Active",
+  },
+  {
+    key: "2",
+    name: "Zoey Lang",
+    role: "Technical Lead",
+    status: "Paused",
+  },
+  {
+    key: "3",
+    name: "Jane Fisher",
+    role: "Senior Developer",
+    status: "Active",
+  },
+  {
+    key: "4",
+    name: "William Howard",
+    role: "Community Manager",
+    status: "Vacation",
+  },
+];
+
+const columns = [
+  {
+    key: "name",
+    label: "NAME",
+  },
+  {
+    key: "role",
+    label: "ROLE",
+  },
+  {
+    key: "status",
+    label: "STATUS",
+  },
+];
+
+export default function App() {
+  const [selectedKeys, setSelectedKeys] = React.useState<Selection>(new Set(["2"]));
+
+  return (
+    <Table
+      aria-label="Controlled table example with dynamic content"
+      selectedKeys={selectedKeys}
+      selectionMode="multiple"
+      onSelectionChange={setSelectedKeys}
+    >
+      <TableHeader columns={columns}>
+        {(column) => <TableColumn key={column.key}>{column.label}</TableColumn>}
+      </TableHeader>
+      <TableBody items={rows}>
+        {(item) => (
+          <TableRow key={item.key}>
+            {(columnKey) => <TableCell>{getKeyValue(item, columnKey)}</TableCell>}
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/docs/content/components/table/controlled-selection.ts
+++ b/apps/docs/content/components/table/controlled-selection.ts
@@ -1,7 +1,9 @@
 import App from "./controlled-selection.raw.jsx?raw";
+import AppTs from "./controlled-selection.raw.tsx?raw";
 
 const react = {
   "/App.jsx": App,
+  "/App.tsx": AppTs,
 };
 
 export default {

--- a/apps/docs/content/components/table/disabled-rows.raw.tsx
+++ b/apps/docs/content/components/table/disabled-rows.raw.tsx
@@ -1,0 +1,79 @@
+import type {Selection} from "@heroui/react";
+
+import React from "react";
+import {
+  Table,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  getKeyValue,
+} from "@heroui/react";
+
+const rows = [
+  {
+    key: "1",
+    name: "Tony Reichert",
+    role: "CEO",
+    status: "Active",
+  },
+  {
+    key: "2",
+    name: "Zoey Lang",
+    role: "Technical Lead",
+    status: "Paused",
+  },
+  {
+    key: "3",
+    name: "Jane Fisher",
+    role: "Senior Developer",
+    status: "Active",
+  },
+  {
+    key: "4",
+    name: "William Howard",
+    role: "Community Manager",
+    status: "Vacation",
+  },
+];
+
+const columns = [
+  {
+    key: "name",
+    label: "NAME",
+  },
+  {
+    key: "role",
+    label: "ROLE",
+  },
+  {
+    key: "status",
+    label: "STATUS",
+  },
+];
+
+export default function App() {
+  const [selectedKeys, setSelectedKeys] = React.useState<Selection>(new Set(["2"]));
+
+  return (
+    <Table
+      aria-label="Controlled table example with dynamic content"
+      disabledKeys={["3", "4"]}
+      selectedKeys={selectedKeys}
+      selectionMode="multiple"
+      onSelectionChange={setSelectedKeys}
+    >
+      <TableHeader columns={columns}>
+        {(column) => <TableColumn key={column.key}>{column.label}</TableColumn>}
+      </TableHeader>
+      <TableBody items={rows}>
+        {(item) => (
+          <TableRow key={item.key}>
+            {(columnKey) => <TableCell>{getKeyValue(item, columnKey)}</TableCell>}
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/docs/content/components/table/disabled-rows.ts
+++ b/apps/docs/content/components/table/disabled-rows.ts
@@ -1,7 +1,9 @@
 import App from "./disabled-rows.raw.jsx?raw";
+import AppTs from "./disabled-rows.raw.tsx?raw";
 
 const react = {
   "/App.jsx": App,
+  "/App.tsx": AppTs,
 };
 
 export default {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4792

## 📝 Description

<!--- Add a brief description -->

When users copy the jsx code from doc in tsx, it will throw a typing error and it is hard to know how to fix that without looking at other examples. This PR is to add two TS examples to show the usage of Selection type. (p.s. other examples are covered already.)

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive table component featuring controlled multi-selection with a predefined selection.
  - Added another table component that supports disabled rows alongside dynamic selection.
  - Integrated TypeScript-based implementations for a seamless interactive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->