### PR TITLE
fix(number-input): only allow number type

### DIFF
--- a/.changeset/stupid-shrimps-divide.md
+++ b/.changeset/stupid-shrimps-divide.md
@@ -1,0 +1,5 @@
+---
+"@heroui/number-input": patch
+---
+
+avoid non number type passing to NumberInput

--- a/packages/components/number-input/src/number-input.tsx
+++ b/packages/components/number-input/src/number-input.tsx
@@ -5,7 +5,9 @@ import {forwardRef} from "@heroui/system";
 import {UseNumberInputProps, useNumberInput} from "./use-number-input";
 import NumberInputStepper from "./number-input-stepper";
 
-export interface NumberInputProps extends UseNumberInputProps {}
+export interface NumberInputProps extends Omit<UseNumberInputProps, "type"> {
+  type?: "number";
+}
 
 const NumberInput = forwardRef<"input", NumberInputProps>((props, ref) => {
   const {

--- a/packages/components/number-input/src/use-number-input.ts
+++ b/packages/components/number-input/src/use-number-input.ts
@@ -99,6 +99,7 @@ export function useNumberInput(originalProps: UseNumberInputProps) {
   const {
     ref,
     as,
+    type,
     label,
     baseRef,
     wrapperRef,
@@ -539,6 +540,7 @@ export function useNumberInput(originalProps: UseNumberInputProps) {
   return {
     Component,
     classNames,
+    type,
     domRef,
     label,
     description,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Currently `NumberInput` accepts all html input type.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

if you pass `type=file`, it becomes 

![image](https://github.com/user-attachments/assets/1d264ed2-e25b-4f27-b1d2-6347ae995bc1)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![image](https://github.com/user-attachments/assets/360412ac-b757-4ead-a340-cee1243ff9c1)

and it should throw a type error

<img width="533" alt="image" src="https://github.com/user-attachments/assets/160f45fd-a7ea-4753-9492-a681b6359c5e" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the NumberInput component to prevent non-numeric types from being passed, ensuring only valid numeric input types are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->