### PR TITLE
fix(docs): text color in 404 page

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -75,7 +75,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
       <head />
       <body
         className={clsx(
-          "min-h-screen bg-background font-sans antialiased",
+          "min-h-screen text-foreground bg-background font-sans antialiased",
           fonts.sans.variable,
           fonts.mono.variable,
         )}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5302 <!-- Github issue # here -->

## 📝 Description

Added text-foreground in the layout.tsx


## ⛳️ Current behavior (updates)

404 error had background text color in light mode

## 🚀 New behavior

![image](https://github.com/user-attachments/assets/11868360-0962-4ed9-bd11-aa42ccfe4ea2)

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information

This behavour is seen in many websites which uses next-themes. In next-themes the 404 error had background text color in light mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated text color styling for improved readability across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->