### PR TITLE
feat(accordion): add transitionDuration and scrollOnOpen props

### DIFF
--- a/.changeset/wicked-jeans-hammer.md
+++ b/.changeset/wicked-jeans-hammer.md
@@ -1,0 +1,6 @@
+---
+"@heroui/accordion": minor
+---
+
+- Introduce - `scrollOnOpen` to automatically scroll to the content when expanded
+- Added `transitionDuration` (default 300ms) prop to customize animation speed

--- a/packages/components/accordion/__tests__/accordion.test.tsx
+++ b/packages/components/accordion/__tests__/accordion.test.tsx
@@ -346,4 +346,59 @@ describe("Accordion", () => {
 
     expect(getByRole("separator")).toHaveClass("bg-rose-500");
   });
+
+  it("should scroll to content when scrollOnOpen is true", async () => {
+    const scrollIntoViewMock = jest.fn();
+
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const wrapper = render(
+      <Accordion scrollOnOpen>
+        <AccordionItem key="1" data-testid="item-1" title="Accordion Item 1">
+          Accordion Item 1 description
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const first = wrapper.getByTestId("item-1");
+    const firstButton = first.querySelector("button") as HTMLElement;
+
+    await user.click(firstButton);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        behavior: "smooth",
+        block: "nearest",
+      }),
+    );
+
+    jest.restoreAllMocks();
+  });
+
+  it("should apply custom transition duration", async () => {
+    const wrapper = render(
+      <Accordion disableAnimation={false} transitionDuration={500}>
+        <AccordionItem key="1" data-testid="item-1" title="Accordion Item 1">
+          Accordion Item 1 description
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const first = wrapper.getByTestId("item-1");
+    const firstButton = first.querySelector("button") as HTMLElement;
+
+    await user.click(firstButton);
+
+    const content = first.querySelector("section");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(content).toBeInTheDocument();
+  });
 });

--- a/packages/components/accordion/src/use-accordion-item.ts
+++ b/packages/components/accordion/src/use-accordion-item.ts
@@ -35,6 +35,16 @@ export interface Props<T extends object> extends HTMLHeroUIProps<"div"> {
    * Callback fired when the focus state changes.
    */
   onFocusChange?: (isFocused: boolean, key?: React.Key) => void;
+  /**
+   * Whether to automatically scroll to the content when expanded.
+   * @default false
+   */
+  scrollOnOpen?: boolean;
+  /**
+   * Custom duration for the expand/collapse animation in milliseconds.
+   * @default 300
+   */
+  transitionDuration?: number;
 }
 
 export type UseAccordionItemProps<T extends object = {}> = Props<T> &
@@ -64,6 +74,8 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
     disableAnimation = globalContext?.disableAnimation ?? false,
     keepContentMounted = false,
     disableIndicatorAnimation = false,
+    scrollOnOpen = false,
+    transitionDuration = 300,
     HeadingComponent = as || "h2",
     onPress,
     onPressStart,
@@ -269,6 +281,8 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
     keepContentMounted,
     disableAnimation,
     motionProps,
+    scrollOnOpen,
+    transitionDuration,
     getBaseProps,
     getHeadingProps,
     getButtonProps,

--- a/packages/components/accordion/src/use-accordion.ts
+++ b/packages/components/accordion/src/use-accordion.ts
@@ -45,6 +45,16 @@ interface Props extends HTMLHeroUIProps<"div"> {
    * The accordion items classNames.
    */
   itemClasses?: AccordionItemProps["classNames"];
+  /**
+   * Whether to automatically scroll to the content when an accordion item is expanded.
+   * @default false
+   */
+  scrollOnOpen?: boolean;
+  /**
+   * Custom duration for the expand/collapse animation in milliseconds.
+   * @default 300
+   */
+  transitionDuration?: number;
 }
 
 export type UseAccordionProps<T extends object = {}> = Props &
@@ -71,6 +81,8 @@ export type ValuesType<T extends object = {}> = {
   keepContentMounted?: Props["keepContentMounted"];
   disableIndicatorAnimation?: AccordionItemProps["disableAnimation"];
   motionProps?: AccordionItemProps["motionProps"];
+  scrollOnOpen?: boolean;
+  transitionDuration?: number;
 };
 
 export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
@@ -103,6 +115,8 @@ export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
     disableAnimation = globalContext?.disableAnimation ?? false,
     disableIndicatorAnimation = false,
     itemClasses,
+    scrollOnOpen = false,
+    transitionDuration = 300,
     ...otherProps
   } = props;
 
@@ -195,6 +209,8 @@ export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
       disableAnimation,
       keepContentMounted,
       disableIndicatorAnimation,
