### PR TITLE
feat(toast): support multiple ToastProvider

### DIFF
--- a/.changeset/great-keys-admire.md
+++ b/.changeset/great-keys-admire.md
@@ -1,0 +1,5 @@
+---
+"@heroui/toast": patch
+---
+
+Support multiple ToastProvider with unique IDs

--- a/packages/components/toast/src/use-toast.ts
+++ b/packages/components/toast/src/use-toast.ts
@@ -110,6 +110,11 @@ export interface ToastProps extends ToastVariantProps {
    * @default "default"
    */
   severity?: "default" | "primary" | "secondary" | "success" | "warning" | "danger";
+  /**
+   * The id of the ToastProvider. The decides which ToastProvider will handle the toast.
+   * @default "heroui"
+   */
+  toasterId?: string;
 }
 
 interface Props<T> extends Omit<HTMLHeroUIProps<"div">, "title">, ToastProps {

--- a/packages/components/toast/stories/toast.stories.tsx
+++ b/packages/components/toast/stories/toast.stories.tsx
@@ -425,6 +425,49 @@ const CloseToastTemplate = (args: ToastProps) => {
   );
 };
 
+const MultiToasterTemplate = (args) => {
+  return (
+    <>
+      <ToastProvider
+        maxVisibleToasts={args.maxVisibleToasts}
+        placement="bottom-left"
+        toasterId="left"
+      />
+      <ToastProvider
+        maxVisibleToasts={args.maxVisibleToasts}
+        placement="bottom-right"
+        toasterId="right"
+      />
+      <div>
+        <Button
+          onPress={() => {
+            addToast({
+              title: "Toast Title",
+              description: "Toast Displayed Successfully",
+              ...args,
+              toasterId: "left",
+            });
+          }}
+        >
+          Show left toast
+        </Button>
+        <Button
+          onPress={() => {
+            addToast({
+              title: "Toast Title",
+              description: "Toast Displayed Successfully",
+              ...args,
+              toasterId: "right",
+            });
+          }}
+        >
+          Show right toast
+        </Button>
+      </div>
+    </>
+  );
+};
+
 export const Default = {
   render: Template,
   args: {
@@ -524,6 +567,13 @@ export const CustomCloseIcon = {
 
 export const CloseToast = {
   render: CloseToastTemplate,
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const MultiToaster = {
+  render: MultiToasterTemplate,
   args: {
     ...defaultProps,
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Related Issue #5559 
Related PR #5602 #5590 

## 📝 Description

This PR adopts the [multi toaster](https://react-hot-toast.com/docs/multi-toaster) design from `react-hot-toast` and adds support for multiple `ToastProvider`. It might provide an alternative solution to the above issues and PRs.

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

All the `ToastProvider` instance shares the same `ToastQueue`. If there are multiple `ToastProvider` instances, call `addToast` once would cause all the `ToastProvider` instance to render the same toast, and hence create duplicate toasts.

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

Each `ToastProvider` instance has their own `ToastQueue` and an unique ID field `toasterId` (default to `heroui`) is used to distinguish each of them. `addToast` and `closeToast` API also receives this `toasterId` field to control the add and close behavior of the corresponding `ToastProvider`.

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

Only a bit change on params, so kind of a no.

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information

Please see the storybook `Multi Toaster` example for demo.