### PR TITLE
fix: open in new tab not working in ios

### DIFF
--- a/apps/docs/components/docs/components/code-demo/code-demo.tsx
+++ b/apps/docs/components/docs/components/code-demo/code-demo.tsx
@@ -202,6 +202,8 @@ export const CodeDemo: React.FC<CodeDemoProps> = ({
       demo: title,
     });
 
+    const newTab = window.open(undefined, "_blank");
+
     const {data, error} = await openInChat({
       component,
       title,
@@ -213,6 +215,7 @@ export const CodeDemo: React.FC<CodeDemoProps> = ({
     setIsLoading(false);
 
     if (error || !data) {
+      if (newTab) newTab.close();
       posthog.capture("CodeDemo - Open in Chat Error", {
         component,
         demo: title,
@@ -228,7 +231,7 @@ export const CodeDemo: React.FC<CodeDemoProps> = ({
       return;
     }
 
-    window.open(data, "_blank");
+    if (newTab) newTab.location.href = data;
   }, [pathname, title, files, posthog]);
 
   return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

open in chat trusted status is lost in ios when there is an await
window.open has to be called before await and then have its href updated


https://github.com/user-attachments/assets/84940c09-38a5-425f-bb8c-2812b12deb60



## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat content now opens in a single, dedicated browser tab for a more streamlined experience.
- **Bug Fixes**
  - Enhanced tab handling automatically closes unused chat tabs in case of loading issues, reducing browser clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->