### PR TITLE
Fix lazy load error in Plasmo

### DIFF
--- a/packages/components/toast/src/toast-provider.tsx
+++ b/packages/components/toast/src/toast-provider.tsx
@@ -1,11 +1,11 @@
 import {ToastOptions, ToastQueue, useToastQueue} from "@react-stately/toast";
 import {useProviderContext} from "@heroui/system";
-import {AnimatePresence, LazyMotion} from "framer-motion";
+import {AnimatePresence, LazyMotion, domMax} from "framer-motion";
 
 import {RegionProps, ToastRegion} from "./toast-region";
 import {ToastProps, ToastPlacement} from "./use-toast";
 
-const loadFeatures = () => import("framer-motion").then((res) => res.domMax);
+const loadFeatures = () => Promise.resolve(domMax);
 
 let globalToastQueue: ToastQueue<ToastProps> | null = null;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

When using the HeroUI Toast component in Plasmo, there's a bug that makes the page not render. After debugging, we found it's because ToastProvider lazy loads framer-motion's domMax. Check out the related error:

https://github.com/PlasmoHQ/plasmo/issues/1180
https://github.com/PlasmoHQ/plasmo/issues/1241


<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

You can check the image descriptions in the two issues mentioned above. This problem causes the page to not render at all, with an error saying "xxx is not a function."

Maybe it's an issue with Parcel used by Plasmo, making it unable to dynamically import some modules. But if HeroUI could provide a usable update ASAP, developers would really appreciate it.

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

Toast will work as expect.

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
NO
