### PR TITLE
fix(tooltip): fix tooltip delay

### DIFF
--- a/.changeset/wild-pillow-live.md
+++ b/.changeset/wild-pillow-live.md
@@ -1,0 +1,5 @@
+---
+"@heroui/tooltip": patch
+---
+
+Fixed tooltip delay (#5341)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5341 <!-- Github issue # here -->

## 📝 Description

Tootip delay doesn't respond when hovering from one tooltip to another

## 🚀 New behavior

https://github.com/user-attachments/assets/87539ccc-ce46-42dd-948d-937a656b155c

The react-stately is bypassed and a custom delay is added to make the expected functionality

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tooltip delay behavior to ensure more accurate and consistent timing when opening and closing tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->