### PR TITLE
refactor(button): omit `disabled` prop from component props

### DIFF
--- a/.changeset/moody-houses-double.md
+++ b/.changeset/moody-houses-double.md
@@ -8,28 +8,29 @@
 
 ### What
 
-Improved the internal handling of `disabled` and `isDisabled` props in `useButton` hook:
+Improved the internal handling of `disabled` and `isDisabled` props in the `useButton` hook:
 
 - Now both `disabled` (native) and `isDisabled` (custom) props are supported in a controlled and consistent way.
-- When both are provided, `disabled` takes precedence over `isDisabled`.
-- This update ensures a predictable and accessible behavior for the button component, and prevents accidental bypass of the disabled state.
+- When both are provided, **`isDisabled` takes precedence** over `disabled`.
+- This update ensures predictable, accessible behavior for the button component, and prevents accidental bypass of the disabled state.
 
 ### Why
 
-Previously, the `useButton` hook relied solely on the `isDisabled` prop for determining the button’s disabled state. While `disabled` was technically allowed via DOM props, it was **not** omitted or internally handled, leading to confusion:
+Previously, the `useButton` hook relied solely on the `isDisabled` prop for determining the button’s disabled state. While `disabled` (the native prop) was allowed via DOM spreading, it was **not** handled or normalized internally, leading to confusion:
 
 - Users could pass `disabled`, expecting it to work, but it would silently be ignored unless `isDisabled` was also set.
-- This behavior caused accessibility inconsistencies and incorrect UI state, especially when consuming the library in uncontrolled environments or when using native props.
+- This caused accessibility inconsistencies and incorrect UI behavior, especially in uncontrolled usage or in integrations with native props (e.g. forms).
+- It was unclear which prop had priority when both were present, leading to ambiguity.
 
-The lack of prioritization between `disabled` and `isDisabled` introduced ambiguity and edge cases where the button appeared enabled but did not respond to user interactions correctly.
+To address this, we aligned behavior with the internal API and clarified the precedence rules.
 
 ### How
 
-- The hook now explicitly checks both `disabled` and `isDisabled`, and **normalizes** them to a single internal `isDisabled` flag.
-- If both are present, `disabled` overrides `isDisabled`, ensuring compatibility with native expectations and avoiding unexpected UI behavior.
-- The final disabled state (`isActuallyDisabled`) is then used consistently throughout focus, hover, ripple, ARIA, and event logic.
-- The implementation maintains backward compatibility while improving robustness.
+- The hook now explicitly checks both `disabled` and `isDisabled`, and **normalizes** them to a single internal `isActuallyDisabled` flag.
+- If both are defined, `isDisabled` takes precedence — providing clearer control from within the design system and ensuring predictable behavior.
+- The normalized disabled state is now consistently used throughout all logic: focus, hover, ripple, ARIA attributes, and event handling.
 
 Also:
-- Import order in `use-button.ts` has been reverted to avoid conflicts with the ongoing ESLint formatting PR.
-- No runtime behavior has been removed — this is a safe, additive change that improves clarity and control.
+- Fixed import order in `use-button.ts` to match ESLint and style guide expectations.
+- Added tests to cover edge cases where `disabled` and `isDisabled` conflict — including the case where `isDisabled={false}` and `disabled={true}`, confirming that the button is interactive.
+- This is a non-breaking, additive update that improves clarity, robustness, and accessibility.

