### PR TITLE
fix(checkbox): pass form id to input tag

### DIFF
--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -87,6 +87,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     children,
     icon,
     name,
+    form,
     isRequired,
     isReadOnly: isReadOnlyProp = false,
     autoFocus = false,
@@ -151,6 +152,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const ariaCheckboxProps = useMemo(
     () => ({
       name,
+      form,
       value,
       children,
       autoFocus,
@@ -167,6 +169,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     }),
     [
       name,
+      form,
       value,
       children,
       autoFocus,
@@ -313,6 +316,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       ...mergeProps(inputProps, focusProps),
       className: slots.hiddenInput({class: classNames?.hiddenInput}),
       onChange: chain(inputProps.onChange, handleCheckboxChange),
+      form: form,
     };
   }, [inputProps, focusProps, handleCheckboxChange, classNames?.hiddenInput]);
 

--- a/packages/components/checkbox/stories/checkbox.stories.tsx
+++ b/packages/components/checkbox/stories/checkbox.stories.tsx
@@ -210,6 +210,56 @@ const WithFormTemplate = (args: CheckboxProps) => {
   );
 };
 
+const SeparateFromFormTemplate = (args: CheckboxProps) => {
+  const [submitted, setSubmitted] = React.useState<{[key: string]: FormDataEntryValue} | null>(
+    null,
+  );
+  const [result, setResult] = React.useState<string | undefined>(undefined);
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+
+    if (data.terms == "true") {
+      setResult("Submitted value: true");
+    } else {
+      setResult("Checkbox is not checked");
+    }
+
+    setSubmitted(data);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Checkbox
+        isRequired
+        classNames={{
+          label: "text-small",
+        }}
+        form="heroui-form"
+        name="terms"
+        validationBehavior="aria"
+        value="true"
+        onValueChange={() => setResult(undefined)}
+        {...args}
+      >
+        This checkbox might be anywhere
+      </Checkbox>
+      <Form id="heroui-form" onSubmit={onSubmit}>
+        {result && <span className="text-small">{result}</span>}
+        <button className={button({class: "w-fit"})} type="submit">
+          Submit
+        </button>
+        {submitted && (
+          <div className="text-small text-default-500 mt-4">
+            Submitted data: <pre>{JSON.stringify(submitted, null, 2)}</pre>
+          </div>
+        )}
+      </Form>
+    </div>
+  );
+};
+
 export const Default = {
   args: {
     ...defaultProps,
@@ -308,6 +358,14 @@ export const Required = {
 
 export const WithForm = {
   render: WithFormTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const SeparateFromForm = {
+  render: SeparateFromFormTemplate,
 
   args: {
     ...defaultProps,


### PR DESCRIPTION
Closes [#5439](https://github.com/heroui-inc/heroui/issues/5439)

## 📝 Description

In HTML it is possible to add form id to inputs that are not children of this form and they are being picked up for this form. 

```html
<Checkbox form="test-form" />
<Form id="test-form"/>
```

## ⛳️ Current behavior (updates)

Adding form currently works for HeroUI Input component, but not for Checkbox. For Checkbox form parameter is being added to label tag, which will not make it work.

```html
<label form="test-form">
    <input type="checkbox" value="" />
</label>
```

## 🚀 New behavior

Form parameter is being passed to input tag, making it possible to use checkboxes outside of form.

```html
<label>
    <input form="test-form" type="checkbox" value="" />
</label>
```

## 💣 Is this a breaking change (Yes/No):

No.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkboxes can now be associated with specific forms using a new property, allowing them to function correctly even when visually separated from the form element.
  * Added a new example demonstrating how to link a checkbox to a form when they are not nested together.

* **Documentation**
  * Updated storybook examples to showcase the new checkbox association feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->