### PR TITLE
fix(theme): `hover-opacity` in Link & Breadcrumb

### DIFF
--- a/.changeset/quick-coats-raise.md
+++ b/.changeset/quick-coats-raise.md
@@ -2,4 +2,4 @@
 "@heroui/theme": patch
 ---
 
-Utilize `hover-opacity` in <Link> component.
+Utilize `hover-opacity` in <Link> component (#5169)

--- a/.changeset/quick-coats-raise.md
+++ b/.changeset/quick-coats-raise.md
@@ -1,0 +1,5 @@
+---
+"@heroui/theme": patch
+---
+
+Utilize `hover-opacity` in <Link> component.

--- a/.changeset/quick-coats-raise.md
+++ b/.changeset/quick-coats-raise.md
@@ -2,4 +2,4 @@
 "@heroui/theme": patch
 ---
 
-Utilize `hover-opacity` in <Link> component (#5169)
+Utilize `hover-opacity` in Link & Breadcrumb component (#5169)

--- a/packages/core/theme/src/components/breadcrumbs.ts
+++ b/packages/core/theme/src/components/breadcrumbs.ts
@@ -84,7 +84,7 @@ const breadcrumbItem = tv({
         item: "cursor-default",
       },
       false: {
-        item: ["hover:opacity-80", "active:opacity-disabled"],
+        item: ["hover:opacity-hover", "active:opacity-disabled"],
       },
     },
     isDisabled: {

--- a/packages/core/theme/src/components/link.ts
+++ b/packages/core/theme/src/components/link.ts
@@ -50,7 +50,7 @@ const link = tv({
         "after:transition-background",
         "after:absolute",
       ],
-      false: "hover:opacity-80 active:opacity-disabled transition-opacity",
+      false: "hover:opacity-hover active:opacity-disabled transition-opacity",
     },
     isDisabled: {
       true: "opacity-disabled cursor-default pointer-events-none",


### PR DESCRIPTION
Closes #5169

## 📝 Description

The hover behavior of HeroUI `<Link>` components is inconsistent with theme configuration.

## ⛳️ Current behavior (updates)

`<Link>` component currently has a hardcoded hover opacity of 80% for non-block links.

## 🚀 New behavior

`<Link>` component utilizes layout `hoverOpacity` variable (i.e., `hover:opacity-hover`).

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated hover opacity for link and breadcrumb components to use a semantic variable, enhancing visual feedback on interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->