### PR TITLE
fix(docs): default value of radius in image

### DIFF
--- a/apps/docs/content/docs/components/image.mdx
+++ b/apps/docs/content/docs/components/image.mdx
@@ -139,7 +139,7 @@ you can use it with HeroUI `Image` component as well.
       attribute: "radius",
       type: "none | sm | md | lg | full",
       description: "The image border radius.",
-      default: "xl"
+      default: "lg"
     },
     {
       attribute: "shadow",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5574

## 📝 Description

<!--- Add a brief description -->

`xl` was used in v1 and now the default one is `lg` and `xl` doesn't exist anymore.

<img width="523" height="148" alt="image" src="https://github.com/user-attachments/assets/e2f07bf9-025d-4722-aa50-9d55d0abf508" />

<img width="503" height="206" alt="image" src="https://github.com/user-attachments/assets/ffdd1343-4171-4a4a-acb8-633714a0caeb" />

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the default value of the `radius` attribute in the Image component documentation from "xl" to "lg".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->