### PR TITLE
docs: update component example to use ref prop instead of forward-ref

### DIFF
--- a/apps/docs/content/docs/design-principles.mdx
+++ b/apps/docs/content/docs/design-principles.mdx
@@ -184,19 +184,24 @@ Wrap, extend, and customize components to match your needs.
 
 ```tsx
 // Custom wrapper component
-const CTAButton = React.forwardRef<HTMLButtonElement, CTAButtonProps>(
-  ({ intent = 'primary-cta', children, ...props }, ref) => {
-    const variantMap = {
-      'primary-cta': 'primary',
-      'secondary-cta': 'secondary',
-      'minimal': 'ghost'
-    };
+const CTAButton = ({
+  intent = 'primary-cta',
+  children,
+  ref,
+  ...props
+}: CTAButtonProps) => {
+  const variantMap = {
+    'primary-cta': 'primary',
+    'secondary-cta': 'secondary',
+    'minimal': 'ghost'
+  };
 
-    return <Button ref={ref} variant={variantMap[intent]} {...props}>
+  return (
+    <Button ref={ref} variant={variantMap[intent]} {...props}>
       {children}
-    </Button>;
-  }
-);
+    </Button>
+  );
+};
 ```
 
 Or extend with Tailwind Variants:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Update component example to use ref prop instead of `forwardRef`

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

<img width="1496" height="949" alt="image" src="https://github.com/user-attachments/assets/5c46c010-5f78-42be-8d86-d0bceb00737b" />
