### PR TITLE
fix(theme): add default value for custom theme properties

### DIFF
--- a/.changeset/honest-keys-swim.md
+++ b/.changeset/honest-keys-swim.md
@@ -2,4 +2,4 @@
 "@heroui/theme": patch
 ---
 
-add default value for custom theme properties
+add default value for custom theme properties (#5194)

--- a/.changeset/honest-keys-swim.md
+++ b/.changeset/honest-keys-swim.md
@@ -1,0 +1,5 @@
+---
+"@heroui/theme": patch
+---
+
+add default value for custom theme properties

--- a/packages/core/theme/src/plugin.ts
+++ b/packages/core/theme/src/plugin.ts
@@ -277,15 +277,15 @@ export const heroui = (config: HeroUIPluginConfig = {}): ReturnType<typeof plugi
   Object.entries(otherThemes).forEach(([themeName, {extend, colors, layout}]) => {
     const baseTheme = extend && isBaseTheme(extend) ? extend : defaultExtendTheme;
 
-    if (colors && typeof colors === "object") {
-      otherThemes[themeName].colors = deepMerge(semanticColors[baseTheme], colors);
-    }
-    if (layout && typeof layout === "object") {
-      otherThemes[themeName].layout = deepMerge(
-        extend ? baseLayouts[extend] : defaultLayoutObj,
-        layout,
-      );
-    }
+    const baseColors = semanticColors[baseTheme];
+
+    otherThemes[themeName].colors =
+      colors && typeof colors === "object" ? deepMerge(baseColors, colors) : baseColors;
+
+    const baseLayout = extend ? baseLayouts[extend] : defaultLayoutObj;
+
+    otherThemes[themeName].layout =
+      layout && typeof layout === "object" ? deepMerge(baseLayout, layout) : baseLayout;
   });
 
   const light: ConfigTheme = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5194 

## 📝 Description

Custom theme reports an error when colors attribute is not specified.

## ⛳️ Current behavior (updates)

The deepMerge operation only applies if the custom theme explicitly defines both colors and layout properties. Undefined properties remain unchanged.

## 🚀 New behavior

Custom theme properties now extend their default values from the parent theme.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency by always assigning default values for theme colors and layout, ensuring these properties are always defined in custom themes.

- **Chores**
  - Added documentation for a patch update to the theme package, highlighting the addition of default values for custom theme properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->