### PR TITLE
fix(input): revise styles in color type

### DIFF
--- a/.changeset/light-hairs-complain.md
+++ b/.changeset/light-hairs-complain.md
@@ -1,0 +1,6 @@
+---
+"@heroui/input": patch
+"@heroui/theme": patch
+---
+
+fix input with type=color style (#5083)

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "@heroui/theme": ">=2.4.9",
+    "@heroui/theme": ">=2.4.12",
     "@heroui/system": ">=2.4.10"
   },
   "dependencies": {

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -375,6 +375,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         "data-filled-within": dataAttr(isFilledWithin),
         "data-has-start-content": dataAttr(hasStartContent),
         "data-has-end-content": dataAttr(!!endContent),
+        "data-type": type,
         className: slots.input({
           class: clsx(
             classNames?.input,

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -45,6 +45,7 @@ const input = tv({
       "w-full font-normal bg-transparent !outline-none placeholder:text-foreground-500 focus-visible:outline-none",
       "data-[has-start-content=true]:ps-1.5",
       "data-[has-end-content=true]:pe-1.5",
+      "data-[type=color]:rounded-none",
       "file:cursor-pointer file:bg-transparent file:border-0",
       "autofill:bg-transparent bg-clip-text",
     ],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5083

## 📝 Description

<!--- Add a brief description -->

With `type=color`, it shows a rectangle in laptop and circle in mobile. since we have `w-full`, it becomes an oval in mobile.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

![image](https://github.com/user-attachments/assets/e78a088c-bbd0-440c-b009-c6e5245efce7)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

same as laptop view

![image](https://github.com/user-attachments/assets/a04bb9ab-b8ea-445d-9c71-86ee1754ae6a)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
