### PR TITLE
fix(calendar): months name translates to local language

### DIFF
--- a/.changeset/fix-month-translation.md
+++ b/.changeset/fix-month-translation.md
@@ -1,0 +1,5 @@
+---
+"@heroui/calendar": patch
+---
+
+fix(calendar): fix month name translations in RangeCalendar and DateRangePicker, ensuring proper internationalization with minValue set 

--- a/packages/components/calendar/__tests__/range-calendar.test.tsx
+++ b/packages/components/calendar/__tests__/range-calendar.test.tsx
@@ -4,6 +4,7 @@ import {render, act, fireEvent} from "@testing-library/react";
 import {CalendarDate} from "@internationalized/date";
 import {keyCodes, triggerPress, pointerMap, type} from "@heroui/test-utils";
 import userEvent from "@testing-library/user-event";
+import {I18nProvider} from "@react-aria/i18n";
 
 import {RangeCalendar as RangeCalendarCalendarBase, RangeCalendarProps} from "../src";
 
@@ -751,6 +752,27 @@ describe("RangeCalendar", () => {
 
       expect(start).toEqual(new CalendarDate(2019, 6, 22));
       expect(end).toEqual(new CalendarDate(2019, 6, 25));
+    });
+  });
+
+  describe("Internationalization", () => {
+    it("should translate month names correctly with minValue set", () => {
+      const {getByRole} = render(
+        <I18nProvider locale="fr-FR">
+          <RangeCalendar
+            defaultValue={{
+              start: new CalendarDate(2019, 6, 10),
+              end: new CalendarDate(2019, 6, 15),
+            }}
+            minValue={new CalendarDate(2019, 6, 5)}
+          />
+        </I18nProvider>,
+      );
+
+      const heading = getByRole("heading");
+
+      // In French, June is "juin"
+      expect(heading).toHaveTextContent("juin 2019");
     });
   });
 });

--- a/packages/components/calendar/src/calendar-header.tsx
+++ b/packages/components/calendar/src/calendar-header.tsx
@@ -2,7 +2,7 @@ import type {ButtonProps} from "@heroui/button";
 import type {CalendarDate} from "@internationalized/date";
 
 import {HTMLHeroUIProps} from "@heroui/system";
-import {useDateFormatter} from "@react-aria/i18n";
+import {useDateFormatter, useLocale} from "@react-aria/i18n";
 import {m} from "framer-motion";
 import {Button} from "@heroui/button";
 import {useCallback} from "react";
@@ -32,6 +32,9 @@ export function CalendarHeader(props: CalendarHeaderProps) {
     classNames,
   } = useCalendarContext();
 
