### PR TITLE
fix(avatar): broken fallbacks

### DIFF
--- a/.changeset/tiny-ducks-think.md
+++ b/.changeset/tiny-ducks-think.md
@@ -1,0 +1,5 @@
+---
+"@heroui/avatar": patch
+---
+
+fix broken fallbacks in avatar (#5506)

--- a/packages/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/components/avatar/__tests__/avatar.test.tsx
@@ -104,4 +104,69 @@ describe("Avatar - fallback + loading strategy", () => {
 
     expect(container.querySelector("svg")).toBeInTheDocument();
   });
+
+  test("should render name initials fallback when image fails to load and showFallback is true", async () => {
+    const mock = mocks.image();
+
+    mock.simulate("error");
+
+    const src = "https://avatars.githubusercontent.com/u/30373425";
+    const name = "Junior Garcia";
+    const {container} = render(<Avatar showFallback name={name} src={src} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(container.querySelector("span")).toHaveTextContent("Jun");
+  });
+
+  test("should render default avatar fallback when image fails to load with no name and showFallback is true", async () => {
+    const mock = mocks.image();
+
+    mock.simulate("error");
+
+    const src = "https://avatars.githubusercontent.com/u/30373425";
+    const {container} = render(<Avatar showFallback src={src} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  test("should not render fallback when image fails to load and showFallback is false", async () => {
+    const mock = mocks.image();
+
+    mock.simulate("error");
+
+    const src = "https://avatars.githubusercontent.com/u/30373425";
+    const name = "Junior Garcia";
+    const {container} = render(<Avatar name={name} showFallback={false} src={src} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(container.querySelector("span")).not.toHaveTextContent("Jun");
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  test("should not render fallback when image fails to load and showFallback is not passed", async () => {
+    const mock = mocks.image();
+
+    mock.simulate("error");
+
+    const src = "https://avatars.githubusercontent.com/u/30373425";
+    const name = "Junior Garcia";
+    const {container} = render(<Avatar name={name} src={src} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(container.querySelector("span")).not.toHaveTextContent("Jun");
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
 });

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -145,7 +145,7 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
     src,
     onError,
     ignoreFallback,
-    shouldBypassImageLoad: as !== undefined || !isHeroImage,
+    shouldBypassImageLoad: as !== undefined || (ImgComponent !== "img" && !isHeroImage),
   });
 
   const isImgLoaded = imageStatus === "loaded";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5506

## 📝 Description

<!--- Add a brief description -->

Fix the incorrect logic: `shouldBypassImageLoad` is set to `true` when `ImgComponent` is non-default value and not using HeroUI Image, e.g. `NextImage`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="870" height="685" alt="image" src="https://github.com/user-attachments/assets/00e071f3-c4c8-425f-b8f8-9a646d4c5744" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the avatar component's fallback was not displaying correctly when the primary image failed to load.

* **Tests**
  * Added new tests to verify avatar fallback behavior, including scenarios with and without a provided name, and different settings for the fallback display option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->