### PR TITLE
fix(checkbox): pass form id to input tag

### DIFF
--- a/.changeset/tasty-glasses-marry.md
+++ b/.changeset/tasty-glasses-marry.md
@@ -1,0 +1,6 @@
+---
+"@heroui/checkbox": minor
+"@heroui/form": minor
+---
+
+Pass form id to checkbox input tag

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -87,6 +87,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     children,
     icon,
     name,
+    form,
     isRequired,
     isReadOnly: isReadOnlyProp = false,
     autoFocus = false,
@@ -151,6 +152,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const ariaCheckboxProps = useMemo(
     () => ({
       name,
+      form,
       value,
       children,
       autoFocus,
@@ -167,6 +169,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     }),
     [
       name,
+      form,
       value,
       children,
       autoFocus,
@@ -313,6 +316,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       ...mergeProps(inputProps, focusProps),
       className: slots.hiddenInput({class: classNames?.hiddenInput}),
       onChange: chain(inputProps.onChange, handleCheckboxChange),
+      form: form,
     };
   }, [inputProps, focusProps, handleCheckboxChange, classNames?.hiddenInput]);
 

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -152,7 +152,6 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
   const ariaCheckboxProps = useMemo(
     () => ({
       name,
-      form,
       value,
       children,
       autoFocus,
@@ -169,7 +168,6 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
     }),
     [
       name,
-      form,
       value,
       children,
       autoFocus,

--- a/packages/components/checkbox/stories/checkbox.stories.tsx
+++ b/packages/components/checkbox/stories/checkbox.stories.tsx
@@ -237,7 +237,7 @@ const SeparateFromFormTemplate = (args: CheckboxProps) => {
           label: "text-small",
         }}
         form="heroui-form"
-        name="terms"
+        name="checkbox"
         validationBehavior="aria"
         value="true"
         onValueChange={() => setResult(undefined)}

--- a/packages/components/checkbox/stories/checkbox.stories.tsx
+++ b/packages/components/checkbox/stories/checkbox.stories.tsx
@@ -210,6 +210,56 @@ const WithFormTemplate = (args: CheckboxProps) => {
   );
 };
 
+const SeparateFromFormTemplate = (args: CheckboxProps) => {
+  const [submitted, setSubmitted] = React.useState<{[key: string]: FormDataEntryValue} | null>(
+    null,
+  );
+  const [result, setResult] = React.useState<string | undefined>(undefined);
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+
+    if (data.terms == "true") {
+      setResult("Submitted value: true");
+    } else {
+      setResult("Checkbox is not checked");
+    }
+
+    setSubmitted(data);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Checkbox
+        isRequired
+        classNames={{
+          label: "text-small",
+        }}
+        form="heroui-form"
+        name="terms"
+        validationBehavior="aria"
+        value="true"
+        onValueChange={() => setResult(undefined)}
+        {...args}
+      >
+        This checkbox might be anywhere
+      </Checkbox>
+      <Form id="heroui-form" onSubmit={onSubmit}>
+        {result && <span className="text-small">{result}</span>}
+        <button className={button({class: "w-fit"})} type="submit">
+          Submit
+        </button>
+        {submitted && (
+          <div className="text-small text-default-500 mt-4">
+            Submitted data: <pre>{JSON.stringify(submitted, null, 2)}</pre>
+          </div>
+        )}
+      </Form>
+    </div>
+  );
+};
+
 export const Default = {
   args: {
     ...defaultProps,
@@ -308,6 +358,14 @@ export const Required = {
 
 export const WithForm = {
   render: WithFormTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const SeparateFromForm = {
+  render: SeparateFromFormTemplate,
 
   args: {
     ...defaultProps,


### PR DESCRIPTION
Closes 

- [#5439](https://github.com/heroui-inc/heroui/issues/5439)

## 📝 Description
There already is similar request present [#4979](https://github.com/heroui-inc/heroui/pull/4979) but it looks abandoned.

In HTML it is possible to add form id to inputs that are not children of this form and they are being picked up for this form. 

```html
<Checkbox form="test-form" />
<Form id="test-form"/>
```

## ⛳️ Current behavior (updates)

Adding form currently works for HeroUI Input component, but not for Checkbox. For Checkbox form parameter is being added to label tag, which will not make it work.

```html
<label form="test-form">
    <input type="checkbox" value="" />
</label>
```

## 🚀 New behavior

Form parameter is being passed to input tag, making it possible to use checkboxes outside of form.

```html
<label>
    <input form="test-form" type="checkbox" value="" />
</label>
```

## 💣 Is this a breaking change (Yes/No):

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkboxes can now be associated with a specific form using the form ID, allowing inputs to be linked to forms even when rendered outside the form element.
  * Added a new example demonstrating how to use a checkbox outside of its associated form.

* **Documentation**
  * Updated stories to showcase the new checkbox and form association capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->