### PR TITLE
fix(docs): incorrect default drawer placement

### DIFF
--- a/apps/docs/content/docs/components/drawer.mdx
+++ b/apps/docs/content/docs/components/drawer.mdx
@@ -84,8 +84,8 @@ You can disable this behavior by setting the following properties:
 ### Drawer placement
 
 The drawer can be placed on any edge of the screen using the `placement` prop:
-- `left` (default)
-- `right`
+- `left`
+- `right` (default)
 - `top`
 - `bottom`
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4809

## 📝 Description

<!--- Add a brief description -->

To correct the default drawer placement.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Drawer component guide to clearly indicate that the default placement is right, with left remaining as an option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->