### PR TITLE
fix(accordion): keepContentMounted with disableAnimation

### DIFF
--- a/.changeset/smooth-bears-leave.md
+++ b/.changeset/smooth-bears-leave.md
@@ -1,0 +1,5 @@
+---
+"@heroui/accordion": patch
+---
+
+fixed keepContentMounted with disableAnimation (#5157)

--- a/packages/components/accordion/__tests__/accordion.test.tsx
+++ b/packages/components/accordion/__tests__/accordion.test.tsx
@@ -267,7 +267,7 @@ describe("Accordion", () => {
     expect(button).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("should support keepContentMounted", async () => {
+  it("should support keepContentMounted={true}", async () => {
     const wrapper = render(
       <Accordion keepContentMounted>
         <AccordionItem key="1" data-testid="item-1" title="Accordion Item 1">
@@ -290,6 +290,84 @@ describe("Accordion", () => {
 
     await user.click(button2);
     expect(item1.querySelector("[role='region']")).toBeInTheDocument();
+    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+  });
+
+  it("should support keepContentMounted={false}", async () => {
+    const wrapper = render(
+      <Accordion keepContentMounted={false}>
+        <AccordionItem key="1" data-testid="item-1" title="Accordion Item 1">
+          Accordion Item 1 description
+        </AccordionItem>
+        <AccordionItem key="2" data-testid="item-2" title="Accordion Item 2">
+          Accordion Item 2 description
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const item1 = wrapper.getByTestId("item-1");
+    const button = item1.querySelector("button") as HTMLElement;
+
+    expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
+
+    await user.click(button);
+    const item2 = wrapper.getByTestId("item-2");
+    const button2 = item2.querySelector("button") as HTMLElement;
+
+    await user.click(button2);
+    expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
+    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+  });
+
+  it("should support keepContentMounted={true} & disableAnimation={true}", async () => {
+    const wrapper = render(
+      <Accordion disableAnimation keepContentMounted>
+        <AccordionItem key="1" data-testid="item-1" title="Accordion Item 1">
+          Accordion Item 1 description
+        </AccordionItem>
+        <AccordionItem key="2" data-testid="item-2" title="Accordion Item 2">
+          Accordion Item 2 description
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const item1 = wrapper.getByTestId("item-1");
+    const button = item1.querySelector("button") as HTMLElement;
+
+    expect(item1.querySelector("[role='region']")).toBeInTheDocument();
+
+    await user.click(button);
+    const item2 = wrapper.getByTestId("item-2");
+    const button2 = item2.querySelector("button") as HTMLElement;
+
+    await user.click(button2);
+    expect(item1.querySelector("[role='region']")).toBeInTheDocument();
+    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+  });
+
+  it("should support keepContentMounted={false} & disableAnimation={true}", async () => {
+    const wrapper = render(
+      <Accordion disableAnimation keepContentMounted={false}>
+        <AccordionItem key="1" data-testid="item-1" title="Accordion Item 1">
+          Accordion Item 1 description
+        </AccordionItem>
+        <AccordionItem key="2" data-testid="item-2" title="Accordion Item 2">
+          Accordion Item 2 description
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const item1 = wrapper.getByTestId("item-1");
+    const button = item1.querySelector("button") as HTMLElement;
+
+    expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
+
+    await user.click(button);
+    const item2 = wrapper.getByTestId("item-2");
+    const button2 = item2.querySelector("button") as HTMLElement;
+
+    await user.click(button2);
+    expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
     expect(item2.querySelector("[role='region']")).toBeInTheDocument();
   });
 

--- a/packages/components/accordion/__tests__/accordion.test.tsx
+++ b/packages/components/accordion/__tests__/accordion.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import * as React from "react";
-import {act, render} from "@testing-library/react";
+import {act, render, waitFor} from "@testing-library/react";
 import {focus, shouldIgnoreReactWarning, spy} from "@heroui/test-utils";
 import userEvent, {UserEvent} from "@testing-library/user-event";
 import {Input} from "@heroui/input";
@@ -289,8 +289,11 @@ describe("Accordion", () => {
     const button2 = item2.querySelector("button") as HTMLElement;
 
     await user.click(button2);
-    expect(item1.querySelector("[role='region']")).toBeInTheDocument();
-    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(item1.querySelector("[role='region']")).toBeInTheDocument();
+      expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+    });
   });
 
   it("should support keepContentMounted={false}", async () => {
@@ -315,8 +318,11 @@ describe("Accordion", () => {
     const button2 = item2.querySelector("button") as HTMLElement;
 
     await user.click(button2);
-    expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
-    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
+      expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+    });
   });
 
   it("should support keepContentMounted={true} & disableAnimation={true}", async () => {
@@ -341,8 +347,11 @@ describe("Accordion", () => {
     const button2 = item2.querySelector("button") as HTMLElement;
 
     await user.click(button2);
-    expect(item1.querySelector("[role='region']")).toBeInTheDocument();
-    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(item1.querySelector("[role='region']")).toBeInTheDocument();
+      expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+    });
   });
 
   it("should support keepContentMounted={false} & disableAnimation={true}", async () => {
@@ -367,8 +376,11 @@ describe("Accordion", () => {
     const button2 = item2.querySelector("button") as HTMLElement;
 
     await user.click(button2);
-    expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
-    expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(item1.querySelector("[role='region']")).not.toBeInTheDocument();
+      expect(item2.querySelector("[role='region']")).toBeInTheDocument();
+    });
   });
 
   it("should handle arrow key navigation within Input inside AccordionItem", async () => {

--- a/packages/components/accordion/src/accordion-item.tsx
+++ b/packages/components/accordion/src/accordion-item.tsx
@@ -54,7 +54,11 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
 
   const content = useMemo(() => {
     if (disableAnimation) {
-      return <div {...getContentProps()}>{children}</div>;
+      if (keepContentMounted) {
+        return <div {...getContentProps()}>{children}</div>;
+      }
+
+      return isOpen && <div {...getContentProps()}>{children}</div>;
     }
 
     const transitionVariants: Variants = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5157

## 📝 Description

<!--- Add a brief description -->

currently `disableAnimation` bypass `keepContentMounted` logic. This PR is to cover it.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

The content is mounted no matter `keepContentMounted` is true or false.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

The content is mounted only when `keepContentMounted` is true.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accordion’s behavior to properly manage content display when animations are disabled. Content is now conditionally rendered based on the `keepContentMounted` setting, ensuring it appears only when expected.

- **Tests**
  - Expanded test coverage to verify the accordion’s performance under different configurations, ensuring consistent behavior whether content is pre-mounted or loaded on interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->