### PR TITLE
fix(toast): remove duplicate toast while multiple providers are declared

### DIFF
--- a/apps/docs/content/components/toast/close.raw.jsx
+++ b/apps/docs/content/components/toast/close.raw.jsx
@@ -1,4 +1,4 @@
-import {addToast, Button, closeToast, closeAll, ToastProvider} from "@heroui/react";
+import {addToast, Button, closeToast, closeAll} from "@heroui/react";
 import React from "react";
 
 export default function App() {
@@ -6,9 +6,7 @@ export default function App() {
 
   return (
     <>
-      <div className="fixed z-[100]">
-        <ToastProvider />
-      </div>
+      <div className="fixed z-[100]" />
       <div className="flex flex-wrap gap-2">
         <Button
           variant="flat"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5559  <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

- Removes the extra <ToastProvider> declared in the example,
- which was causing duplicate toasts when combined with the global provider.
- This will ensures only the global toast provider instance that is used in the docs.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

- Multiple <ToastProvider> declarations in the app cause the toast queue to render duplicates,
- as each provider instance manages its own region rendering.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

- Only the global provider instance is used.
- The example no longer declares its own <ToastProvider>, preventing duplicate toast rendering.

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the toast component example to remove the provider wrapper and simplify setup within a fixed container.
  * Example continues to demonstrate adding, closing, and clearing toasts; visible behavior remains unchanged.
  * Improves clarity and aligns the sample with current usage patterns; no API changes or new configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->