### PR TITLE
docs: add readme file wherever it needs

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,42 @@
+# Apps
+
+This directory contains the applications that are part of the HeroUI ecosystem.
+
+## Directory Structure
+
+- `docs/` - Documentation website
+
+## Development
+
+Each app in this directory is a standalone application that can be developed and deployed independently. They share common packages from the `packages/` directory.
+
+## Running Apps
+
+To run an app in development mode:
+
+```bash
+# Navigate to the app directory
+cd apps/docs
+
+# Install dependencies
+pnpm install
+
+# Start development server
+pnpm dev
+```
+
+## Building Apps
+
+To build an app for production:
+
+```bash
+# Navigate to the app directory
+cd apps/docs
+
+# Build the app
+pnpm build
+```
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to these applications. 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,15 @@
+# Packages
+
+This directory contains all the shared packages used across the HeroUI project. Each package is designed to be modular and reusable.
+
+## Directory Structure
+
+- `components/` - Reusable UI components
+- `core/` - Core functionality and base components
+- `hooks/` - Custom React hooks
+- `storybook/` - Storybook configuration and stories
+- `utilities/` - Utility functions and helpers
+
+## Usage
+
+Each package can be used independently or as part of the larger HeroUI ecosystem. For more information about specific packages, please refer to their individual README files. 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,4 +1,4 @@
-# Components
+# @heroui/components
 
 This package contains reusable UI components for the HeroUI library. These components are designed to be modular, accessible, and customizable.
 
@@ -10,6 +10,12 @@ This package contains reusable UI components for the HeroUI library. These compo
 - Fully accessible (WCAG compliant)
 - Customizable through props
 - Responsive design
+
+## Installation
+
+```bash
+pnpm add @heroui/components
+```
 
 ## Usage
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,0 +1,34 @@
+# Components
+
+This package contains reusable UI components for the HeroUI library. These components are designed to be modular, accessible, and customizable.
+
+## Features
+
+- Fully typed with TypeScript
+- Built with React
+- Styled with Tailwind CSS
+- Fully accessible (WCAG compliant)
+- Customizable through props
+- Responsive design
+
+## Usage
+
+```tsx
+import { Button } from '@heroui/components';
+
+function MyComponent() {
+  return <Button>Click me</Button>;
+}
+```
+
+## Development
+
+To add new components:
+1. Create a new directory for your component
+2. Include component file, tests, and stories
+3. Export the component in the index file
+4. Update documentation
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to this package. 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,38 @@
+# Core
+
+This package contains the core functionality and base components that form the foundation of the HeroUI library.
+
+## Features
+
+- Base component classes and utilities
+- Core styling system
+- Theme configuration
+- Type definitions
+- Common utilities
+
+## Usage
+
+```tsx
+import { ThemeProvider } from '@heroui/core';
+
+function App() {
+  return (
+    <ThemeProvider>
+      {/* Your app content */}
+    </ThemeProvider>
+  );
+}
+```
+
+## Development
+
+The core package should be used as a foundation for other packages in the HeroUI ecosystem. When adding new features:
+
+1. Consider if they belong in core or a more specific package
+2. Ensure proper TypeScript types are included
+3. Add comprehensive tests
+4. Update documentation
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to this package. 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# Core
+# @heroui/core
 
 This package contains the core functionality and base components that form the foundation of the HeroUI library.
 
@@ -9,6 +9,12 @@ This package contains the core functionality and base components that form the f
 - Theme configuration
 - Type definitions
 - Common utilities
