### PR TITLE
Fix invalid example code in Toast component

### DIFF
--- a/apps/docs/content/docs/components/toast.mdx
+++ b/apps/docs/content/docs/components/toast.mdx
@@ -47,7 +47,7 @@ The `ToastProvider` must be added to the application before using the `addToast`
 import {HeroUIProvider} from '@heroui/react'
 import {ToastProvider} from "@heroui/toast";
 
-export default function Providers({children}) {
+export function Providers({children}) {
   return (
     <HeroUIProvider>
       <ToastProvider />


### PR DESCRIPTION
Named export should be used instead of default export.

```diff
// app/providers.tsx

- export default function Providers({children}) {
+ export function Providers({children}) {
```

```tsx
// app/layout.tsx

import {Providers} from "./providers";
```