### PR TITLE
fix: no require.resolve in modern node

### DIFF
--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -1,6 +1,9 @@
 import {dirname, join} from "path";
 import remarkGfm from "remark-gfm";
 import type {StorybookConfig} from "@storybook/react-vite";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
 
 const config: StorybookConfig = {
   stories: [


### PR DESCRIPTION
No `require.resolve`: https://nodejs.org/api/esm.html#differences-between-es-modules-and-commonjs

[import.meta.resolve](https://nodejs.org/api/esm.html#importmetaresolvespecifier) still has some problem here. So this is why I use `module.createRequire()`

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d463f4f9-392f-4af7-af0b-a107a6b4b094" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved compatibility with ES module environments for package path resolution in Storybook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->