### PR TITLE
fix(number-input): add missing dependencies to stepper button props

### DIFF
--- a/.changeset/clever-moles-divide.md
+++ b/.changeset/clever-moles-divide.md
@@ -1,0 +1,5 @@
+---
+"@heroui/number-input": patch
+---
+
+add missing dependencies to getStepperIncreaseButtonProps and getStepperDecreaseButtonProps (#5095)

--- a/packages/components/number-input/src/use-number-input.ts
+++ b/packages/components/number-input/src/use-number-input.ts
@@ -518,7 +518,7 @@ export function useNumberInput(originalProps: UseNumberInputProps) {
         ...mergeProps(incrementButtonProps, props),
       };
     },
-    [slots],
+    [slots, incrementButtonProps, classNames?.stepperButton],
   );
 
   const getStepperDecreaseButtonProps: PropGetter = useCallback(
@@ -533,7 +533,7 @@ export function useNumberInput(originalProps: UseNumberInputProps) {
         ...mergeProps(decrementButtonProps, props),
       };
     },
-    [slots],
+    [slots, decrementButtonProps, classNames?.stepperButton],
   );
 
   return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5095

## 📝 Description

<!--- Add a brief description -->

Originally `value` is same as `minValue`, the decrease button will be disabled. After increasing `value`, isDisabled` becomes `false` but it didn't reflect since the `decrementButtonProps` is not added to dependencies list. This PR also covers the `maxValue` case.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

stepper button is disabled even the value is not same as min / max value.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

stepper button is only disabled when it reaches the min / max value.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the responsiveness of the number input component’s increase and decrease controls, ensuring they update reliably when underlying properties change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->