### PR TITLE
fix(drawer): adjust placement according to scrollbar width

### DIFF
--- a/packages/components/drawer/__tests__/drawer.test.tsx
+++ b/packages/components/drawer/__tests__/drawer.test.tsx
@@ -110,4 +110,33 @@ describe("Drawer", () => {
     fireEvent.keyDown(drawer, {key: "Escape"});
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("should apply right offset equal to scrollbar width", () => {
+    Object.defineProperty(window, "innerWidth", {value: 2000});
+    Object.defineProperty(document.documentElement, "clientWidth", {value: 1980});
+
+    const {getByRole} = render(
+      <Drawer isOpen placement="right">
+        <DrawerContent>content</DrawerContent>
+      </Drawer>,
+    );
+    const drawer = getByRole("dialog");
+
+    expect(drawer).toHaveStyle({right: "20px"});
+  });
+
+  it("should not apply right offset equal to scrollbar width when placement is left", () => {
+    Object.defineProperty(window, "innerWidth", {value: 2000});
+    Object.defineProperty(document.documentElement, "clientWidth", {value: 1980});
+
+    const {getByRole} = render(
+      <Drawer isOpen placement="left">
+        <DrawerContent>content</DrawerContent>
+      </Drawer>,
+    );
+
+    const drawer = getByRole("dialog");
+
+    expect(drawer).not.toHaveStyle({right: "20px"});
+  });
 });

--- a/packages/components/drawer/src/use-drawer.ts
+++ b/packages/components/drawer/src/use-drawer.ts
@@ -80,6 +80,9 @@ export function useDrawer(originalProps: UseDrawerProps) {
   );
 
   const getModalProps = useCallback<PropGetter>(() => {
+    const scrollBarWidth =
+      typeof window !== "undefined" ? window.innerWidth - document.documentElement.clientWidth : 0;
+
     return {
       classNames: {
         ...classNames,
@@ -89,6 +92,10 @@ export function useDrawer(originalProps: UseDrawerProps) {
       scrollBehavior,
       size,
       ...otherProps,
+      style: {
+        ...(placement === "right" ? {right: `${scrollBarWidth}px`} : {}),
+        ...(otherProps.style ?? {}),
+      },
     };
   }, [baseStyles, classNames, motionProps, scrollBehavior, size, otherProps]);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5558 

## 📝 Description
Fixes Drawer alignment issue when placement="right". The drawer now accounts for scrollbar width to avoid misalignment.

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->
Before :
When placement="right", the drawer aligns incorrectly if the page has a vertical scrollbar
<!--- Please describe the behavior or changes this PR adds -->
After :
Drawer offsets correctly by scrollbar width (right: <scrollbarWidth>px).
Added test to ensure correct style is applied.
## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Added a test to validate that Drawer with placement="right" applies right: "20px" when a scrollbar is present.
## Screenshots
### Before
<img width="790" height="962" alt="Screenshot from 2025-09-04 17-16-53" src="https://github.com/user-attachments/assets/c468ae96-9643-41e9-8115-6e22f1c5e3e2" />

### After
<img width="790" height="962" alt="Screenshot from 2025-09-04 17-16-05" src="https://github.com/user-attachments/assets/487be2fa-3dea-44c1-837e-888eed21734b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Right-placed Drawer now offsets by the page’s scrollbar width, preventing overlap and ensuring proper alignment when a vertical scrollbar is present. Other placements are unaffected.

- Tests
  - Added tests validating scrollbar-based offset behavior for right and left Drawer placements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->