### PR TITLE
fix(autocomplete): onClear

### DIFF
--- a/.changeset/real-apes-invite.md
+++ b/.changeset/real-apes-invite.md
@@ -1,0 +1,5 @@
+---
+"@heroui/autocomplete": patch
+---
+
+support onClear in Autocomplete (#5297)

--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -811,6 +811,12 @@ properties to customize the popover, listbox and input components.
       type: "() => void",
       description: "Handler that is called when the Autocomplete's Popover is closed.",
       default: "-"
+    },
+    {
+      attribute: "onClear",
+      type: "() => void",
+      description: "Handler that is called when the clear button is clicked.",
+      default: "-"
     }
   ]}
 />

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -171,9 +171,16 @@ describe("Autocomplete", () => {
     expect(autocomplete).toHaveFocus();
   });
 
-  it("should clear value after clicking clear button", async () => {
+  it("should clear the value and onClear is triggered", async () => {
+    const onClear = jest.fn();
+
     const wrapper = render(
-      <Autocomplete aria-label="Favorite Animal" data-testid="autocomplete" label="Favorite Animal">
+      <Autocomplete
+        aria-label="Favorite Animal"
+        data-testid="autocomplete"
+        label="Favorite Animal"
+        onClear={onClear}
+      >
         <AutocompleteItem key="penguin">Penguin</AutocompleteItem>
         <AutocompleteItem key="zebra">Zebra</AutocompleteItem>
         <AutocompleteItem key="shark">Shark</AutocompleteItem>
@@ -203,6 +210,9 @@ describe("Autocomplete", () => {
 
     // click the clear button
     await user.click(clearButton);
+
+    // onClear is triggered
+    expect(onClear).toHaveBeenCalledTimes(1);
 
     // assert that the input has empty value
     expect(autocomplete).toHaveValue("");

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -112,6 +112,11 @@ interface Props<T> extends Omit<HTMLHeroUIProps<"input">, keyof ComboBoxProps<T>
    */
   onClose?: () => void;
   /**
+   * Callback fired when the value is cleared.
+   * if you pass this prop, the clear button will be shown.
+   */
+  onClear?: () => void;
+  /**
    * Whether to enable virtualization of the listbox items.
    * By default, virtualization is automatically enabled when the number of items is greater than 50.
    * @default undefined
@@ -186,6 +191,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     errorMessage,
     onOpenChange,
     onClose,
+    onClear,
     isReadOnly = false,
     ...otherProps
   } = props;
@@ -453,6 +459,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
         }
         state.setInputValue("");
         state.open();
+        onClear?.();
       },
       "data-visible": !!state.selectedItem || state.inputValue?.length > 0,
       className: slots.clearButton({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5297

## 📝 Description

<!--- Add a brief description -->

Currently if users pass `onClear` to `Autocomplete`, it will pass along to `Input` causing `<button> cannot be a descendant of <button>` issue. Hence, this PR is to add onClear in Autocomplete so that it won't reference in Input.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an `onClear` event handler in the Autocomplete component, allowing actions to be triggered when the clear button is clicked.

- **Documentation**
  - Updated Autocomplete component documentation to include the new `onClear` event handler.

- **Tests**
  - Enhanced tests to verify that the `onClear` callback is triggered when the clear button is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->