### PR TITLE
fix(modal): draggable modal, scrollable on mobile

### DIFF
--- a/.changeset/clean-bulldogs-visit.md
+++ b/.changeset/clean-bulldogs-visit.md
@@ -1,0 +1,5 @@
+---
+"@heroui/use-draggable": patch
+---
+
+Draggable modal will be scrollable in mobile devices (#5280)

--- a/packages/hooks/use-draggable/src/index.ts
+++ b/packages/hooks/use-draggable/src/index.ts
@@ -28,9 +28,11 @@ export interface UseDraggableProps {
 export function useDraggable(props: UseDraggableProps): MoveResult {
   const {targetRef, isDisabled = false, canOverflow = false} = props;
   const boundary = useRef({minLeft: 0, minTop: 0, maxLeft: 0, maxTop: 0});
+  const isDragging = useRef(false);
   let transform = {offsetX: 0, offsetY: 0};
 
   const onMoveStart = useCallback(() => {
+    isDragging.current = true;
     const {offsetX, offsetY} = transform;
 
     const targetRect = targetRef?.current?.getBoundingClientRect();
@@ -82,27 +84,35 @@ export function useDraggable(props: UseDraggableProps): MoveResult {
     [isDisabled, transform, boundary.current, canOverflow, targetRef?.current],
   );
 
+  const onMoveEnd = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
   const {moveProps} = useMove({
     onMoveStart,
     onMove,
+    onMoveEnd,
   });
 
   const preventDefault = useCallback((e: TouchEvent) => {
-    e.preventDefault();
+    // Only prevent touchmove events if we're actively dragging
+    if (isDragging.current) {
+      e.preventDefault();
+    }
   }, []);
 
   // NOTE: This process is due to the modal being displayed at the bottom instead of the center when opened on mobile sizes.
   // It will become unnecessary once the modal is centered properly.
   useEffect(() => {
     if (!isDisabled) {
-      // Prevent body scroll when dragging at mobile.
+      // Prevent body scroll when dragging at mobile, but only during active dragging.
       document.body.addEventListener("touchmove", preventDefault, {passive: false});
     }
 
     return () => {
       document.body.removeEventListener("touchmove", preventDefault);
     };
-  }, [isDisabled]);
+  }, [isDisabled, preventDefault]);
 
   return {
     moveProps: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5280  <!-- Github issue # here -->

## 📝 Description

Previously the draggable modal was not scrollable on mobile

## 🚀 New behavior

Now the draggable modal is scrollable on mobile screens 


https://github.com/user-attachments/assets/f90a6757-c1f0-4e8f-9dbe-d29add3397b7


## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the draggable modal to allow scrolling on mobile devices. Scrolling is now only prevented during active dragging, enhancing usability on touch screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->