### PR TITLE
fix(toast): Toast items close in reverse order

### DIFF
--- a/.changeset/perfect-turtles-eat.md
+++ b/.changeset/perfect-turtles-eat.md
@@ -2,4 +2,4 @@
 "@heroui/toast": patch
 ---
 
-Fix toast items closing in reverse order. Toasts now close in proper FIFO instead of LIFO (#5405)
+Fix toast items closing in reverse order. Toasts now close in proper FIFO instead of LIFO (#5096)

--- a/.changeset/perfect-turtles-eat.md
+++ b/.changeset/perfect-turtles-eat.md
@@ -1,0 +1,5 @@
+---
+"@heroui/toast": patch
+---
+
+Fix toast items closing in reverse order. Toasts now close in proper FIFO instead of LIFO (#5405)

--- a/packages/components/toast/src/use-toast.ts
+++ b/packages/components/toast/src/use-toast.ts
@@ -220,7 +220,7 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
         startTime.current = timestamp;
       }
 
-      if (isToastHovered || isRegionExpanded || index != 0) {
+      if (isToastHovered || isRegionExpanded || index !== 0) {
         pausedTime.current += timestamp - startTime.current;
         startTime.current = null;
         animationRef.current = requestAnimationFrame(updateProgress);

--- a/packages/components/toast/src/use-toast.ts
+++ b/packages/components/toast/src/use-toast.ts
@@ -202,6 +202,7 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
   }, []);
 
   const [isLoading, setIsLoading] = useState<boolean>(!!promiseProp);
+  const [isToastExiting, setIsToastExiting] = useState(false);
 
   useEffect(() => {
     if (!promiseProp) return;
@@ -220,7 +221,7 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
         startTime.current = timestamp;
       }
 
-      if (isToastHovered || isRegionExpanded || index !== 0) {
+      if (isToastHovered || isRegionExpanded) {
         pausedTime.current += timestamp - startTime.current;
         startTime.current = null;
         animationRef.current = requestAnimationFrame(updateProgress);
@@ -232,7 +233,7 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
 
       timeElapsed.current = elapsed;
       if (timeElapsed.current >= timeout) {
-        state.close(toast.key);
+        setIsToastExiting(true);
       }
 
       progressRef.current = Math.min((elapsed / timeout) * 100, 100);
@@ -264,6 +265,7 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
     total,
     isRegionExpanded,
     isLoading,
+    setIsToastExiting,
   ]);
 
   const Component = as || "div";
@@ -283,7 +285,6 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
   }, []);
 
   const [initialHeight, setInitialHeight] = useState<number>(0);
-  const [isToastExiting, setIsToastExiting] = useState(false);
 
   // Following was inspired from sonner ❤️
   useLayoutEffect(() => {

--- a/packages/components/toast/src/use-toast.ts
+++ b/packages/components/toast/src/use-toast.ts
@@ -220,7 +220,7 @@ export function useToast<T extends ToastProps>(originalProps: UseToastProps<T>) 
         startTime.current = timestamp;
       }
 
-      if (isToastHovered || isRegionExpanded || index != total - 1) {
+      if (isToastHovered || isRegionExpanded || index != 0) {
         pausedTime.current += timestamp - startTime.current;
         startTime.current = null;
         animationRef.current = requestAnimationFrame(updateProgress);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5096 

## 📝 Description

Fixes the bug where toast items were closing in reverse order (LIFO instead of FIFO). The issue was in the timeout progression logic that was allowing only the oldest toast to progress its timeout, causing it to close first.

## ⛳️ Current behavior (updates)

- Toast items close in LIFO order (Last In First Out)
- The oldest toast (first added) closes first
- This behavior is counterintuitive to users who expect newer toasts to disappear first

## 🚀 New behavior

- Toast items now close in proper FIFO order (First In First Out) 
- The newest toast (most recently added) closes first
- Behavior now aligns with user expectations and common UX patterns
- Maintains all existing visual styling, animations, and other functionality

## 💣 Is this a breaking change (Yes/No):

**No** - This is a bug fix that corrects the intended behavior. While it changes the closing order, it fixes the behavior to match user expectations and the natural UX pattern. All existing APIs, props, and functionality remain unchanged.

## 📝 Additional Information

- **Testing:** All existing tests pass ✅
- **Compatibility:** No API changes, fully backward compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed toast notifications to close in the order they appear (FIFO), ensuring older toasts dismiss before newer ones.
	- Improved toast timeout progress behavior for better consistency when multiple toasts are displayed.
	- Enhanced toast exit animations for smoother transitions when closing via timeout or close button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->