### PR TITLE
fix(docs): popover shouldBlockScroll default value

### DIFF
--- a/apps/docs/content/docs/components/popover.mdx
+++ b/apps/docs/content/docs/components/popover.mdx
@@ -256,7 +256,7 @@ You can customize the `Popover` component by passing custom Tailwind CSS classes
       attribute: "shouldBlockScroll",
       type: "boolean",
       description: "Whether the popover should block the scroll outside the popover.",
-      default: "true"
+      default: "false"
     },
     {
       attribute: "shouldCloseOnScroll",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/643a0eca-86f4-4891-8ba2-950573bf502b)


## 🚀 New behavior

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/2c8e77c0-3bf7-4bb8-bed4-e1dfc4bbb01b" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated popover behavior so that when it is open, background scrolling is allowed by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->