### PR TITLE
fix(tailwind): add missing values config for bg-grid plugin

### DIFF
--- a/apps/docs/tailwind.config.js
+++ b/apps/docs/tailwind.config.js
@@ -410,7 +410,7 @@ module.exports = {
             )}")`,
           }),
         },
-        // {values: flattenColorPalette(theme("backgroundColor")), type: "color"},
+        {values: flattenColorPalette(theme("backgroundColor")), type: "color"},
       );
     }),
   ],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Add relevant Github issue number here -->

## 📝 Description

Fixed the configuration issue of the `bg-grid` plugin in `tailwind.config.js` by adding the missing `values` configuration, ensuring the plugin can correctly generate grid background styles based on background colors.

## ⛳️ Current behavior (updates)

In the `<mcfile name="tailwind.config.js" path="f:\Code\fontEndHub\heroui\apps\docs\tailwind.config.js"></mcfile>` file, the `bg-grid` plugin was missing the `values` configuration when using `matchUtilities`, causing the plugin to fail to correctly retrieve background color values and generate corresponding CSS classes.

## 🚀 New behavior

Added `values: flattenColorPalette(theme("backgroundColor"))` configuration to ensure the `bg-grid` plugin can correctly generate grid background styles based on background colors.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

After the fix, you can verify it with:
```html
<div class="bg-grid-blue-500"></div>
```