+      scrollOnOpen,
+      transitionDuration,
     }),
     [
       focusedKey,
@@ -209,6 +225,8 @@ export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
       state.expandedKeys.size,
       state.disabledKeys.size,
       motionProps,
+      scrollOnOpen,
+      transitionDuration,
     ],
   );
 
@@ -244,6 +262,8 @@ export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
     disableAnimation,
     handleFocusChanged,
     itemClasses,
+    scrollOnOpen,
+    transitionDuration,
   };
 }
 

--- a/packages/components/accordion/stories/accordion.stories.tsx
+++ b/packages/components/accordion/stories/accordion.stories.tsx
@@ -1,22 +1,22 @@
 import type {Selection} from "@react-types/shared";
 
-import React from "react";
-import {Meta} from "@storybook/react";
-import {accordionItem, button} from "@heroui/theme";
+import {Avatar} from "@heroui/avatar";
+import {Button} from "@heroui/button";
+import {Input, Textarea} from "@heroui/input";
 import {
   AnchorIcon,
-  MoonIcon,
-  SunIcon,
   InfoIcon,
-  ShieldSecurityIcon,
-  MonitorMobileIcon,
   InvalidCardIcon,
+  MonitorMobileIcon,
+  MoonIcon,
+  ShieldSecurityIcon,
+  SunIcon,
 } from "@heroui/shared-icons";
-import {Avatar} from "@heroui/avatar";
-import {Input, Textarea} from "@heroui/input";
-import {Button} from "@heroui/button";
+import {accordionItem, button} from "@heroui/theme";
+import {Meta} from "@storybook/react";
+import React from "react";
 
-import {Accordion, AccordionProps, AccordionItem, AccordionItemProps} from "../src";
+import {Accordion, AccordionItem, AccordionItemProps, AccordionProps} from "../src";
 
 export default {
   title: "Components/Accordion",
@@ -376,6 +376,57 @@ const WithFormTemplate = (args: AccordionProps) => {
   );
 };
 
+const WithScrollOnOpenTemplate = (args: AccordionProps) => (
+  <div className="h-96 overflow-auto p-4 border rounded">
+    <h3 className="text-xl font-bold mb-6">Scroll container</h3>
+    <div className="mb-96">
+      <p className="mb-6">Scroll down to see the accordion</p>
+    </div>
+    <Accordion {...args} scrollOnOpen>
+      <AccordionItem key="1" aria-label="Accordion 1" title="Scroll on open (try opening this)">
+        <div className="p-4">
+          <p className="mb-4">{defaultContent}</p>
+          <Button color="primary">This will be scrolled into view</Button>
+        </div>
+      </AccordionItem>
+      <AccordionItem key="2" aria-label="Accordion 2" title="Accordion 2">
+        {defaultContent}
+      </AccordionItem>
+      <AccordionItem key="3" aria-label="Accordion 3" title="Accordion 3">
+        {defaultContent}
+      </AccordionItem>
+    </Accordion>
+  </div>
+);
+
+const WithCustomTransitionDurationTemplate = (args: AccordionProps) => (
+  <div className="flex flex-col gap-8">
+    <div>
+      <h3 className="mb-2 font-medium">Fast Transition (150ms)</h3>
+      <Accordion {...args} transitionDuration={150}>
+        <AccordionItem key="1" aria-label="Accordion 1" title="Fast transition accordion">
+          {defaultContent}
+        </AccordionItem>
+        <AccordionItem key="2" aria-label="Accordion 2" title="Accordion 2">
+          {defaultContent}
+        </AccordionItem>
+      </Accordion>
+    </div>
+
+    <div>
+      <h3 className="mb-2 font-medium">Slow Transition (800ms)</h3>
+      <Accordion {...args} transitionDuration={800}>
+        <AccordionItem key="1" aria-label="Accordion 1" title="Slow transition accordion">
+          {defaultContent}
+        </AccordionItem>
+        <AccordionItem key="2" aria-label="Accordion 2" title="Accordion 2">
+          {defaultContent}
+        </AccordionItem>
+      </Accordion>
+    </div>
+  </div>
+);
+
 export const Default = {
   render: Template,
 
@@ -523,6 +574,22 @@ export const Controlled = {
 
 export const CustomWithClassNames = {
   render: CustomWithClassNamesTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const WithScrollOnOpen = {
+  render: WithScrollOnOpenTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const WithCustomTransitionDuration = {
+  render: WithCustomTransitionDurationTemplate,
 
   args: {
     ...defaultProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- Added optional property`transitionDuration` (default 300ms just like in Framer), to customize behaviour
- Added  optional property `scrollOnOpen` to scroll automatically to just opened accordion item to increase content visibility.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->
Currently it was not possible to customize animation duration time.
## 🚀 New behavior
<!--- Please describe the behavior or changes this PR adds -->
User can customize animation duration time and additionally apply automatic scroll to just opened accordion item.

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
