### PR TITLE
fix: double fetch img src

### DIFF
--- a/.changeset/sharp-gifts-invite.md
+++ b/.changeset/sharp-gifts-invite.md
@@ -1,0 +1,6 @@
+---
+"@heroui/image": patch
+"@heroui/use-image": patch
+---
+
+fixed image src double fetch issue (#3847)

--- a/.changeset/sharp-gifts-invite.md
+++ b/.changeset/sharp-gifts-invite.md
@@ -1,4 +1,5 @@
 ---
+"@heroui/avatar": patch
 "@heroui/image": patch
 "@heroui/use-image": patch
 ---

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -137,11 +137,21 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
   const {isHovered, hoverProps} = useHover({isDisabled});
   const disableAnimation = disableAnimationProp ?? globalContext?.disableAnimation ?? false;
 
-  const imageStatus = useImage({src, onError, ignoreFallback});
+  const isHeroImage =
+    (typeof ImgComponent === "object" && (ImgComponent as any)?.displayName?.includes("HeroUI")) ??
+    false;
+
+  const imageStatus = useImage({
+    src,
+    onError,
+    ignoreFallback,
+    shouldBypassImageLoad: as !== undefined || !isHeroImage,
+  });
 
   const isImgLoaded = imageStatus === "loaded";
 
-  const shouldFilterDOMProps = typeof ImgComponent === "string";
+  // if the ImgComponent is not a HeroUI component, we need to filter out `disableAnimation`
+  const shouldFilterDOMProps = !isHeroImage;
 
   /**
    * Fallback avatar applies under 2 conditions:

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -105,6 +105,7 @@ export function useImage(originalProps: UseImageProps) {
     srcSet,
     sizes,
     crossOrigin,
+    shouldBypassImageLoad: as !== undefined,
   });
 
   const disableAnimation =

--- a/packages/hooks/use-image/src/index.ts
+++ b/packages/hooks/use-image/src/index.ts
@@ -40,7 +40,14 @@ export interface UseImageProps {
    * This tells the browser to request cross-origin access when trying to download the image data.
    */
   crossOrigin?: NativeImageProps["crossOrigin"];
+  /**
+   * Defines the `loading` attribute for the image
+   */
   loading?: NativeImageProps["loading"];
+  /**
+   * If `true`, image load will be bypassed and the load will be handled by `as` component.
+   */
+  shouldBypassImageLoad?: boolean;
 }
 
 type Status = "loading" | "failed" | "pending" | "loaded";
@@ -66,7 +73,17 @@ type ImageEvent = SyntheticEvent<HTMLImageElement, Event>;
  */
 
 export function useImage(props: UseImageProps = {}) {
-  const {onLoad, onError, ignoreFallback, src, crossOrigin, srcSet, sizes, loading} = props;
+  const {
+    onLoad,
+    onError,
+    ignoreFallback,
+    src,
+    crossOrigin,
+    srcSet,
+    sizes,
+    loading,
+    shouldBypassImageLoad = false,
+  } = props;
 
   const isHydrated = useIsHydrated();
 
@@ -98,7 +115,7 @@ export function useImage(props: UseImageProps = {}) {
 
   const load = useCallback((): Status => {
     if (!src) return "pending";
-    if (ignoreFallback) return "loaded";
+    if (ignoreFallback || shouldBypassImageLoad) return "loaded";
 
     const img = new Image();
 
@@ -114,7 +131,7 @@ export function useImage(props: UseImageProps = {}) {
     }
 
     return "loading";
-  }, [src, crossOrigin, srcSet, sizes, onLoad, onError, loading]);
+  }, [src, crossOrigin, srcSet, sizes, onLoad, onError, loading, shouldBypassImageLoad]);
 
   useSafeLayoutEffect(() => {
     if (isHydrated) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3847

## 📝 Description

- `use-image` will load the image. If users use custom component, it will load twice. 
- This PR is to check if custom component is in use, then bypass the internal load
- Also fixes `disableAnimation` passing to Avatar if using non HeroUI component

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![image](https://github.com/user-attachments/assets/1d81a571-d6e3-49dd-b639-80d9a75478c6)

![image](https://github.com/user-attachments/assets/4890bcde-13c1-4358-817c-4976bd666b68)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
