### PR TITLE
Feat/listbox virtualized gap

### DIFF
--- a/.changeset/wet-ways-boil.md
+++ b/.changeset/wet-ways-boil.md
@@ -1,0 +1,5 @@
+---
+"@heroui/listbox": minor
+---
+
+Allow specifying the gap property for list items in a virtualized listbox component

--- a/apps/docs/content/docs/components/listbox.mdx
+++ b/apps/docs/content/docs/components/listbox.mdx
@@ -344,7 +344,7 @@ You can customize the `Listbox` items style by using the `itemClasses` prop and 
       type: "boolean",
       description: "Whether keyboard navigation is circular.",
       default: "false"
-    },   
+    },
     {
       attribute: "isVirtualized",
       type: "boolean",
@@ -353,7 +353,7 @@ You can customize the `Listbox` items style by using the `itemClasses` prop and 
     },
     {
       attribute: "virtualization",
-      type: "Record<\"maxListboxHeight\" & \"itemHeight\", number>",
+      type: "Record<\"maxListboxHeight\" & \"itemHeight\", number> & { gap?: number; }",
       description: "Configuration for virtualization, optimizing rendering for large datasets. Required if isVirtualized is set to true.",
       default: "-",
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756217674,
+        "narHash": "sha256-TH1SfSP523QI7kcPiNtMAEuwZR3Jdz0MCDXPs7TS8uo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4e7667a90c167f7a81d906e5a75cba4ad8bee620",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description="flake for heroui development";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+  };
+  outputs = { self, nixpkgs }:
+    let
+      linux = "x86_64-linux";
+      aarch64 = "aarch64-darwin";
+      buildInputs = pkgs: with pkgs; [
+        pkgs.nodejs_22
+        pkgs.pnpm
+        pkgs.nodePackages.typescript-language-server
+        pkgs.nodePackages.vscode-langservers-extracted
+      ];
+  in rec {
+    devShells = {
+        "${linux}".default = let pkgs = nixpkgs.legacyPackages."${linux}"; in
+          pkgs.mkShell {
+            buildInputs = buildInputs pkgs;
+          };
+        "${aarch64}".default = let pkgs = nixpkgs.legacyPackages."${aarch64}"; in
+          pkgs.mkShell {
+            buildInputs = buildInputs pkgs;
+          };
+      };
+  };
+}

--- a/packages/components/listbox/src/listbox.tsx
+++ b/packages/components/listbox/src/listbox.tsx
@@ -12,6 +12,7 @@ import VirtualizedListbox from "./virtualized-listbox";
 export interface VirtualizationProps {
   maxListboxHeight: number;
   itemHeight: number;
+  gap?: number;
 }
 
 interface Props<T> extends UseListboxProps<T> {

--- a/packages/components/listbox/src/virtualized-listbox.tsx
+++ b/packages/components/listbox/src/virtualized-listbox.tsx
@@ -103,6 +103,7 @@ const VirtualizedListbox = (props: Props) => {
     count: [...state.collection].length,
     getScrollElement: () => parentRef.current,
     estimateSize: (i) => itemSizes[i],
+    gap: virtualization.gap,
   });
 
   const virtualItems = rowVirtualizer.getVirtualItems();


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Allow the user to set the gap between the list items in a virtualized list box.


I could not find a way to set a gap between the items in the documentation, but I saw that it was supported by the underyling TanStack library. I added a 'gap' property to the listbox component's `virtualized` prop and passed then passed that through to the `useVirtualizer` hook along with the other `virtualized` attributes.

## ⛳️ Current behavior (updates)

Users cannot specify a numerical gap between the items in a virtualized listbox.

## 🚀 New behavior

Users can specify a numerical gap between the items in a virtualized listbox.

With a gap of `undefined` or 0, the listbox will appear as it did before.
<img width="357" height="422" alt="Screenshot 2025-08-29 at 15 45 46" src="https://github.com/user-attachments/assets/3788c644-4d53-4b09-96a2-25fa9ea8fb86" />

With a gap specified, there will be a gap between the list items.
<img width="357" height="422" alt="Screenshot 2025-08-29 at 15 44 34" src="https://github.com/user-attachments/assets/8bd3e714-9e02-4925-b669-4127fda626b2" />

## 💣 Is this a breaking change (Yes/No):
## 📝 Additional Information
I wanted to add a unit test for this, but I realized that it would be meaningless. JSDOM doesn't implement rendering, so `getBoundingClientRect` will always return all 0s. The unit test would have verified that there was a gap of N pixels in between the individual list items by using `getBoundingClientRect` to verify the Y coordinates of the list items.

In order to get the test to work, I would need to mock `getBoundingClientRect`, and the test would then only be testing the mock and seemed pointless.

I visually confirmed that a gap does appear in Storybook.

I added a nix flake so that I could get the correct version of pnpm to be able to contribute. `flake.nix` and `flake.lock` could be removed from the PR. I will remove them if it's decided that this PR could be merged.