### PR TITLE
fix(toast): show animation when closing all modals

### DIFF
--- a/.changeset/twelve-needles-bathe.md
+++ b/.changeset/twelve-needles-bathe.md
@@ -2,4 +2,4 @@
 "@heroui/toast": patch
 ---
 
-show animation when closing all modals
+show animation when closing all modals (#5620)

--- a/.changeset/twelve-needles-bathe.md
+++ b/.changeset/twelve-needles-bathe.md
@@ -1,0 +1,5 @@
+---
+"@heroui/toast": patch
+---
+
+show animation when closing all modals

--- a/packages/components/toast/src/toast-provider.tsx
+++ b/packages/components/toast/src/toast-provider.tsx
@@ -82,7 +82,9 @@ export const closeAll = () => {
 
   const keys = globalToastQueue.visibleToasts.map((toast) => toast.key);
 
-  keys.map((key) => {
-    globalToastQueue?.close(key);
+  keys.forEach((key, index) => {
+    setTimeout(() => {
+      globalToastQueue?.close(key);
+    }, index * 100);
   });
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5620
## 📝 Description
The modals were not closing with animation because they were all closing simultaneously. I added a slight delay between each modal's closing to allow the animations to play smoothly.


https://github.com/user-attachments/assets/4de0597e-2aab-44a1-9db1-10572b035367




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Closing all toasts now animates smoothly instead of disappearing instantly.
  * Toasts dismiss in a brief, staggered sequence, improving visual feedback and readability during bulk closures.
  * No changes to public APIs; existing integrations continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->