### PR TITLE
fix(docs): fixing toast not appearing on press in blog v2.7.0

### DIFF
--- a/apps/docs/content/blog/v2.7.0.mdx
+++ b/apps/docs/content/blog/v2.7.0.mdx
@@ -114,9 +114,12 @@ function Example() {
 }
 ```
 
+<Spacer y={2} />
+
 <CodeDemo
   title="Simple Usage"
   files={simpleToast}
+  showEditor={false}
 />
 
 

--- a/apps/docs/content/components/toast/simple.raw.jsx
+++ b/apps/docs/content/components/toast/simple.raw.jsx
@@ -1,18 +1,21 @@
-import {addToast, Button} from "@heroui/react";
+import {addToast, Button, ToastProvider} from "@heroui/react";
 
 export default function App() {
   return (
-    <div className="flex flex-wrap gap-2">
-      <Button
-        onPress={() => {
-          addToast({
-            title: "Success",
-            description: "Your changes have been saved successfully.",
-          });
-        }}
-      >
-        Show Toast
-      </Button>
-    </div>
+    <>
+      <ToastProvider />
+      <div className="flex flex-wrap gap-2">
+        <Button
+          onPress={() => {
+            addToast({
+              title: "Success",
+              description: "Your changes have been saved successfully.",
+            });
+          }}
+        >
+          Show Toast
+        </Button>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description

The PR fixes the toast not appearing on press in blog v2.7.0

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved documentation display by adding extra vertical spacing before interactive demos and streamlining the layout by hiding the code editor.
  - Integrated a toast notification provider to enhance user feedback when triggering notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->