### PR TITLE
fix(progress): add RTL support to the progress component

### DIFF
--- a/.changeset/happy-kangaroos-thank.md
+++ b/.changeset/happy-kangaroos-thank.md
@@ -1,0 +1,12 @@
+---
+"@heroui/progress": patch
+---
+
+These changes ensure that the progress bar behaves correctly in both LTR and RTL layouts, which is crucial for supporting languages that read from right to left (like Arabic, Hebrew, etc.). The transform origin points are particularly important for animations and transitions of the progress indicator.
+
+In the track class:
+Added rtl:rotate-180 which rotates the track 180 degrees when in RTL mode, ensuring correct direction
+
+In the indicator class added RTL-aware origin points:
+rtl:origin-right sets the transform origin to the right side in RTL mode.
+ltr:origin-left sets the transform origin to the left side in LTR (Left-to-Right) mode.

--- a/.changeset/happy-kangaroos-thank.md
+++ b/.changeset/happy-kangaroos-thank.md
@@ -2,11 +2,4 @@
 "@heroui/progress": patch
 ---
 
-These changes ensure that the progress bar behaves correctly in both LTR and RTL layouts, which is crucial for supporting languages that read from right to left (like Arabic, Hebrew, etc.). The transform origin points are particularly important for animations and transitions of the progress indicator.
-
-In the track class:
-Added rtl:rotate-180 which rotates the track 180 degrees when in RTL mode, ensuring correct direction
-
-In the indicator class added RTL-aware origin points:
-rtl:origin-right sets the transform origin to the right side in RTL mode.
-ltr:origin-left sets the transform origin to the left side in LTR (Left-to-Right) mode.
+add RTL support to progress (#4908)

--- a/packages/core/theme/src/components/progress.ts
+++ b/packages/core/theme/src/components/progress.ts
@@ -97,7 +97,7 @@ const progress = tv(
       },
       isIndeterminate: {
         true: {
-          indicator: ["absolute", "w-full", "animate-indeterminate-bar"],
+          indicator: ["absolute", "w-full", "origin-left", "animate-indeterminate-bar"],
         },
       },
       isDisabled: {

--- a/packages/core/theme/src/components/progress.ts
+++ b/packages/core/theme/src/components/progress.ts
@@ -27,8 +27,8 @@ const progress = tv(
       label: "",
       labelWrapper: "flex justify-between",
       value: "",
-      track: "z-0 relative bg-default-300/50 overflow-hidden",
-      indicator: "h-full",
+      track: "z-0 relative bg-default-300/50 overflow-hidden rtl:rotate-180",
+      indicator: "h-full rtl:origin-right ltr:origin-left",
     },
     variants: {
       color: {
@@ -97,7 +97,13 @@ const progress = tv(
       },
       isIndeterminate: {
         true: {
-          indicator: ["absolute", "w-full", "origin-left", "animate-indeterminate-bar"],
+          indicator: [
+            "absolute",
+            "w-full",
+            "rtl:origin-right",
+            "ltr:origin-left",
+            "animate-indeterminate-bar",
+          ],
         },
       },
       isDisabled: {

--- a/packages/core/theme/src/components/progress.ts
+++ b/packages/core/theme/src/components/progress.ts
@@ -28,7 +28,7 @@ const progress = tv(
       labelWrapper: "flex justify-between",
       value: "",
       track: "z-0 relative bg-default-300/50 overflow-hidden rtl:rotate-180",
-      indicator: "h-full rtl:origin-right ltr:origin-left",
+      indicator: "h-full",
     },
     variants: {
       color: {
@@ -97,13 +97,7 @@ const progress = tv(
       },
       isIndeterminate: {
         true: {
-          indicator: [
-            "absolute",
-            "w-full",
-            "rtl:origin-right",
-            "ltr:origin-left",
-            "animate-indeterminate-bar",
-          ],
+          indicator: ["absolute", "w-full", "rtl:origin-right", "animate-indeterminate-bar"],
         },
       },
       isDisabled: {

--- a/packages/core/theme/src/components/progress.ts
+++ b/packages/core/theme/src/components/progress.ts
@@ -97,7 +97,7 @@ const progress = tv(
       },
       isIndeterminate: {
         true: {
-          indicator: ["absolute", "w-full", "rtl:origin-right", "animate-indeterminate-bar"],
+          indicator: ["absolute", "w-full", "animate-indeterminate-bar"],
         },
       },
       isDisabled: {


### PR DESCRIPTION
Closes #4908 

## 📝 Description

Add RTL support to the Progress component.

## ⛳️ Current behavior (updates)

The Progress component currently lacks support for right-to-left (RTL) direction, when the page direction is RTL the progress bar is filled from left-to-right as it behaves in LTR pages.

## 🚀 New behavior

Now the progress bar is filled from right-to-left if the page direction is RTL.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the progress component to support both right-to-left and left-to-right layouts, ensuring smooth and directionally accurate animations for a consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->