--- a/.changeset/moody-houses-double.md
+++ b/.changeset/moody-houses-double.md
@@ -1,0 +1,35 @@
+# Update: Handle disabled vs isDisabled in useButton
+
+---
+
+"@heroui/button": minor
+
+---
+
+### What
+
+Improved the internal handling of `disabled` and `isDisabled` props in `useButton` hook:
+
+- Now both `disabled` (native) and `isDisabled` (custom) props are supported in a controlled and consistent way.
+- When both are provided, `disabled` takes precedence over `isDisabled`.
+- This update ensures a predictable and accessible behavior for the button component, and prevents accidental bypass of the disabled state.
+
+### Why
+
+Previously, the `useButton` hook relied solely on the `isDisabled` prop for determining the button’s disabled state. While `disabled` was technically allowed via DOM props, it was **not** omitted or internally handled, leading to confusion:
+
+- Users could pass `disabled`, expecting it to work, but it would silently be ignored unless `isDisabled` was also set.
+- This behavior caused accessibility inconsistencies and incorrect UI state, especially when consuming the library in uncontrolled environments or when using native props.
+
+The lack of prioritization between `disabled` and `isDisabled` introduced ambiguity and edge cases where the button appeared enabled but did not respond to user interactions correctly.
+
+### How
+
+- The hook now explicitly checks both `disabled` and `isDisabled`, and **normalizes** them to a single internal `isDisabled` flag.
+- If both are present, `disabled` overrides `isDisabled`, ensuring compatibility with native expectations and avoiding unexpected UI behavior.
+- The final disabled state (`isActuallyDisabled`) is then used consistently throughout focus, hover, ripple, ARIA, and event logic.
+- The implementation maintains backward compatibility while improving robustness.
+
+Also:
+- Import order in `use-button.ts` has been reverted to avoid conflicts with the ongoing ESLint formatting PR.
+- No runtime behavior has been removed — this is a safe, additive change that improves clarity and control.

--- a/.changeset/moody-houses-double.md
+++ b/.changeset/moody-houses-double.md
@@ -1,36 +1,5 @@
-# Update: Handle disabled vs isDisabled in useButton
-
+---
+"@heroui/button": patch
 ---
 
-"@heroui/button": minor
-
----
-
-### What
-
-Improved the internal handling of `disabled` and `isDisabled` props in the `useButton` hook:
-
-- Now both `disabled` (native) and `isDisabled` (custom) props are supported in a controlled and consistent way.
-- When both are provided, **`isDisabled` takes precedence** over `disabled`.
-- This update ensures predictable, accessible behavior for the button component, and prevents accidental bypass of the disabled state.
-
-### Why
-
-Previously, the `useButton` hook relied solely on the `isDisabled` prop for determining the button’s disabled state. While `disabled` (the native prop) was allowed via DOM spreading, it was **not** handled or normalized internally, leading to confusion:
-
-- Users could pass `disabled`, expecting it to work, but it would silently be ignored unless `isDisabled` was also set.
-- This caused accessibility inconsistencies and incorrect UI behavior, especially in uncontrolled usage or in integrations with native props (e.g. forms).
-- It was unclear which prop had priority when both were present, leading to ambiguity.
-
-To address this, we aligned behavior with the internal API and clarified the precedence rules.
-
-### How
-
-- The hook now explicitly checks both `disabled` and `isDisabled`, and **normalizes** them to a single internal `isActuallyDisabled` flag.
-- If both are defined, `isDisabled` takes precedence — providing clearer control from within the design system and ensuring predictable behavior.
-- The normalized disabled state is now consistently used throughout all logic: focus, hover, ripple, ARIA attributes, and event handling.
-
-Also:
-- Fixed import order in `use-button.ts` to match ESLint and style guide expectations.
-- Added tests to cover edge cases where `disabled` and `isDisabled` conflict — including the case where `isDisabled={false}` and `disabled={true}`, confirming that the button is interactive.
-- This is a non-breaking, additive update that improves clarity, robustness, and accessibility.
+fix: clarify precedence of isDisabled over disabled prop in useButton hook for consistent behavior

--- a/packages/components/button/__tests__/button.test.tsx
+++ b/packages/components/button/__tests__/button.test.tsx
@@ -57,6 +57,28 @@ describe("Button", () => {
 
     expect(onPress).not.toHaveBeenCalled();
   });
