### PR TITLE
fix(accordion): double click to focus when we have input or another component

### DIFF
--- a/.changeset/wise-trees-buy.md
+++ b/.changeset/wise-trees-buy.md
@@ -1,0 +1,5 @@
+---
+"@heroui/accordion": patch
+---
+
+fix(accordion): double click to focus when we have input or another component (#4981)

--- a/packages/components/accordion/src/use-accordion-item.ts
+++ b/packages/components/accordion/src/use-accordion-item.ts
@@ -192,6 +192,21 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
         "data-disabled": dataAttr(isDisabled),
         "data-slot": "content",
         className: slots.content({class: classNames?.content}),
+        onClickCapture: (e) => {
+          const target = e.target;
+
+          if (target instanceof HTMLElement) {
+            // Check if the element is focusable and not disabled
+            const isFocusable = target.tabIndex >= 0;
+            const isNotDisabled = !target.hasAttribute("disabled");
+            const hasFocusMethod = typeof target.focus === "function";
+
+            if (isFocusable && isNotDisabled && hasFocusMethod) {
+              e.stopPropagation();
+              target.focus();
+            }
+          }
+        },
         ...mergeProps(regionProps, props),
       };
     },

--- a/packages/components/accordion/stories/accordion.stories.tsx
+++ b/packages/components/accordion/stories/accordion.stories.tsx
@@ -461,6 +461,15 @@ export const WithForm = {
   },
 };
 
+export const WithFormAndOpenAccordion = {
+  render: WithFormTemplate,
+
+  args: {
+    ...defaultProps,
+    defaultSelectedKeys: ["1"],
+  },
+};
+
 export const CustomMotion = {
   render: Template,
 


### PR DESCRIPTION
Closes #4981

## 📝 Description

In HeroUI v2.7.4, a bug was discovered where interactive elements (like inputs) inside controlled accordion items required two clicks to become focused. This issue occurred when:

- The accordion was controlled (using `selectedKeys` or `defaultSelectedKeys`)
- The accordion item was initially expanded
- Users tried to interact with form elements inside the accordion

Users had to click twice on form elements to focus them and begin typing, leading to a poor user experience.

## ⛳️ Current behavior (updates)

When we have a focusable component in a default open accordion, we need to click 2 times to focus the element. This issue occurs due to event handling not properly managing focus for interactive elements inside the accordion.

## 🚀 New behavior

When we have a focusable component in a default open accordion, we focus the element in one click. The implementation adds a new handler with clear, explicit conditions.

This solution:

1. Explicitly checks if the element is focusable with `target.tabIndex >= 0`
2. Verifies the element is not disabled with `!target.hasAttribute("disabled")`
3. Ensures the focus method exists and is a function with `typeof target.focus === "function"`
4. Only proceeds with focus handling when all three conditions are met

```js
onClickCapture: (e) => {
  const target = e.target;

  if (target instanceof HTMLElement) {
    // Check if the element is focusable and not disabled
    const isFocusable = target.tabIndex >= 0;
    const isNotDisabled = !target.hasAttribute("disabled");
    const hasFocusMethod = typeof target.focus === "function";

    if (isFocusable && isNotDisabled && hasFocusMethod) {
      e.stopPropagation();
      target.focus();
    }
  }
}
```

## Benefits

- Interactive elements inside accordion items now properly focus on the first click
- The code is more maintainable with clear variable names describing the conditions
- The logical flow is more predictable, fixing the focus behavior across all accordion use cases

## 💣 Is this a breaking change (Yes/No):

No

