### PR TITLE
fix(theme): border radius in Table when isMultiSelectable

### DIFF
--- a/.changeset/small-candles-beg.md
+++ b/.changeset/small-candles-beg.md
@@ -1,0 +1,5 @@
+---
+"@heroui/theme": patch
+---
+
+fix border radius in Table when isMultiSelectable (#4807)

--- a/packages/core/theme/src/components/table.ts
+++ b/packages/core/theme/src/components/table.ts
@@ -208,13 +208,13 @@ const table = tv({
       true: {
         td: [
           // first
-          "group-data-[first=true]/tr:first:before:rounded-ts-lg",
-          "group-data-[first=true]/tr:last:before:rounded-te-lg",
+          "group-data-[first=true]/tr:first:before:rounded-ss-lg",
+          "group-data-[first=true]/tr:last:before:rounded-se-lg",
           // middle
           "group-data-[middle=true]/tr:before:rounded-none",
           // last
-          "group-data-[last=true]/tr:first:before:rounded-bs-lg",
-          "group-data-[last=true]/tr:last:before:rounded-be-lg",
+          "group-data-[last=true]/tr:first:before:rounded-es-lg",
+          "group-data-[last=true]/tr:last:before:rounded-ee-lg",
         ],
       },
       false: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4807

## 📝 Description

This PR fixes an issue where the Table component applies incorrect Tailwind classes to the first and last rows when `selectionMode` is set to `multiple`. The previous classes used (`rounded-ts-lg`, `rounded-te-lg`, `rounded-bs-lg`, `rounded-be-lg`) do not exist in Tailwind, leading to styling issues.

## ⛳️ Current behavior (updates)

Invalid Tailwind classes are applied to the first and last rows when `selectionMode="multiple"`.
This causes incorrect or missing border-radius styles.

![image](https://github.com/user-attachments/assets/baac0235-5f13-4160-a5fa-a8d62d2f5169)

## 🚀 New behavior

Updated the incorrect classes with the correct ones:
`rounded-ts-lg` → `rounded-ss-lg`
`rounded-te-lg` → `rounded-se-lg`
`rounded-bs-lg` → `rounded-es-lg`
`rounded-be-lg` → `rounded-ee-lg`
The first and last rows now correctly apply border-radius styles.

![image](https://github.com/user-attachments/assets/edcc5744-3d09-43c6-99b3-f0431a796e59)

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Refined the appearance of multi-selectable tables with updated rounded corners on key rows, providing a refreshed, modern look that aligns with our updated design guidelines.
- **Bug Fixes**
	- Addressed an issue related to the border radius in the Table component when the multi-selectable property is enabled, ensuring correct visual styling under specified conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->