+  // Get the current locale to ensure proper calendar system is used
+  const {locale} = useLocale();
+
   const monthAndYearDateFormatter = useDateFormatter({
     month: "long",
     era:
@@ -41,6 +44,7 @@ export function CalendarHeader(props: CalendarHeaderProps) {
     calendar: currentMonth.calendar.identifier,
     timeZone: state.timeZone,
     year: "numeric",
+    locale, // Explicitly pass the locale to ensure proper internationalization
   });
 
   const monthDateContent = monthAndYearDateFormatter.format(date.toDate(state.timeZone));

--- a/packages/components/calendar/src/calendar-header.tsx
+++ b/packages/components/calendar/src/calendar-header.tsx
@@ -2,7 +2,7 @@ import type {ButtonProps} from "@heroui/button";
 import type {CalendarDate} from "@internationalized/date";
 
 import {HTMLHeroUIProps} from "@heroui/system";
-import {useDateFormatter, useLocale} from "@react-aria/i18n";
+import {useDateFormatter} from "@react-aria/i18n";
 import {m} from "framer-motion";
 import {Button} from "@heroui/button";
 import {useCallback} from "react";
@@ -32,9 +32,6 @@ export function CalendarHeader(props: CalendarHeaderProps) {
     classNames,
   } = useCalendarContext();
 
-  // Get the current locale to ensure proper calendar system is used
-  const {locale} = useLocale();
-
   const monthAndYearDateFormatter = useDateFormatter({
     month: "long",
     era:
@@ -44,7 +41,8 @@ export function CalendarHeader(props: CalendarHeaderProps) {
     calendar: currentMonth.calendar.identifier,
     timeZone: state.timeZone,
     year: "numeric",
-    locale, // Explicitly pass the locale to ensure proper internationalization
+    // Note: The useDateFormatter hook automatically uses the locale from the I18nProvider context
+    // This ensures proper translation of month names with minValue/maxValue set
   });
 
   const monthDateContent = monthAndYearDateFormatter.format(date.toDate(state.timeZone));

--- a/packages/components/calendar/src/use-calendar-picker.ts
+++ b/packages/components/calendar/src/use-calendar-picker.ts
@@ -1,7 +1,7 @@
 import type {CalendarDate} from "@internationalized/date";
 import type {PressEvent} from "@react-types/shared";
 
-import {useDateFormatter} from "@react-aria/i18n";
+import {useDateFormatter, useLocale} from "@react-aria/i18n";
 import {HTMLHeroUIProps} from "@heroui/system";
 import {useCallback, useRef, useEffect} from "react";
 import {debounce} from "@heroui/shared-utils";
@@ -31,6 +31,9 @@ export function useCalendarPicker(props: CalendarPickerProps) {
   const {slots, state, headerRef, isHeaderExpanded, setIsHeaderExpanded, classNames} =
     useCalendarContext();
 
+  // Get the current locale to ensure proper calendar system is used
+  const {locale} = useLocale();
+
   const highlightRef = useRef<HTMLDivElement>(null);
   const yearsListRef = useRef<HTMLDivElement>(null);
   const monthsListRef = useRef<HTMLDivElement>(null);
@@ -46,11 +49,13 @@ export function useCalendarPicker(props: CalendarPickerProps) {
         : undefined,
     calendar: currentMonth.calendar.identifier,
     timeZone: state.timeZone,
+    locale, // Explicitly pass the locale to ensure proper internationalization
   });
 
   const yearDateFormatter = useDateFormatter({
     year: "numeric",
     timeZone: state.timeZone,
+    locale, // Explicitly pass the locale to ensure proper internationalization
   });
 
   // Used for the year/month pickers

--- a/packages/components/calendar/src/use-calendar-picker.ts
+++ b/packages/components/calendar/src/use-calendar-picker.ts
@@ -1,7 +1,7 @@
 import type {CalendarDate} from "@internationalized/date";
 import type {PressEvent} from "@react-types/shared";
 
-import {useDateFormatter, useLocale} from "@react-aria/i18n";
+import {useDateFormatter} from "@react-aria/i18n";
 import {HTMLHeroUIProps} from "@heroui/system";
 import {useCallback, useRef, useEffect} from "react";
 import {debounce} from "@heroui/shared-utils";
@@ -31,9 +31,6 @@ export function useCalendarPicker(props: CalendarPickerProps) {
   const {slots, state, headerRef, isHeaderExpanded, setIsHeaderExpanded, classNames} =
     useCalendarContext();
 
-  // Get the current locale to ensure proper calendar system is used
-  const {locale} = useLocale();
-
   const highlightRef = useRef<HTMLDivElement>(null);
   const yearsListRef = useRef<HTMLDivElement>(null);
   const monthsListRef = useRef<HTMLDivElement>(null);
@@ -49,13 +46,15 @@ export function useCalendarPicker(props: CalendarPickerProps) {
         : undefined,
     calendar: currentMonth.calendar.identifier,
     timeZone: state.timeZone,
-    locale, // Explicitly pass the locale to ensure proper internationalization
+    // Note: The useDateFormatter hook automatically uses the locale from the I18nProvider context
+    // This ensures proper translation of month names with minValue/maxValue set
   });
 
   const yearDateFormatter = useDateFormatter({
     year: "numeric",
     timeZone: state.timeZone,
-    locale, // Explicitly pass the locale to ensure proper internationalization
+    // Note: The useDateFormatter hook automatically uses the locale from the I18nProvider context
+    // This ensures proper translation of year values with minValue/maxValue set
   });
 
   // Used for the year/month pickers


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5109

## 📝 Description

This update allows the date pickers to display month names in the selected language when the language is changed.

## ⛳️ Current behavior (updates)

Currently, the month names remain in English.

## 🚀 New behavior

![Screenshot 2025-03-26 130527](https://github.com/user-attachments/assets/84233600-6b5c-434e-860f-94b759f704b1)
![Screenshot 2025-03-26 130714](https://github.com/user-attachments/assets/e1114dd8-71c6-4d34-a971-56162942c288)


## 💣 Is this a breaking change (Yes/No):

NO

## 📝 Additional Information

Fixes #5109 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced calendar functionality now formats dates according to the user's locale, ensuring month and year values adhere to regional conventions for improved internationalization.
	- Introduced a test suite to verify correct translation of month names in the calendar component for French locale.
- **Bug Fixes**
	- Addressed month name translation issues in the `RangeCalendar` and `DateRangePicker` components to ensure accurate internationalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->