### PR TITLE
fix(progress): incorrect size in indeterminate storybook

### DIFF
--- a/packages/components/progress/stories/progress.stories.tsx
+++ b/packages/components/progress/stories/progress.stories.tsx
@@ -108,7 +108,7 @@ export const Indeterminate = {
 
   args: {
     ...defaultProps,
-    size: "xs",
+    size: "sm",
     radius: "none",
     isIndeterminate: true,
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4966

## 📝 Description

<!--- Add a brief description -->

in indeterminate storybook, `xs` is specified but it's not a correct option.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![image](https://github.com/user-attachments/assets/03d8674f-4c68-46ad-bef4-dd7135c87f7c)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The indeterminate progress indicator has been updated to a medium size from its previous extra-small version, providing a more substantial visual presence. This change offers improved visual consistency and better user perception of loading states, ensuring clarity and balance throughout the interface. Additionally, this modification supports ongoing efforts to standardize component sizing for an enhanced overall appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->