### PR TITLE
fix(breadcrumbs): missing key for ellipsisItem

### DIFF
--- a/.changeset/modern-balloons-wash.md
+++ b/.changeset/modern-balloons-wash.md
@@ -1,0 +1,5 @@
+---
+"@heroui/breadcrumbs": patch
+---
+
+fixed missing key for ellipsisItem in breadcrumbs (#4973)

--- a/packages/components/breadcrumbs/src/breadcrumbs.tsx
+++ b/packages/components/breadcrumbs/src/breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, useMemo} from "react";
+import {cloneElement, isValidElement, useMemo} from "react";
 import {forwardRef} from "@heroui/system";
 import {ChevronRightIcon, EllipsisIcon} from "@heroui/shared-icons";
 import {warn} from "@heroui/shared-utils";
@@ -90,7 +90,7 @@ const Breadcrumbs = forwardRef<"div", BreadcrumbsProps>((props, ref) => {
 
     return [
       ...items.slice(0, itemsBeforeCollapse),
-      ellipsisItem,
+      isValidElement(ellipsisItem) && cloneElement(ellipsisItem, {key: "ellipsis-item"}),
       ...items.slice(items.length - itemsAfterCollapse, items.length),
     ];
   }, [


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4973

## 📝 Description

Keys are specified for before & after collapse but not in ellipsisItem if users use `renderEllipsis`. Hence, this PR is to cater this case.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the ellipsis item in breadcrumbs could cause rendering problems by ensuring it always has a proper key assigned. This improves stability and consistency in breadcrumb navigation displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->