### PR TITLE
fix(docs): missing quote

### DIFF
--- a/apps/docs/content/docs/components/toast.mdx
+++ b/apps/docs/content/docs/components/toast.mdx
@@ -291,7 +291,7 @@ Toast has the following slots:
     },
     {
       attribute: "classNames",
-      type: "Partial<Record<\"base\" | \"content\" | \"wrapper\" | \"title\" | \"description\" | \"icon\" | \"loadingComponent\" | \"progressTrack\" | \"progressIndicator\ | \"motionDiv\" | \"closeButton\" | \"closeIcon\", string>>",
+      type: "Partial<Record<\"base\" | \"content\" | \"wrapper\" | \"title\" | \"description\" | \"icon\" | \"loadingComponent\" | \"progressTrack\" | \"progressIndicator\" | \"motionDiv\" | \"closeButton\" | \"closeIcon\", string>>",
       description: "Allows to set custom class names for the toast slots.",
       default: "-"
     }


### PR DESCRIPTION
`294-294`: Broken type string: missing quote and stray backslash.

```diff
-      type: "Partial<Record<\"base\" | \"content\" | \"wrapper\" | \"title\" | \"description\" | \"icon\" | \"loadingComponent\" | \"progressTrack\" | \"progressIndicator\ | \"motionDiv\" | \"closeButton\" | \"closeIcon\", string>>",
+      type: "Partial<Record<\"base\" | \"content\" | \"wrapper\" | \"title\" | \"description\" | \"icon\" | \"loadingComponent\" | \"progressTrack\" | \"progressIndicator\" | \"motionDiv\" | \"closeButton\" | \"closeIcon\", string>>",
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted the type signature for the Toast component’s classNames prop to improve readability and consistency in the docs.
  * No changes to the available keys: base, content, wrapper, title, description, icon, loadingComponent, progressTrack, progressIndicator, motionDiv, closeButton, closeIcon.
  * No functional or API changes; behavior remains the same.
  * Aims to make it easier for readers to understand styling customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->