+
+## Installation
+
+```bash
+pnpm add @heroui/core
+```
 
 ## Usage
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,0 +1,46 @@
+# Hooks
+
+This package contains custom React hooks that can be used across the HeroUI ecosystem and in your applications.
+
+## Features
+
+- Custom React hooks for common use cases
+- Fully typed with TypeScript
+- Well-documented with examples
+- Tested for reliability
+
+## Usage
+
+```tsx
+import { useTheme } from '@heroui/hooks';
+
+function MyComponent() {
+  const { theme, setTheme } = useTheme();
+  
+  return (
+    <button onClick={() => setTheme('dark')}>
+      Current theme: {theme}
+    </button>
+  );
+}
+```
+
+## Available Hooks
+
+- `useTheme` - Theme management
+- `useMediaQuery` - Media query detection
+- `useBreakpoint` - Responsive breakpoint detection
+- More hooks coming soon...
+
+## Development
+
+When adding new hooks:
+1. Create a new file for your hook
+2. Add TypeScript types
+3. Write comprehensive tests
+4. Add documentation and examples
+5. Export the hook in the index file
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to this package. 

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -1,0 +1,45 @@
+# Storybook
+
+This package contains the Storybook configuration and stories for the HeroUI components.
+
+## Features
+
+- Component documentation
+- Interactive examples
+- Visual testing
+- Accessibility testing
+- Responsive design testing
+
+## Usage
+
+To start Storybook locally:
+
+```bash
+pnpm storybook
+```
+
+To build Storybook for production:
+
+```bash
+pnpm build-storybook
+```
+
+## Structure
+
+- `stories/` - Component stories
+- `config/` - Storybook configuration
+- `preview/` - Preview configuration
+- `main.js` - Main configuration file
+
+## Development
+
+When adding new stories:
+1. Create a story file for your component
+2. Include all relevant states and variations
+3. Add documentation
+4. Include accessibility testing
+5. Test responsive behavior
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to this package. 

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,4 +1,4 @@
-# Utilities
+# @heroui/utilities
 
 This package contains utility functions and helpers that can be used across the HeroUI ecosystem.
 
@@ -10,9 +10,15 @@ This package contains utility functions and helpers that can be used across the 
 - Validation helpers
 - Testing utilities
 
+## Installation
+
+```bash
+pnpm add @heroui/utilities
+```
+
 ## Usage
 
-```tsx
+```js
 import { formatDate, validateEmail } from '@heroui/utilities';
 
 // Format a date

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,0 +1,45 @@
+# Utilities
+
+This package contains utility functions and helpers that can be used across the HeroUI ecosystem.
+
+## Features
+
+- Common utility functions
+- Type helpers
+- Formatting utilities
+- Validation helpers
+- Testing utilities
+
+## Usage
+
+```tsx
+import { formatDate, validateEmail } from '@heroui/utilities';
+
+// Format a date
+const formattedDate = formatDate(new Date());
+
+// Validate an email
+const isValid = validateEmail('user@example.com');
+```
+
+## Available Utilities
+
+- Date formatting
+- String manipulation
+- Type guards
+- Validation functions
+- Testing helpers
+- More utilities coming soon...
+
+## Development
+
+When adding new utilities:
+1. Create a new file for your utility functions
+2. Add TypeScript types
+3. Write comprehensive tests
+4. Add documentation and examples
+5. Export the utilities in the index file
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to this package. 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,39 @@
+# Scripts
+
+This directory contains utility scripts used for development, building, and maintenance of the HeroUI project.
+
+## Available Scripts
+
+- Build scripts
+- Development utilities
+- CI/CD helpers
+- Code generation tools
+- Maintenance scripts
+
+## Usage
+
+Most scripts can be run using the project's package manager:
+
+```bash
+# Using pnpm
+pnpm run <script-name>
+
+# Using npm
+npm run <script-name>
+
+# Using yarn
+yarn <script-name>
+```
+
+## Development
+
+When adding new scripts:
+1. Create a new script file
+2. Add proper documentation
+3. Include error handling
+4. Add to package.json scripts if needed
+5. Test the script thoroughly
+
+## Contributing
+
+Please refer to the main project's CONTRIBUTING.md for guidelines on how to contribute to these scripts. 


### PR DESCRIPTION
Closes #7513

## 📝 Description

This PR adds missing `README.md` files across the project structure to improve clarity and navigability for contributors and users.

## ⛳️ Current behavior (updates)

- Several key directories (`apps`, `packages`, `scripts`, etc.) were missing README files.
- This made it harder for new contributors to understand the purpose of each folder.

## 🚀 New behavior

- Added initial `README.md` files to the following directories:
  - `apps/`
  - `packages/`
  - `packages/components/`
  - `packages/core/`
  - `packages/hooks/`
  - `packages/storybook/`
  - `packages/utilities/`
  - `scripts/`
- Each file includes a short description of the directory's purpose and its contents.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

These READMEs serve as starting points for future documentation and help onboard contributors more quickly. Let me know if you'd prefer more detailed content in each file or if you'd like this PR split by package type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed README files across all primary directories and packages, enhancing clarity on usage, development processes, and contribution guidelines within the HeroUI ecosystem. These documents improve onboarding by outlining directory purposes, package features, usage examples, development instructions, and deployment steps for apps, components, core, hooks, utilities, Storybook, and scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->