### PR TITLE
fix(Avatar): add the safeInitials function to get the initials name

### DIFF
--- a/.changeset/twelve-pianos-serve.md
+++ b/.changeset/twelve-pianos-serve.md
@@ -1,0 +1,6 @@
+---
+"@heroui/shared-utils": patch
+"@heroui/avatar": patch
+---
+
+fix getInitials (#5671)

--- a/packages/components/avatar/__tests__/avatar.test.tsx
+++ b/packages/components/avatar/__tests__/avatar.test.tsx
@@ -31,7 +31,7 @@ describe("Avatar", () => {
   it("should render initials", () => {
     const {container} = render(<Avatar name="Junior" />);
 
-    expect(container.querySelector("span")).toHaveTextContent("Jun");
+    expect(container.querySelector("span")).toHaveTextContent("J");
   });
 
   it('should work with custom "getInitials" function', () => {
@@ -96,7 +96,7 @@ describe("Avatar - fallback + loading strategy", () => {
   test("should render a name avatar if no src", () => {
     const {container} = render(<Avatar name="Junior" />);
 
-    expect(container.querySelector("span")).toHaveTextContent("Jun");
+    expect(container.querySelector("span")).toHaveTextContent("J");
   });
 
   test("should render a default avatar if no name or src", () => {
@@ -118,7 +118,7 @@ describe("Avatar - fallback + loading strategy", () => {
       jest.runAllTimers();
     });
 
-    expect(container.querySelector("span")).toHaveTextContent("Jun");
+    expect(container.querySelector("span")).toHaveTextContent("JG");
   });
 
   test("should render default avatar fallback when image fails to load with no name and showFallback is true", async () => {
@@ -149,7 +149,7 @@ describe("Avatar - fallback + loading strategy", () => {
       jest.runAllTimers();
     });
 
-    expect(container.querySelector("span")).not.toHaveTextContent("Jun");
+    expect(container.querySelector("span")).not.toHaveTextContent("JG");
     expect(container.querySelector("svg")).not.toBeInTheDocument();
   });
 
@@ -166,7 +166,7 @@ describe("Avatar - fallback + loading strategy", () => {
       jest.runAllTimers();
     });
 
-    expect(container.querySelector("span")).not.toHaveTextContent("Jun");
+    expect(container.querySelector("span")).not.toHaveTextContent("JG");
     expect(container.querySelector("svg")).not.toBeInTheDocument();
   });
 });

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -5,7 +5,7 @@ import type {ReactRef} from "@heroui/react-utils";
 import {avatar} from "@heroui/theme";
 import {useProviderContext} from "@heroui/system";
 import {useDOMRef, filterDOMProps} from "@heroui/react-utils";
-import {clsx, safeText, dataAttr, mergeProps} from "@heroui/shared-utils";
+import {clsx, dataAttr, mergeProps, safeInitials} from "@heroui/shared-utils";
 import {useFocusRing} from "@react-aria/focus";
 import {useMemo, useCallback} from "react";
 import {useImage} from "@heroui/use-image";
@@ -117,7 +117,7 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
     isBordered = groupContext?.isBordered ?? false,
     isDisabled = groupContext?.isDisabled ?? false,
     isFocusable = false,
-    getInitials = safeText,
+    getInitials = safeInitials,
     ignoreFallback = false,
     showFallback: showFallbackProp = false,
     ImgComponent = "img",

--- a/packages/components/user/__tests__/user.test.tsx
+++ b/packages/components/user/__tests__/user.test.tsx
@@ -100,6 +100,6 @@ describe("User", () => {
       />,
     );
 
-    expect(getByRole("img")).toHaveTextContent("WK");
+    expect(getByRole("img")).toHaveTextContent("W");
   });
 });

--- a/packages/utilities/shared-utils/src/common/text.ts
+++ b/packages/utilities/shared-utils/src/common/text.ts
@@ -4,6 +4,18 @@ export const safeText = (text: string): string => {
   return text?.slice(0, 3);
 };
 
+export const safeInitials = (text: string): string => {
+  const initials =
+    text
+      ?.trim()
+      .split(/[\s\-_.]+/)
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase())
+      .join("") || "";
+
+  return safeText(initials);
+};
+
 export const safeAriaLabel = (...texts: any[]): string => {
   let ariaLabel = " ";
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->
#5671 
## 📝 Description
add the safeInitials function to get the initials name.
<!--- Add a brief description -->
update the getInitials
## ⛳️ Current behavior (updates)
If the name passes Jone Smith, Jon will be displayed.
<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->
If the name passes Jone Smith, JS will be displayed
## 💣 Is this a breaking change (Yes/No):
No.
<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
