### PR TITLE
fix(input): prevent accessibility label duplication

### DIFF
--- a/.changeset/light-cups-melt.md
+++ b/.changeset/light-cups-melt.md
@@ -2,4 +2,4 @@
 "@heroui/input": patch
 ---
 
-fix `Input` accessibility label duplication
+fix `Input` accessibility label duplication (#5150)

--- a/.changeset/light-cups-melt.md
+++ b/.changeset/light-cups-melt.md
@@ -1,0 +1,5 @@
+---
+"@heroui/input": patch
+---
+
+fix `Input` accessibility label duplication

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -86,7 +86,37 @@ describe("Input", () => {
     const labelId = container.querySelector("label")?.id;
     const labelledBy = container.querySelector("input")?.getAttribute("aria-labelledby");
 
-    expect(labelledBy?.includes(labelId as string)).toBeTruthy();
+    expect(labelledBy).toBe(labelId);
+  });
+
+  it("should be labelled by placeholder when no label is provided", () => {
+    const {getByRole} = render(<Input placeholder="test input" />);
+
+    expect(getByRole("textbox", {name: "test input"})).toBeInTheDocument();
+  });
+
+  it("should be labelled by aria-label when no label is provided", () => {
+    const {getByRole} = render(<Input aria-label="test input" />);
+
+    expect(getByRole("textbox", {name: "test input"})).toBeInTheDocument();
+  });
+
+  it("should be labelled by label when label is provided", () => {
+    const {getByRole} = render(<Input label="test input" />);
+
+    expect(getByRole("textbox", {name: "test input"})).toBeInTheDocument();
+  });
+
+  it("should be labelled by label and aria-label when both label and aria-label are provided", () => {
+    const {getByRole} = render(<Input aria-label="test input" label="test input" />);
+
+    expect(getByRole("textbox", {name: "test input test input"})).toBeInTheDocument();
+  });
+
+  it("should be labelled by label when both label and placeholder are provided", () => {
+    const {getByRole} = render(<Input label="test input" placeholder="test input placeholder" />);
+
+    expect(getByRole("textbox", {name: "test input"})).toBeInTheDocument();
   });
 
   it("should have the correct type attribute", () => {

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -190,11 +190,9 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       validationBehavior,
       autoCapitalize: originalProps.autoCapitalize as AutoCapitalize,
       value: inputValue,
-      "aria-label": safeAriaLabel(
-        originalProps["aria-label"],
-        originalProps.label,
-        originalProps.placeholder,
-      ),
+      "aria-label": originalProps.label
+        ? originalProps["aria-label"]
+        : safeAriaLabel(originalProps["aria-label"], originalProps.placeholder),
       inputElementType: isMultiline ? "textarea" : "input",
       onChange: setInputValue,
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5150 

## 📝 Description

This PR fixes an accessibility label issue with `Input` and adds new tests to assert various behaviours around label-like props passed to the component.

## ⛳️ Current behavior (updates)
`label` prop passed to `Input` gets duplicated in the accessibility tree.  

<img width="330" alt="Screenshot 2025-04-07 at 2 36 31 PM" src="https://github.com/user-attachments/assets/fbc2378d-1d4e-4ee1-8213-2829deec4bcd" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->
`label` prop passed to `Input` gets properly represented in the accessibility tree.  

<img width="371" alt="Screenshot 2025-04-07 at 2 31 47 PM" src="https://github.com/user-attachments/assets/dc5ca6b8-db62-464d-a6e1-19bb2edc2a44" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->
The change is a breaking one for consumers that wrote tests with selectors like `getByRole('input', {name: "Email Email"})` to work around the bug. If this sort of fix requires a major update tag, I can update the changeset, no problem.

## 📝 Additional Information
As I outlined in [this comment](https://github.com/heroui-inc/heroui/issues/5150#issuecomment-2779749367) on the original issue, `useTextField` from `@react-aria` essentially concatenates `aria-label` and `label` passed to it by adding input ID and label ID to `aria-labelledby`.

Considering the fact that, according to git log, the relevant logic has survived multiple refactorings and has [a test explicitly asserting that labels are concatenated](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/label/test/useLabel.test.js#L42-L50), it appears that the `useTextField` hook acts as intended and it is the HeroUI that is misusing the `@react-aria` API.

The new tests I added were built with a few assumptions that are not 100% documented, but should make sense in the context of how `@react-aria` acts:
* passing one of `label`, `aria-label`, `placeholder`  produces an duplicated accessibility label
* `placeholder` is only used as a fallback, if neither `label` nor `aria-label` are passed. This is an undocumented HeroUI feature.
* to get the original duplicated label behaviour, consumers need to pass both `label` and `aria-label` explicitly. This is similar to how the `useTextField` hook from `@react-aria` would behave, if consumed directly by consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the Input component could display duplicate accessibility labels, improving accessibility compliance.

- **Tests**
  - Added new test cases to ensure the Input component correctly handles labeling with placeholders, aria-labels, and labels under various scenarios. Enhanced test coverage for accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->