### PR TITLE
fix(date-range-picker): fix manual date selection in presets example

### DIFF
--- a/apps/docs/content/components/date-range-picker/presets.raw.jsx
+++ b/apps/docs/content/components/date-range-picker/presets.raw.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {DateRangePicker, Radio, RadioGroup, Button, ButtonGroup, cn} from "@heroui/react";
 import {
   today,
@@ -15,6 +16,7 @@ export default function App() {
     end: today(getLocalTimeZone()).add({days: 7}),
   };
   let [value, setValue] = React.useState(defaultDate);
+  let [focusedValue, setFocusedValue] = React.useState(defaultDate.start);
 
   let {locale} = useLocale();
   let formatter = useDateFormatter({dateStyle: "full"});
@@ -81,20 +83,39 @@ export default function App() {
             variant="bordered"
           >
             <Button
-              onPress={() =>
-                setValue({
+              onPress={() => {
+                const thisWeek = {
                   start: now,
                   end: now.add({days: 7}),
-                })
-              }
+                };
+
+                setValue(thisWeek);
+                setFocusedValue(thisWeek.start);
+              }}
             >
               This week
             </Button>
-            <Button onPress={() => setValue(nextWeek)}>Next week</Button>
-            <Button onPress={() => setValue(nextMonth)}>Next month</Button>
+            <Button
+              onPress={() => {
+                setValue(nextWeek);
+                setFocusedValue(nextWeek.start);
+              }}
+            >
+              Next week
+            </Button>
+            <Button
+              onPress={() => {
+                setValue(nextMonth);
+                setFocusedValue(nextMonth.start);
+              }}
+            >
+              Next month
+            </Button>
           </ButtonGroup>
         }
         calendarProps={{
+          focusedValue: focusedValue,
+          onFocusChange: setFocusedValue,
           nextButtonProps: {
             variant: "bordered",
           },

--- a/apps/docs/content/components/date-range-picker/presets.raw.jsx
+++ b/apps/docs/content/components/date-range-picker/presets.raw.jsx
@@ -95,8 +95,6 @@ export default function App() {
           </ButtonGroup>
         }
         calendarProps={{
-          focusedValue: value.start,
-          onFocusChange: (val) => setValue({...value, start: val}),
           nextButtonProps: {
             variant: "bordered",
           },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4941 <!-- Github issue # here -->

## 📝 Description

Fixes the manual date selection issue in the `DateRangePicker` presets example where clicking on calendar dates was not properly updating both start and end dates.

## ⛳️ Current behavior (updates)

- Manual date selection in calendar only updates the start date
- End date remains unchanged when users click on calendar dates

## 🚀 New behavior

- Manual date selection now properly updates both start and end dates
- Users can click on calendar dates to select complete date ranges
- Calendar interaction works seamlessly with preset buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved date range picker presets to allow independent control of the calendar's focused date, enhancing usability when selecting preset ranges.

* **Bug Fixes**
  * Resolved issues where the calendar focus did not update correctly when choosing preset date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->