### PR TITLE
feat(toast): provide a way to close the toast itself within the endContent

### DIFF
--- a/.changeset/grumpy-boxes-doubt.md
+++ b/.changeset/grumpy-boxes-doubt.md
@@ -1,0 +1,5 @@
+---
+"@heroui/toast": patch
+---
+
+Enable the toast's endContent to close the toast using the onClose function

--- a/packages/components/toast/src/toast.tsx
+++ b/packages/components/toast/src/toast.tsx
@@ -82,6 +82,11 @@ const Toast = forwardRef<"div", ToastProps>((props, ref) => {
       ? closeIcon({})
       : isValidElement(closeIcon) && cloneElement(closeIcon as ReactElement, {});
 
+  const customEndContent =
+    typeof endContent === "function"
+      ? endContent((getCloseButtonProps() as ButtonProps).onPress as () => void)
+      : endContent;
+
   const toastContent = (
     <Component ref={domRef} {...getToastProps()}>
       <div {...getContentProps()}>
@@ -104,7 +109,7 @@ const Toast = forwardRef<"div", ToastProps>((props, ref) => {
       <Button isIconOnly {...(getCloseButtonProps() as ButtonProps)}>
         {customCloseIcon || <CloseIcon {...getCloseIconProps()} />}
       </Button>
-      {endContent}
+      {customEndContent}
     </Component>
   );
 

--- a/packages/components/toast/src/use-toast.ts
+++ b/packages/components/toast/src/use-toast.ts
@@ -67,7 +67,7 @@ export interface ToastProps extends ToastVariantProps {
   /**
    * Content to be displayed in the end side of the toast
    */
-  endContent?: ReactNode;
+  endContent?: ReactNode | ((onClose: () => void) => ReactNode);
   /**
    * Icon to be displayed in the toast - overrides the default icon
    */

--- a/packages/components/toast/stories/toast.stories.tsx
+++ b/packages/components/toast/stories/toast.stories.tsx
@@ -143,11 +143,6 @@ const WithEndContentTemplate = (args) => {
           addToast({
             title: "Toast Title",
             description: "Toast Description",
-            // endContent: (
-            //   <Button color="warning" size="sm" variant="flat">
-            //     Upgrade
-            //   </Button>
-            // ),
             endContent: args.endContent,
             color: "warning",
             variant: "faded",

--- a/packages/components/toast/stories/toast.stories.tsx
+++ b/packages/components/toast/stories/toast.stories.tsx
@@ -143,11 +143,12 @@ const WithEndContentTemplate = (args) => {
           addToast({
             title: "Toast Title",
             description: "Toast Description",
-            endContent: (
-              <Button color="warning" size="sm" variant="flat">
-                Upgrade
-              </Button>
-            ),
+            // endContent: (
+            //   <Button color="warning" size="sm" variant="flat">
+            //     Upgrade
+            //   </Button>
+            // ),
+            endContent: args.endContent,
             color: "warning",
             variant: "faded",
             ...args,
@@ -444,6 +445,28 @@ export const WithEndContent = {
   render: WithEndContentTemplate,
   args: {
     ...defaultProps,
+    endContent: (
+      <Button color="warning" size="sm" variant="flat">
+        Upgrade
+      </Button>
+    ),
+  },
+};
+
+export const WithEndContentCloseFunction = {
+  render: WithEndContentTemplate,
+  args: {
+    ...defaultProps,
+    endContent: (onClose) => (
+      <>
+        <Button color="warning" size="sm" variant="flat">
+          Upgrade
+        </Button>
+        <Button color="danger" size="sm" variant="flat" onPress={onClose}>
+          Maybe later
+        </Button>
+      </>
+    ),
   },
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR changes the `endContent` attribute of the `ToastProps`. It can now not only receive a variable of type `ReactNode`, but also a function with a `onClose` param and a return type of `ReactNode`. The functionality of the `onClose` function is the same as the toast's close button's onPress event. When users call the `onClose` function, it closes the toast just like clicking on the close button.

With this PR, Users can now create customized close button in the `endContent`.

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

There is no way to create a close button in `endContent`. Although `closeToast` api provides a way to programmtically close a toast, it requires the toast's id which users can only access it after the toast is created. Since the toast's id won't be available when the user defines the `endContent`, there is no way to utilize the `closeToast` api to close itself.

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

As mentioned in the description, users can now utilize the `onClose` function to customize a close button or whatever ui effect they may want within the `endContent`.

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