+  it("should ignore events when only disabled prop is set", async () => {
+    const onPress = jest.fn();
+    const {getByRole} = render(<Button disableRipple disabled onPress={onPress} />);
+
+    const button = getByRole("button");
+
+    await user.click(button);
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+  it("should prioritize isDisabled over disabled (isDisabled=false, disabled=true)", async () => {
+    const onPress = jest.fn();
+    const {getByRole} = render(
+      <Button disableRipple disabled isDisabled={false} onPress={onPress} />,
+    );
+
+    const button = getByRole("button");
+
+    await user.click(button);
+
+    expect(onPress).toHaveBeenCalled();
+  });
 
   it("should renders with start icon", () => {
     const wrapper = render(

--- a/packages/components/button/__tests__/button.test.tsx
+++ b/packages/components/button/__tests__/button.test.tsx
@@ -57,6 +57,7 @@ describe("Button", () => {
 
     expect(onPress).not.toHaveBeenCalled();
   });
+
   it("should ignore events when only disabled prop is set", async () => {
     const onPress = jest.fn();
     const {getByRole} = render(<Button disableRipple disabled onPress={onPress} />);
@@ -67,6 +68,7 @@ describe("Button", () => {
 
     expect(onPress).not.toHaveBeenCalled();
   });
+
   it("should prioritize isDisabled over disabled (isDisabled=false, disabled=true)", async () => {
     const onPress = jest.fn();
     const {getByRole} = render(

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -1,26 +1,24 @@
+import type {RippleProps} from "@heroui/ripple";
+import type {HTMLHeroUIProps, PropGetter} from "@heroui/system";
 import type {ButtonVariantProps} from "@heroui/theme";
 import type {AriaButtonProps} from "@heroui/use-aria-button";
 import type {ReactNode} from "react";
-import type {RippleProps} from "@heroui/ripple";
-import type {HTMLHeroUIProps, PropGetter} from "@heroui/system";
 
-import {useProviderContext} from "@heroui/system";
-import {dataAttr} from "@heroui/shared-utils";
-import {ReactRef} from "@heroui/react-utils";
-import {MouseEventHandler, useCallback} from "react";
-import {useFocusRing} from "@react-aria/focus";
-import {chain, mergeProps} from "@react-aria/utils";
-import {useDOMRef, filterDOMProps} from "@heroui/react-utils";
-import {button} from "@heroui/theme";
-import {isValidElement, cloneElement, useMemo} from "react";
-import {useAriaButton} from "@heroui/use-aria-button";
-import {PressEvent, useHover} from "@react-aria/interactions";
-import {SpinnerProps} from "@heroui/spinner";
+import {filterDOMProps, ReactRef, useDOMRef} from "@heroui/react-utils";
 import {useRipple} from "@heroui/ripple";
+import {dataAttr} from "@heroui/shared-utils";
+import {SpinnerProps} from "@heroui/spinner";
+import {useProviderContext} from "@heroui/system";
+import {button} from "@heroui/theme";
+import {useAriaButton} from "@heroui/use-aria-button";
+import {useFocusRing} from "@react-aria/focus";
+import {PressEvent, useHover} from "@react-aria/interactions";
+import {chain, mergeProps} from "@react-aria/utils";
+import {cloneElement, isValidElement, MouseEventHandler, useCallback, useMemo} from "react";
 
 import {useButtonGroupContext} from "./button-group-context";
 
-interface Props extends HTMLHeroUIProps<"button"> {
+interface Props extends Omit<HTMLHeroUIProps<"button">, "disabled"> {
   /**
    * Ref to the DOM node.
    */


### PR DESCRIPTION
Omit the `disabled` prop from the Button component to prevent it from being passed directly by consumers.

This change allows the Button component's internal logic to explicitly control the disabled state,
avoiding potential conflicts or misuse that could arise from external control of the `disabled` prop.

There are no changes to the external API or visual behavior of the component.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that add new external dependencies might take longer to review.
- Keep your PR as focused and small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix).
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR refactors the Button component by omitting the `disabled` prop from its public props,
ensuring that the disabled state is managed internally to maintain consistency and prevent misuse.

## ⛳️ Current behavior (updates)

Consumers can directly pass the `disabled` prop to the Button component, which may cause conflicts.

## 🚀 New behavior

The `disabled` prop is omitted from the component's public interface,
and the disabled state is controlled exclusively by the component’s internal logic.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced button disabled state handling to unify native and custom props for consistent behavior and accessibility, including loading state consideration.

- **Tests**
  - Added tests verifying disabled state precedence and event handling for buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->