### PR TITLE
fix(toast): prevent duplicate toasts when multiple providers are declared

### DIFF
--- a/.changeset/empty-needles-hope.md
+++ b/.changeset/empty-needles-hope.md
@@ -1,5 +1,0 @@
----
-"@heroui/toast": patch
----
-
-prevent duplicate toasts when multiple providers are declared

--- a/.changeset/empty-needles-hope.md
+++ b/.changeset/empty-needles-hope.md
@@ -1,0 +1,5 @@
+---
+"@heroui/toast": patch
+---
+
+prevent duplicate toasts when multiple providers are declared

--- a/apps/docs/content/components/toast/close.raw.jsx
+++ b/apps/docs/content/components/toast/close.raw.jsx
@@ -3,12 +3,15 @@ import React from "react";
 
 export default function App() {
   const [toastKey, setToastKey] = React.useState([]);
+  const [isBlogPage, setIsBlogPage] = React.useState(false);
+
+  React.useEffect(() => {
+    setIsBlogPage(window.location.pathname.startsWith("/blog"));
+  }, []);
 
   return (
     <>
-      <div className="fixed z-[100]">
-        <ToastProvider />
-      </div>
+      <div className="fixed z-[100]">{isBlogPage && <ToastProvider />}</div>
       <div className="flex flex-wrap gap-2">
         <Button
           variant="flat"

--- a/apps/docs/content/components/toast/close.raw.jsx
+++ b/apps/docs/content/components/toast/close.raw.jsx
@@ -1,4 +1,4 @@
-import {addToast, Button, closeToast, closeAll} from "@heroui/react";
+import {addToast, Button, closeToast, closeAll, ToastProvider} from "@heroui/react";
 import React from "react";
 
 export default function App() {
@@ -6,7 +6,9 @@ export default function App() {
 
   return (
     <>
-      <div className="fixed z-[100]" />
+      <div className="fixed z-[100]">
+        <ToastProvider />
+      </div>
       <div className="flex flex-wrap gap-2">
         <Button
           variant="flat"

--- a/apps/docs/content/components/toast/close.raw.jsx
+++ b/apps/docs/content/components/toast/close.raw.jsx
@@ -1,4 +1,4 @@
-import {addToast, Button, closeToast, closeAll, ToastProvider} from "@heroui/react";
+import {addToast, Button, closeToast, closeAll} from "@heroui/react";
 import React from "react";
 
 export default function App() {
@@ -6,9 +6,7 @@ export default function App() {
 
   return (
     <>
-      <div className="fixed z-[100]">
-        <ToastProvider />
-      </div>
+      <div className="fixed z-[100]" />
       <div className="flex flex-wrap gap-2">
         <Button
           variant="flat"


### PR DESCRIPTION
Closes #5559 


### 📝 Description
- Removes the extra `<ToastProvider>` declared in the example, 
- which was causing duplicate toasts when combined with the global provider. 
- This change ensures only the global provider instance is used in the docs/examples.
<br/>

_before_


https://github.com/user-attachments/assets/fa922af7-3589-4bc5-8ec1-c5d8211e9fff



<br/>

_after_


https://github.com/user-attachments/assets/4e91e4c2-fbc5-4bad-972c-52d177a2b497



<br/>

###  ⛳️ Current behavior (updates)
- Multiple `<ToastProvider>` declarations in the app cause the toast queue to render duplicates, 
- as each provider instance manages its own region rendering.

<br/>

###  🚀 New behavior
- Only the global provider instance is used. 
- The example no longer declares its own `<ToastProvider>`, preventing duplicate toast rendering.

<br/>

###  💣 Is this a breaking change (Yes/No):
- No

<br/>

###  📝 Additional Information
- As a future improvement, we can make `<ToastProvider>` internally manage a global singleton toast queue so that even if multiple providers are declared, they share the same instance and avoid duplicates:

```ts
const G = globalThis as any;
const QUEUE_KEY = "__heroui_toast_queue__";

export const getToastQueue = () => {
  if (!G[QUEUE_KEY]) {
    G[QUEUE_KEY] = new ToastQueue<ToastProps>({ maxVisibleToasts: Infinity });
  }
  return G[QUEUE_KEY];
};
```
- If the team agrees with this approach, I can apply it in a follow-up PR :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Toast notifications now appear only on blog pages (paths under /blog).
  * Other areas of the site no longer display or mount the toast container, reducing unexpected pop-ups outside the blog.
  * Existing toast behavior and interactions on blog pages remain unchanged.
  * No changes to public component APIs; users should experience a more focused UI with toasts confined to relevant blog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->