### PR TITLE
fix(checkbox): pass form prop to checkbox

### DIFF
--- a/.changeset/smart-cats-walk.md
+++ b/.changeset/smart-cats-walk.md
@@ -1,0 +1,5 @@
+---
+"@heroui/checkbox": patch
+---
+
+Pass form prop to checkbox

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -146,6 +146,16 @@ describe("Checkbox", () => {
     expect(onChange).toHaveBeenCalled();
   });
 
+  it('should work correctly with "form" prop', () => {
+    const wrapper = render(
+      <Checkbox data-testid="checkbox-test" form="test-form-id">
+        Option
+      </Checkbox>,
+    );
+
+    expect(wrapper.container.querySelector("input")).toHaveAttribute("form", "test-form-id");
+  });
+
   describe("validation", () => {
     describe("validationBehavior=native", () => {
       it("supports isRequired", async () => {

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -320,8 +320,9 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       ...mergeProps(inputProps, focusProps),
       className: slots.hiddenInput({class: classNames?.hiddenInput}),
       onChange: chain(inputProps.onChange, handleCheckboxChange),
+      ...(otherProps.form ? {form: otherProps.form} : {}),
     };
-  }, [inputProps, focusProps, handleCheckboxChange, classNames?.hiddenInput]);
+  }, [inputProps, focusProps, handleCheckboxChange, classNames?.hiddenInput, otherProps]);
 
   const getLabelProps: PropGetter = useCallback(
     () => ({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

- closes: #5439 

Fixes an issue where the checkbox component couldn't be used when passing a form as a prop. which works for the other components exposed from Hero UI


## ⛳️ Current behavior (updates)

the form prop passed to a checkbox component was just silently dropped.

## 🚀 New behavior

the form prop passed to a checkbox component is now passed down to the input component. Followed the same pattern that was used for the `<Input>` component of using `filterDOMProps` 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Same idea as #4854 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Checkbox component now supports associating with a specific form via a new form property.
- **Tests**
  - Added a test case to verify the correct application of the form attribute in the Checkbox component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->