### PR TITLE
fix(docs): correct Tailwind v4 migration guide syntax and formatting

### DIFF
--- a/apps/docs/content/docs/guide/tailwind-v4.mdx
+++ b/apps/docs/content/docs/guide/tailwind-v4.mdx
@@ -39,7 +39,7 @@ TailwindCSS v4 is now available in Beta! This guide will help you migrate your e
 - @tailwind utilities;
 
 + @import "tailwindcss";
-+ @config "../../tailwind.config.js"
++ @config "../../tailwind.config.js";
 ```
 
 ### Update PostCSS Configuration


### PR DESCRIPTION
Tailwindcss CSS configuration must end with `;`, the original document contains a syntax error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a CSS import snippet for improved accuracy.
  - Improved formatting by adding a newline after the last list item in the "Need Help?" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->