### PR TITLE
docs: replace invalid yarn command

### DIFF
--- a/apps/docs/content/docs/guide/tailwind-v4.mdx
+++ b/apps/docs/content/docs/guide/tailwind-v4.mdx
@@ -23,7 +23,7 @@ TailwindCSS v4 is now available in Beta! This guide will help you migrate your e
     cli: "npx heroui-cli@latest upgrade --all --beta",
     pnpm: "pnpm install @heroui/react@beta",
     npm: "npm install @heroui/react@beta",
-    yarn: "yarn install @heroui/react@beta",
+    yarn: "yarn add @heroui/react@beta",
     bun: "bun install @heroui/react@beta"
   }}
 />
@@ -34,7 +34,7 @@ TailwindCSS v4 is now available in Beta! This guide will help you migrate your e
 
 #### Without `tailwind.config.js`
 
-Since Tailwind v4 favors a CSS-first approach, `tailwind.config.js` will not be required. 
+Since Tailwind v4 favors a CSS-first approach, `tailwind.config.js` will not be required.
 
 Create `hero.ts` file
 


### PR DESCRIPTION
## 📝 Description

Replaces an incorrect `yarn install` command with the correct `yarn add` command for installing `@heroui/react@beta` in the Tailwind v4 section of the documentation.

## ⛳️ Current behavior (updates)
The docs suggest running: 
```
yarn install @heroui/react@beta
```
This is invalid syntax, `yarn install` does not accept a package name.

## 🚀 New behavior
The command is now: 
```
yarn add @heroui/react@beta
```

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
This change only affects documentation.
The error was found while following the Tailwind v4 integration guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Yarn installation command for the `@heroui/react@beta` package.
  * Improved formatting by removing an unnecessary trailing space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->