### PR TITLE
fix(listbox): pass missing press events to usePress

### DIFF
--- a/.changeset/nine-ties-bake.md
+++ b/.changeset/nine-ties-bake.md
@@ -1,0 +1,5 @@
+---
+"@heroui/listbox": patch
+---
+
+pass missing press events to usePress (#4798)

--- a/packages/components/listbox/__tests__/listbox.test.tsx
+++ b/packages/components/listbox/__tests__/listbox.test.tsx
@@ -299,4 +299,48 @@ describe("Listbox", () => {
 
     expect(menuItem).not.toHaveProperty("className", expect.stringContaining("truncate"));
   });
+
+  it("should trigger press events", async () => {
+    const onPress = jest.fn();
+    const onPressStart = jest.fn();
+    const onPressEnd = jest.fn();
+    const onPressUp = jest.fn();
+    const onPressChange = jest.fn();
+
+    const {getAllByRole} = render(
+      <Listbox aria-label="Actions">
+        <ListboxItem
+          key="new"
+          onPress={onPress}
+          onPressChange={onPressChange}
+          onPressEnd={onPressEnd}
+          onPressStart={onPressStart}
+          onPressUp={onPressUp}
+        >
+          New file
+        </ListboxItem>
+        <ListboxItem key="copy">Copy link</ListboxItem>
+        <ListboxItem key="edit">Edit file</ListboxItem>
+        <ListboxItem key="delete" color="danger">
+          Delete file
+        </ListboxItem>
+      </Listbox>,
+    );
+
+    let listboxItems = getAllByRole("option");
+
+    expect(listboxItems.length).toBe(4);
+
+    await user.click(listboxItems[0]);
+
+    expect(onPress).toHaveBeenCalled();
+
+    expect(onPressStart).toHaveBeenCalled();
+
+    expect(onPressEnd).toHaveBeenCalled();
+
+    expect(onPressUp).toHaveBeenCalled();
+
+    expect(onPressChange).toHaveBeenCalled();
+  });
 });

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -41,6 +41,10 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     classNames,
     autoFocus,
     onPress,
+    onPressUp,
+    onPressStart,
+    onPressEnd,
+    onPressChange,
     onClick: deprecatedOnClick,
     shouldHighlightOnFocus,
     hideSelectedIcon = false,
@@ -74,6 +78,10 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     ref: domRef,
     isDisabled: isDisabled,
     onPress,
+    onPressUp,
+    onPressStart,
+    onPressEnd,
+    onPressChange,
   });
 
   const {isHovered, hoverProps} = useHover({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4798

## 📝 Description

<!--- Add a brief description -->

Passing missing press events to usePress (just like `use-accordion-item.ts`)

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

```tsx
<Listbox aria-label="Actions">
  <ListboxItem
    key="new"
    onPress={() => console.log("onPress")}
    onPressChange={(isPressed) => {
      console.log("onPressChange", isPressed);
    }}
    onPressEnd={(e) => {
      console.log("onPressEnd", e);
    }}
    onPressStart={(e) => {
      console.log("onPressStart", e);
    }}
    onPressUp={(e) => {
      console.log("onPressUp", e);
    }}
  >
    New file
  </ListboxItem>
  <ListboxItem key="copy">Copy link</ListboxItem>
  <ListboxItem key="edit">Edit file</ListboxItem>
  <ListboxItem key="delete" className="text-danger" color="danger">
    Delete file
  </ListboxItem>
</Listbox>
```

Only `onPress` works.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![Image](https://github.com/user-attachments/assets/8e5a3743-e40c-482b-86c8-3153d6640a8b)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
