### PR TITLE
fix(accordion): add data-slot attributes to accordion

### DIFF
--- a/.changeset/eighty-eels-double.md
+++ b/.changeset/eighty-eels-double.md
@@ -1,5 +1,5 @@
 ---
-"@heroui/accordion": minor
+"@heroui/accordion": patch
 ---
 
 Add data-slot attributes to accordion

--- a/.changeset/eighty-eels-double.md
+++ b/.changeset/eighty-eels-double.md
@@ -1,0 +1,5 @@
+---
+"@heroui/accordion": minor
+---
+
+Add data-slot attributes to accordion

--- a/packages/components/accordion/src/use-accordion-item.ts
+++ b/packages/components/accordion/src/use-accordion-item.ts
@@ -141,6 +141,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
       return {
         "data-open": dataAttr(isOpen),
         "data-disabled": dataAttr(isDisabled),
+        "data-slot": "base",
         className: slots.base({class: baseStyles}),
         ...mergeProps(
           filterDOMProps(otherProps, {
@@ -162,6 +163,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
       "data-disabled": dataAttr(isDisabled),
       "data-hover": dataAttr(isHovered),
       "data-pressed": dataAttr(isPressed),
+      "data-slot": "trigger",
       className: slots.trigger({class: classNames?.trigger}),
       onFocus: callAllHandlers(
         handleFocus,
@@ -188,6 +190,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
       return {
         "data-open": dataAttr(isOpen),
         "data-disabled": dataAttr(isDisabled),
+        "data-slot": "content",
         className: slots.content({class: classNames?.content}),
         ...mergeProps(regionProps, props),
       };
@@ -201,6 +204,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
         "aria-hidden": dataAttr(true),
         "data-open": dataAttr(isOpen),
         "data-disabled": dataAttr(isDisabled),
+        "data-slot": "indicator",
         className: slots.indicator({class: classNames?.indicator}),
         ...props,
       };
@@ -213,6 +217,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
       return {
         "data-open": dataAttr(isOpen),
         "data-disabled": dataAttr(isDisabled),
+        "data-slot": "heading",
         className: slots.heading({class: classNames?.heading}),
         ...props,
       };
@@ -225,6 +230,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
       return {
         "data-open": dataAttr(isOpen),
         "data-disabled": dataAttr(isDisabled),
+        "data-slot": "title",
         className: slots.title({class: classNames?.title}),
         ...props,
       };
@@ -237,6 +243,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
       return {
         "data-open": dataAttr(isOpen),
         "data-disabled": dataAttr(isDisabled),
+        "data-slot": "subtitle",
         className: slots.subtitle({class: classNames?.subtitle}),
         ...props,
       };


### PR DESCRIPTION
## 📝 Description

Add data-slot attributes to accordion
- base
- trigger
- content
- indicator
- heading
- title

## ⛳️ Current behavior (updates)

The slots were not injected into the html and therefore we could not easily find them in the dom

## 🚀 New behavior

data-slot attributes existe into the html 

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the accordion component with additional customization options through configurable content slots.
	- Extended functionality offers more flexible styling and arrangement while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->