### PR TITLE
fix(input): hide a small eye icon for password input in edge

### DIFF
--- a/.changeset/slow-gifts-guess.md
+++ b/.changeset/slow-gifts-guess.md
@@ -1,0 +1,5 @@
+---
+"@heroui/input": patch
+---
+
+fix a small eye icon for password input in edge browser(#4927)

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -361,7 +361,12 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         "data-has-start-content": dataAttr(hasStartContent),
         "data-has-end-content": dataAttr(!!endContent),
         className: slots.input({
-          class: clsx(classNames?.input, isFilled ? "is-filled" : "", isMultiline ? "pe-0" : ""),
+          class: clsx(
+            classNames?.input,
+            isFilled ? "is-filled" : "",
+            isMultiline ? "pe-0" : "",
+            type === "password" ? "[&::-ms-reveal]:hidden" : "",
+          ),
         }),
         ...mergeProps(
           focusProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4927

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with password input fields in Edge browsers by ensuring that an unintended reveal icon is now hidden, resulting in a cleaner and more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->