### PR TITLE
chore(docs): remove unused or deprecated info in autocomplete

### DIFF
--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -365,7 +365,6 @@ properties to customize the popover, listbox and input components.
 
 - **base**: The main wrapper of the autocomplete. This wraps the input and popover components.
 - **listboxWrapper**: The wrapper of the listbox. This wraps the listbox component, this slot is used on top of the scroll shadow component.
-- **listbox**: The listbox component. This is the component that wraps the autocomplete items.
 - **popoverContent**: The popover content slot. Use this to modify the popover content styles.
 - **endContentWrapper**: The wrapper of the end content. This wraps the clear button and selector button.
 - **clearButton**: The clear button slot.
@@ -726,12 +725,6 @@ properties to customize the popover, listbox and input components.
       type: "boolean",
       description: "Whether the clear button should be shown.",
       default: "true"
-    },
-    {
-      attribute: "disableClearable",
-      type: "boolean",
-      description: "Whether the clear button should be hidden. (Deprecated) Use isClearable instead.",
-      default: "false"
     },
     {
       attribute: "disableAnimation",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5579

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Autocomplete component documentation to remove the mention of the listbox slot.
  * Removed the deprecated `disableClearable` property from the API props table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->