### PR TITLE
fix(slider): slider display when `hideThumb` is `true`

### DIFF
--- a/.changeset/funny-yaks-smoke.md
+++ b/.changeset/funny-yaks-smoke.md
@@ -1,0 +1,6 @@
+---
+"@heroui/theme": patch
+"@heroui/slider": patch
+---
+
+fixed slider display when `hideThumb` is `true` (#5085)

--- a/packages/components/slider/src/use-slider.ts
+++ b/packages/components/slider/src/use-slider.ts
@@ -311,11 +311,15 @@ export function useSlider(originalProps: UseSliderProps) {
   };
 
   const getTrackProps: PropGetter = (props = {}) => {
+    const fillWidth = (endOffset - startOffset) * 100;
+
     return {
       ref: trackRef,
       "data-slot": "track",
       "data-thumb-hidden": !!originalProps?.hideThumb,
       "data-vertical": isVertical,
+      "data-fill-start": fillWidth > 0,
+      "data-fill-end": fillWidth == 100,
       className: slots.track({class: classNames?.track}),
       ...trackProps,
       ...props,

--- a/packages/components/slider/src/use-slider.ts
+++ b/packages/components/slider/src/use-slider.ts
@@ -318,8 +318,15 @@ export function useSlider(originalProps: UseSliderProps) {
       "data-slot": "track",
       "data-thumb-hidden": !!originalProps?.hideThumb,
       "data-vertical": isVertical,
-      "data-fill-start": fillWidth > 0,
-      "data-fill-end": fillWidth == 100,
+      ...(hasSingleThumb
+        ? {
+            "data-fill-start": fillWidth > 0,
+            "data-fill-end": fillWidth == 100,
+          }
+        : {
+            "data-fill-start": startOffset == 0,
+            "data-fill-end": startOffset * 100 + fillWidth == 100,
+          }),
       className: slots.track({class: classNames?.track}),
       ...trackProps,
       ...props,

--- a/packages/core/theme/src/components/slider.ts
+++ b/packages/core/theme/src/components/slider.ts
@@ -311,11 +311,12 @@ const slider = tv({
           "w-7 mx-[calc((theme(spacing.7)-theme(spacing.5))/2)] border-y-[calc(theme(spacing.7)/2)]",
       },
     },
-    // color && !isVertical && hasSingleThumb
+    // color && !isVertical && hasSingleThumb & !hideThumb
     {
       color: "foreground",
       isVertical: false,
       hasSingleThumb: true,
+      hideThumb: false,
       class: {
         track: "border-s-foreground",
       },
@@ -324,6 +325,7 @@ const slider = tv({
       color: "primary",
       isVertical: false,
       hasSingleThumb: true,
+      hideThumb: false,
       class: {
         track: "border-s-primary",
       },
@@ -332,6 +334,7 @@ const slider = tv({
       color: "secondary",
       isVertical: false,
       hasSingleThumb: true,
+      hideThumb: false,
       class: {
         track: "border-s-secondary",
       },
@@ -340,6 +343,7 @@ const slider = tv({
       color: "success",
       isVertical: false,
       hasSingleThumb: true,
+      hideThumb: false,
       class: {
         track: "border-s-success",
       },
@@ -348,6 +352,7 @@ const slider = tv({
       color: "warning",
       isVertical: false,
       hasSingleThumb: true,
+      hideThumb: false,
       class: {
         track: "border-s-warning",
       },
@@ -356,8 +361,53 @@ const slider = tv({
       color: "danger",
       isVertical: false,
       hasSingleThumb: true,
+      hideThumb: false,
       class: {
         track: "border-s-danger",
+      },
+    },
+    // color && hideThumb
+    {
+      color: "foreground",
+      hideThumb: true,
+      class: {
+        track:
+          "data-[fill-start=true]:border-s-foreground data-[fill-end=true]:border-e-foreground",
+      },
+    },
+    {
+      color: "primary",
+      hideThumb: true,
+      class: {
+        track: "data-[fill-start=true]:border-s-primary data-[fill-end=true]:border-e-primary",
+      },
+    },
+    {
+      color: "secondary",
+      hideThumb: true,
+      class: {
+        track: "data-[fill-start=true]:border-s-secondary data-[fill-end=true]:border-e-secondary",
+      },
+    },
+    {
+      color: "success",
+      hideThumb: true,
+      class: {
+        track: "data-[fill-start=true]:border-s-success data-[fill-end=true]:border-e-success",
+      },
+    },
+    {
+      color: "warning",
+      hideThumb: true,
+      class: {
+        track: "data-[fill-start=true]:border-s-warning data-[fill-end=true]:border-e-warning",
+      },
+    },
+    {
+      color: "danger",
+      hideThumb: true,
+      class: {
+        track: "data-[fill-start=true]:border-s-danger data-[fill-end=true]:border-e-danger",
       },
     },
     // color && isVertical && hasSingleThumb

--- a/packages/core/theme/src/components/slider.ts
+++ b/packages/core/theme/src/components/slider.ts
@@ -366,10 +366,11 @@ const slider = tv({
         track: "border-s-danger",
       },
     },
-    // color && hideThumb
+    // color && !isVertical && hideThumb
     {
       color: "foreground",
       hideThumb: true,
+      isVertical: false,
       class: {
         track:
           "data-[fill-start=true]:border-s-foreground data-[fill-end=true]:border-e-foreground",
@@ -378,6 +379,7 @@ const slider = tv({
     {
       color: "primary",
       hideThumb: true,
+      isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-primary data-[fill-end=true]:border-e-primary",
       },
@@ -385,6 +387,7 @@ const slider = tv({
     {
       color: "secondary",
       hideThumb: true,
+      isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-secondary data-[fill-end=true]:border-e-secondary",
       },
@@ -392,6 +395,7 @@ const slider = tv({
     {
       color: "success",
       hideThumb: true,
+      isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-success data-[fill-end=true]:border-e-success",
       },
@@ -399,6 +403,7 @@ const slider = tv({
     {
       color: "warning",
       hideThumb: true,
+      isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-warning data-[fill-end=true]:border-e-warning",
       },
@@ -406,57 +411,59 @@ const slider = tv({
     {
       color: "danger",
       hideThumb: true,
+      isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-danger data-[fill-end=true]:border-e-danger",
       },
     },
-    // color && isVertical && hasSingleThumb
+    // color && isVertical && hideThumb
     {
       color: "foreground",
+      hideThumb: true,
       isVertical: true,
-      hasSingleThumb: true,
       class: {
-        track: "border-b-foreground",
+        track:
+          "data-[fill-start=true]:border-b-foreground data-[fill-end=true]:border-t-foreground",
       },
     },
     {
       color: "primary",
+      hideThumb: true,
       isVertical: true,
-      hasSingleThumb: true,
       class: {
-        track: "border-b-primary",
+        track: "data-[fill-start=true]:border-b-primary data-[fill-end=true]:border-t-primary",
       },
     },
     {
       color: "secondary",
+      hideThumb: true,
       isVertical: true,
-      hasSingleThumb: true,
       class: {
-        track: "border-b-secondary",
+        track: "data-[fill-start=true]:border-b-secondary data-[fill-end=true]:border-t-secondary",
       },
     },
     {
       color: "success",
+      hideThumb: true,
       isVertical: true,
-      hasSingleThumb: true,
       class: {
-        track: "border-b-success",
+        track: "data-[fill-start=true]:border-b-success data-[fill-end=true]:border-t-success",
       },
     },
     {
       color: "warning",
+      hideThumb: true,
       isVertical: true,
-      hasSingleThumb: true,
       class: {
-        track: "border-b-warning",
+        track: "data-[fill-start=true]:border-b-warning data-[fill-end=true]:border-t-warning",
       },
     },
     {
       color: "danger",
+      hideThumb: true,
       isVertical: true,
-      hasSingleThumb: true,
       class: {
-        track: "border-b-danger",
+        track: "data-[fill-start=true]:border-b-danger data-[fill-end=true]:border-t-danger",
       },
     },
   ],

--- a/packages/core/theme/src/components/slider.ts
+++ b/packages/core/theme/src/components/slider.ts
@@ -311,65 +311,9 @@ const slider = tv({
           "w-7 mx-[calc((theme(spacing.7)-theme(spacing.5))/2)] border-y-[calc(theme(spacing.7)/2)]",
       },
     },
-    // color && !isVertical && hasSingleThumb & !hideThumb
+    // color && !isVertical
     {
       color: "foreground",
-      isVertical: false,
-      hasSingleThumb: true,
-      hideThumb: false,
-      class: {
-        track: "border-s-foreground",
-      },
-    },
-    {
-      color: "primary",
-      isVertical: false,
-      hasSingleThumb: true,
-      hideThumb: false,
-      class: {
-        track: "border-s-primary",
-      },
-    },
-    {
-      color: "secondary",
-      isVertical: false,
-      hasSingleThumb: true,
-      hideThumb: false,
-      class: {
-        track: "border-s-secondary",
-      },
-    },
-    {
-      color: "success",
-      isVertical: false,
-      hasSingleThumb: true,
-      hideThumb: false,
-      class: {
-        track: "border-s-success",
-      },
-    },
-    {
-      color: "warning",
-      isVertical: false,
-      hasSingleThumb: true,
-      hideThumb: false,
-      class: {
-        track: "border-s-warning",
-      },
-    },
-    {
-      color: "danger",
-      isVertical: false,
-      hasSingleThumb: true,
-      hideThumb: false,
-      class: {
-        track: "border-s-danger",
-      },
-    },
-    // color && !isVertical && hideThumb
-    {
-      color: "foreground",
-      hideThumb: true,
       isVertical: false,
       class: {
         track:
@@ -378,7 +322,6 @@ const slider = tv({
     },
     {
       color: "primary",
-      hideThumb: true,
       isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-primary data-[fill-end=true]:border-e-primary",
@@ -386,7 +329,6 @@ const slider = tv({
     },
     {
       color: "secondary",
-      hideThumb: true,
       isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-secondary data-[fill-end=true]:border-e-secondary",
@@ -394,7 +336,6 @@ const slider = tv({
     },
     {
       color: "success",
-      hideThumb: true,
       isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-success data-[fill-end=true]:border-e-success",
@@ -402,7 +343,6 @@ const slider = tv({
     },
     {
       color: "warning",
-      hideThumb: true,
       isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-warning data-[fill-end=true]:border-e-warning",
@@ -410,16 +350,14 @@ const slider = tv({
     },
     {
       color: "danger",
-      hideThumb: true,
       isVertical: false,
       class: {
         track: "data-[fill-start=true]:border-s-danger data-[fill-end=true]:border-e-danger",
       },
     },
-    // color && isVertical && hideThumb
+    // color && isVertical
     {
       color: "foreground",
-      hideThumb: true,
       isVertical: true,
       class: {
         track:
@@ -428,7 +366,6 @@ const slider = tv({
     },
     {
       color: "primary",
-      hideThumb: true,
       isVertical: true,
       class: {
         track: "data-[fill-start=true]:border-b-primary data-[fill-end=true]:border-t-primary",
@@ -436,7 +373,6 @@ const slider = tv({
     },
     {
       color: "secondary",
-      hideThumb: true,
       isVertical: true,
       class: {
         track: "data-[fill-start=true]:border-b-secondary data-[fill-end=true]:border-t-secondary",
@@ -444,7 +380,6 @@ const slider = tv({
     },
     {
       color: "success",
-      hideThumb: true,
       isVertical: true,
       class: {
         track: "data-[fill-start=true]:border-b-success data-[fill-end=true]:border-t-success",
@@ -452,7 +387,6 @@ const slider = tv({
     },
     {
       color: "warning",
-      hideThumb: true,
       isVertical: true,
       class: {
         track: "data-[fill-start=true]:border-b-warning data-[fill-end=true]:border-t-warning",
@@ -460,7 +394,6 @@ const slider = tv({
     },
     {
       color: "danger",
-      hideThumb: true,
       isVertical: true,
       class: {
         track: "data-[fill-start=true]:border-b-danger data-[fill-end=true]:border-t-danger",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5085

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

![image](https://github.com/user-attachments/assets/a02f3ade-0cdf-49d4-b28e-c6eeef0aaf32)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![image](https://github.com/user-attachments/assets/dcf3387a-7eb1-4cb0-bbf2-502f24a5a45b)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue causing improper slider display when the thumb is hidden.
  - Enhanced the accuracy of the slider’s fill state tracking for a smoother user experience.

- **Style**
  - Refined slider track styling with dynamic visual indicators for improved consistency across variants and orientations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->