### PR TITLE
fix(docs): remove misused color in listbox radio-group

### DIFF
--- a/apps/docs/content/components/listbox/variants.raw.jsx
+++ b/apps/docs/content/components/listbox/variants.raw.jsx
@@ -27,7 +27,6 @@ export default function App() {
       </ListboxWrapper>
       <div className="flex flex-col gap-2">
         <RadioGroup
-          color={selectedVariant}
           defaultValue="solid"
           label="Select listbox item variant"
           orientation="horizontal"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Removed a misused `color` property in the `radio-group` of the `listbox` component documentation.

## ⛳️ Current behavior (updates)

The `color` property was incorrectly applied, causing the selected state to be invisible when clicking a radio option.

<img width="820" alt="image" src="https://github.com/user-attachments/assets/9be172d1-c15a-4022-b854-cc086c763bb5" />

## 🚀 New behavior

The incorrect `color` property has been removed, ensuring that the selected state is now properly visible.

<img width="827" alt="image" src="https://github.com/user-attachments/assets/7716d2ce-19aa-4d5e-94e5-31e70db1fa19" />

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the variant list display to simplify and streamline its visual presentation. This change may subtly affect how selected items appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->