### PR TITLE
fix(theme): dropdown-item has no ellipsis when it has a width and desc 

### DIFF
--- a/.changeset/plenty-keys-turn.md
+++ b/.changeset/plenty-keys-turn.md
@@ -2,4 +2,4 @@
 "@heroui/theme": patch
 ---
 
-fix after setting the maximum width at DropdownMenu, if there is a description, an ellipsis will not appear if the text is too long ([#5564](https://github.com/heroui-inc/heroui/issues/5564))
+fix after setting the maximum width at DropdownMenu, if there is a description, an ellipsis will not appear if the text is too long (#5564)

--- a/.changeset/plenty-keys-turn.md
+++ b/.changeset/plenty-keys-turn.md
@@ -1,0 +1,5 @@
+---
+"@heroui/theme": patch
+---
+
+fix after setting the maximum width at DropdownMenu, if there is a description, an ellipsis will not appear if the text is too long ([#5564](https://github.com/heroui-inc/heroui/issues/5564))

--- a/packages/core/theme/src/components/menu.ts
+++ b/packages/core/theme/src/components/menu.ts
@@ -70,8 +70,8 @@ const menuItem = tv({
       ...dataFocusVisibleClasses,
       "data-[focus-visible=true]:dark:ring-offset-background-content1",
     ],
-    wrapper: "w-full flex flex-col items-start justify-center",
-    title: "flex-1 text-small font-normal",
+    wrapper: "w-full flex flex-col items-start justify-center min-w-0",
+    title: "flex-1 text-small font-normal w-full",
     description: ["w-full", "text-tiny", "text-foreground-500", "group-hover:text-current"],
     selectedIcon: ["text-inherit", "w-3", "h-3", "shrink-0"],
     shortcut: [


### PR DESCRIPTION
…psis when there was a desc

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5564

## 📝 Description

<!--- Add a brief description -->


## ⛳️ Current behavior (updates)

When the dropdown component has a width and the dropdown-item has a description, if the text is too long, an ellipsis cannot appear.
<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->
<img width="363" height="221" alt="image" src="https://github.com/user-attachments/assets/1469dd05-3a25-4556-a1cd-5e6aa175a136" />
<img width="378" height="222" alt="image" src="https://github.com/user-attachments/assets/7da0dfc7-2b0f-4854-acfb-8c1793e8ed7e" />
## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->
no
## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DropdownMenu text truncation: when a maximum width and a description are present, long item titles now wrap correctly instead of being truncated with an ellipsis, preserving expected widths and improving readability.
* **Chores**
  * Added a patch release entry for the theme package documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->