### PR TITLE
docs: fixed a typo in the accordion docs

### DIFF
--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -294,15 +294,15 @@ Here's an example of how to customize the accordion styles:
       default: "-"
     },
     {
-      attribute: "selectedKeys",
+      attribute: "expandedKeys",
       type: "all | React.Key[]",
-      description: "The currently selected keys in the collection (controlled).",
+      description: "The currently expanded keys in the collection (controlled).",
       default: "-"
     },
     {
-      attribute: "defaultSelectedKeys",
+      attribute: "defaultExpandedKeys",
       type: "all | React.Key[]",
-      description: "The initial selected keys in the collection (uncontrolled).",
+      description: "The initial expanded keys in the collection (uncontrolled).",
       default: "-"
     }
   ]}


### PR DESCRIPTION
## 📝 Description

Just fixed a small typo in the Accordion component documentation regarding expandedKeys and defaultExpandedKeys

## ⛳️ Current behavior (updates)

Accordion documentation contains selectedKeys instead of expandedKeys

## 🚀 New behavior

Corrected the typos

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

No additional information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Accordion component documentation to clarify terminology, renaming properties from "selectedKeys" to "expandedKeys" and from "defaultSelectedKeys" to "defaultExpandedKeys" for improved clarity regarding expanded items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->