### PR TITLE
fix(table): allow text selection with cursor in table cells

### DIFF
--- a/packages/core/theme/src/components/table.ts
+++ b/packages/core/theme/src/components/table.ts
@@ -88,6 +88,7 @@ const table = tv({
       "[&>*]:relative",
       ...dataFocusVisibleClasses,
       // before content for selection
+      "before:pointer-events-none",
       "before:content-['']",
       "before:absolute",
       "before:z-0",


### PR DESCRIPTION
Closes #5413

## 📝 Description

Can select text with cursor like a normal person in Table

## ⛳️ Current behavior (updates)

Text selection inside `<td>` elements was unintuitive or broken due to a full-cell `::before` pseudo-element intercepting mouse events.

## 🚀 New behavior


Users can now select text within table cells normally, including selecting from right to left. The `::before` element no longer interferes with cursor interaction.

## 💣 Is this a breaking change (Yes/No):

No
