### PR TITLE
fix(popover): add null check to PopoverContent children to fix arrow glitch

### DIFF
--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -15,7 +15,7 @@ import {usePopoverContext} from "./popover-context";
 export interface PopoverContentProps
   extends AriaDialogProps,
     Omit<HTMLHeroUIProps, "children" | "role"> {
-  children: ReactNode | ((titleProps: DOMAttributes<HTMLElement>) => ReactNode);
+  children?: ReactNode | ((titleProps: DOMAttributes<HTMLElement>) => ReactNode);
 }
 
 const domAnimation = () => import("@heroui/dom-animation").then((res) => res.default);
@@ -50,11 +50,13 @@ const PopoverContent = (props: PopoverContentProps) => {
   const content = (
     <>
       {!isNonModal && <DismissButton onDismiss={onClose} />}
-      <Component {...dialogProps}>
-        <div {...getContentProps({className})}>
-          {typeof children === "function" ? children(titleProps) : children}
-        </div>
-      </Component>
+      {children && (
+        <Component {...dialogProps}>
+          <div {...getContentProps({className})}>
+            {typeof children === "function" ? children(titleProps) : children}
+          </div>
+        </Component>
+      )}
       <DismissButton onDismiss={onClose} />
     </>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4142

## 📝 Description

Fixes an issue where the Popover renders an arrow and unnecessary padding even when no content (`children`) is passed.

## ⛳️ Current behavior (updates)

The `<Component>` receives `data-arrow="true"` even when `children` is `null`, leading to an unwanted arrow.
Additionally, when `children` is `null`, the Popover still renders an internal `<div>` with default padding, which results in visual glitches.

<img width="1190" height="664" alt="Screenshot 2025-07-20 at 10 02 26 PM" src="https://github.com/user-attachments/assets/94a59c23-6a4c-401e-9767-d18c6f10c468" />

## 🚀 New behavior

Added a null check for `children` before rendering the Popover content. This prevents:

* Arrow rendering when there’s no content.
* Rendering of an empty padded content `<div>`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Also updated the children prop type with ? (optional) to avoid TypeScript errors when children is not provided.
This ensures the component can safely handle cases where no content is passed, preventing TypeScript from throwing type errors during compile time.