### PR TITLE
fix(docs): include .npmrc in sandbox

### DIFF
--- a/apps/docs/components/sandpack/entries.ts
+++ b/apps/docs/components/sandpack/entries.ts
@@ -54,3 +54,5 @@ export const postcssConfig = `module.exports = {
 export const stylesConfig = `@tailwind base;
 @tailwind components;
 @tailwind utilities;`;
+
+export const npmrcConfig = `public-hoist-pattern[]=*@heroui/*`;

--- a/apps/docs/components/sandpack/use-sandpack.ts
+++ b/apps/docs/components/sandpack/use-sandpack.ts
@@ -5,7 +5,14 @@ import {useLocalStorage} from "usehooks-ts";
 
 import {HighlightedLines} from "./types";
 import {getHighlightedLines, getFileName} from "./utils";
-import {stylesConfig, postcssConfig, tailwindConfig, getHtmlFile, rootFile} from "./entries";
+import {
+  stylesConfig,
+  postcssConfig,
+  tailwindConfig,
+  npmrcConfig,
+  getHtmlFile,
+  rootFile,
+} from "./entries";
 
 export interface UseSandpackProps {
   files?: SandpackFiles;
@@ -205,6 +212,10 @@ export const useSandpack = ({
       },
       "styles.css": {
         code: stylesConfig,
+        hidden: true,
+      },
+      ".npmrc": {
+        code: npmrcConfig,
         hidden: true,
       },
     },

--- a/apps/docs/hooks/use-stackblitz.ts
+++ b/apps/docs/hooks/use-stackblitz.ts
@@ -39,7 +39,17 @@ export function useStackblitz(props: UseSandpackProps) {
     typescriptStrict,
   });
 
-  const transformFiles = mapKeys(filesData, (_, key) => key.replace(/^\//, ""));
+  // in stackblitz, npm will be used to install dependencies
+  // it doesn't need `public-hoist-pattern[]=*@heroui/*`
+  const filteredFilesData = Object.keys(filesData)
+    .filter((k) => k !== ".npmrc")
+    .reduce((o, k) => {
+      o[k] = filesData[k];
+
+      return o;
+    }, {});
+
+  const transformFiles = mapKeys(filteredFilesData, (_, key) => key.replace(/^\//, ""));
 
   const dependencies = {...customSetup.dependencies, ...customSetup.devDependencies};
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4949

## 📝 Description

<!--- Add a brief description -->

in codesandbox, pnpm is used to install dependencies. However, it doesn't set `public-hoist-pattern[]=*@heroui/*` so the styles will be off. stackblitz doesn't have such issue since it's using npm.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

![image](https://github.com/user-attachments/assets/b8f1287d-3076-48a3-af28-189d80f9b546)


## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![image](https://github.com/user-attachments/assets/1ce41273-abfe-44e9-b21e-d697d3957ee9)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an additional configuration option that enhances npm dependency management in our live code simulation environments.
	- Improved the setup process by incorporating behind-the-scenes handling of this configuration, ensuring a streamlined and cleaner preview experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->