### PR TITLE
fix(image): removed extra height style

### DIFF
--- a/.changeset/beige-boxes-cheat.md
+++ b/.changeset/beige-boxes-cheat.md
@@ -1,0 +1,5 @@
+---
+"@heroui/image": patch
+---
+
+Removed additional height style (#3813)

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -116,7 +116,7 @@ export function useImage(originalProps: UseImageProps) {
 
   const domRef = useDOMRef(ref);
 
-  const {w, h} = useMemo(() => {
+  const {w} = useMemo(() => {
     return {
       w: props.width
         ? typeof props.width === "number"
@@ -162,7 +162,6 @@ export function useImage(originalProps: UseImageProps) {
       style: {
         // img has `height: auto` by default
         // passing the custom height here to override if it is specified
-        ...(otherProps?.height && {height: h}),
         ...props.style,
         ...otherProps.style,
       },

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -123,13 +123,8 @@ export function useImage(originalProps: UseImageProps) {
           ? `${props.width}px`
           : props.width
         : "fit-content",
-      h: props.height
-        ? typeof props.height === "number"
-          ? `${props.height}px`
-          : props.height
-        : "auto",
     };
-  }, [props?.width, props?.height]);
+  }, [props?.width]);
 
   const showFallback = (!src || !isImgLoaded) && !!fallbackSrc;
   const showSkeleton = isLoading && !disableSkeleton;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3813  <!-- Github issue # here -->

## 📝 Description

Removed the additional style prop which was providing height

![Screenshot 2025-05-06 143853](https://github.com/user-attachments/assets/f719af10-0a86-44fa-97f0-0fe380ebc308)


## ⛳️ Current behavior (updates)

The current behavious is distorting the image vertically

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior
The image will only have one height prop and not the additional `style="height: Ypx"`

![Screenshot 2025-05-06 143908](https://github.com/user-attachments/assets/23192c12-8dbb-438f-badf-6bf73be3cf63)

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed unintended extra height styling from images to ensure correct image display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->