### PR TITLE
Fix/select accessibility label

### DIFF
--- a/.changeset/selfish-pears-boil.md
+++ b/.changeset/selfish-pears-boil.md
@@ -1,0 +1,6 @@
+---
+"@heroui/use-aria-multiselect": patch
+"@heroui/select": patch
+---
+
+fix `Select` accessibility label not including selected options

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect.ts
@@ -144,7 +144,7 @@ export function useMultiSelect<T>(
         valueId,
         triggerProps["aria-labelledby"],
         triggerProps["aria-label"] && !triggerProps["aria-labelledby"] ? triggerProps.id : null,
-      ].join(","),
+      ].join(" "),
       onFocus(e: FocusEvent) {
         if (state.isFocused) {
           return;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5586 

## 📝 Description

Reverts https://github.com/heroui-inc/heroui/pull/5100/commits/35979764a73870a858af7ffccaa0a52ba8f3ac6c. Browsers [expect](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby#values) the IDs in `aria-labelledby` to be space-separated. 

## ⛳️ Current behavior (updates)

The browsers fallback to either `aria-label` or inner text to determine accessibility label.

## 🚀 New behavior

The browser can parse and identify the elements in `aria-labelledby`.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
