### PR TITLE
refactor(docs): standardize copy code feedback across all tabs

### DIFF
--- a/apps/docs/components/copy-button.tsx
+++ b/apps/docs/components/copy-button.tsx
@@ -2,6 +2,7 @@ import type {ButtonProps} from "@heroui/react";
 
 import {useClipboard} from "@heroui/use-clipboard";
 import {memo} from "react";
+import {Tooltip} from "@heroui/react";
 
 import {PreviewButton} from "./preview-button";
 
@@ -32,7 +33,17 @@ export const CopyButton = memo<CopyButtonProps>(({value, className, ...buttonPro
     copy(value);
   };
 
-  return <PreviewButton className={className} icon={icon} onPress={handleCopy} {...buttonProps} />;
+  return (
+    <Tooltip
+      key={copied ? "copied" : "copy"}
+      className="text-xs px-2"
+      closeDelay={0}
+      content={copied ? "Copied!" : "Copy"}
+      radius="md"
+    >
+      <PreviewButton className={className} icon={icon} onPress={handleCopy} {...buttonProps} />
+    </Tooltip>
+  );
 });
 
 CopyButton.displayName = "CopyButton";

--- a/apps/docs/components/sandpack/copy-button.tsx
+++ b/apps/docs/components/sandpack/copy-button.tsx
@@ -3,7 +3,7 @@ import {useSandpack} from "@codesandbox/sandpack-react";
 import {Tooltip, Button} from "@heroui/react";
 import {useClipboard} from "@heroui/use-clipboard";
 
-import {CopyLinearIcon} from "@/components/icons";
+import {CheckLinearIcon, CopyLinearIcon} from "@/components/icons";
 
 export const CopyButton = ({code: codeProp}: {code?: string}) => {
   const {copy, copied} = useClipboard();
@@ -16,15 +16,33 @@ export const CopyButton = ({code: codeProp}: {code?: string}) => {
     copy(code);
   };
 
+  const icon = copied ? (
+    <CheckLinearIcon
+      className="text-white dark:text-zinc-500 opacity-0 scale-50 data-[visible=true]:opacity-100 data-[visible=true]:scale-100 transition-transform-opacity"
+      data-visible={copied}
+      height={16}
+      size={16}
+      width={16}
+    />
+  ) : (
+    <CopyLinearIcon
+      className="text-white dark:text-zinc-500 opacity-0 scale-50 data-[visible=true]:opacity-100 data-[visible=true]:scale-100 transition-transform-opacity"
+      data-visible={!copied}
+      height={16}
+      width={16}
+    />
+  );
+
   return (
     <Tooltip
+      key={copied ? "copied" : "copy"}
       className="text-xs px-2"
       closeDelay={0}
       content={copied ? "Copied!" : "Copy"}
       radius="md"
     >
       <Button isIconOnly size="sm" title="Copy Code" variant="light" onPress={copyHandler}>
-        <CopyLinearIcon className="text-white dark:text-zinc-500" height={16} width={16} />
+        {icon}
       </Button>
     </Tooltip>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR standardizes the **"Copy code"** button feedback behavior across the components of the documentantion, ensuring a consistent feedback that the user actually copied the code regardless of which tab they are in.

## ⛳️ Current behavior (updates)

In the **Preview** tab, the checkmark works as normal, but it doesn't show the "Copy" tooltip, nor does it display "Copied!" after the user clicks the button.
In the **Code** tab, the checkmark doesn't appear at all, and the "Copied!" message is only shown if the user hovers twice within 2 seconds after clicking.

![ScreenRecordingBeforeHeroUi](https://github.com/user-attachments/assets/2ef4ad87-16f2-411a-a0e1-7807c694f33b)


## 🚀 New behavior

The checkmark and tooltip now behave consistently across both tabs. After clicking the "Copy" button, the user will see immediate visual feedback with a checkmark and "Copy" and "Copied!" tooltip showing.

![ScreenRecordingAfterHeroUi](https://github.com/user-attachments/assets/576e59cb-17c7-40c9-a288-4e0640c03190)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Since the button was already copying the content as normal, I put this PR name as a Refactor instead of Fix
**Browsers tested:** 
- Google Chrome
- Opera GX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to copy buttons, providing immediate visual feedback ("Copy" or "Copied!") after a copy action.
  * Copy buttons now visually switch icons to indicate successful copying.

* **Style**
  * Enhanced button transitions and tooltip appearance for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->