### PR TITLE
fix(table): remove removeWrapper on virtualized table

### DIFF
--- a/.changeset/nine-carrots-pay.md
+++ b/.changeset/nine-carrots-pay.md
@@ -1,0 +1,5 @@
+---
+"@heroui/table": patch
+---
+
+remove `removeWrapper` from virtualized table (#4995)

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -127,6 +127,7 @@ In case you don't want to render the header, you can use the `hideHeader` prop.
 
 By default the table is wrapped in a `div` element with a small shadow effect and a border radius.
 You can use the `removeWrapper` prop to remove the wrapper and only render the table.
+However, the `removeWrapper` prop has no effect on a virtualized table, as the wrapper is required to manage its height.
 
 <CodeDemo title="Without Wrapper" files={tableContent.withoutWrapper} />
 
@@ -538,7 +539,7 @@ You can customize the `Table` component by passing custom Tailwind CSS classes t
     {
       attribute: "removeWrapper",
       type: "boolean",
-      description: "Whether the table base container should not be rendered.",
+      description: "Whether the base container should not be rendered for a non-virtualized table.",
       default: "false"
     },
     {

--- a/packages/components/table/src/virtualized-table.tsx
+++ b/packages/components/table/src/virtualized-table.tsx
@@ -29,7 +29,6 @@ const VirtualizedTable = forwardRef<"table", TableProps>((props, ref) => {
     topContentPlacement,
     bottomContentPlacement,
     bottomContent,
-    removeWrapper,
     getBaseProps,
     getWrapperProps,
     getTableProps,
@@ -42,10 +41,6 @@ const VirtualizedTable = forwardRef<"table", TableProps>((props, ref) => {
 
   const Wrapper = useCallback(
     ({children}: {children: JSX.Element}) => {
-      if (removeWrapper) {
-        return children;
-      }
-
       return (
         <BaseComponent
           {...getWrapperProps()}
@@ -57,7 +52,7 @@ const VirtualizedTable = forwardRef<"table", TableProps>((props, ref) => {
         </BaseComponent>
       );
     },
-    [removeWrapper, getWrapperProps, maxTableHeight],
+    [getWrapperProps, maxTableHeight],
   );
 
   const items = [...collection.body.childNodes];


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4995

## 📝 Description

<!--- Add a brief description -->

Currently if users use `removeWrapper` on a virtualized table, the table content won't be shown since the height is not determined. In this case, the wrapper is required. This PR is to remove the `removeWrapper` rendering logic for virtualized table and update the docs.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
