### PR TITLE
fix(number-input): backspace behavior with formatted numbers

### DIFF
--- a/.changeset/gentle-owls-arrive.md
+++ b/.changeset/gentle-owls-arrive.md
@@ -1,0 +1,5 @@
+---
+"@heroui/number-input": patch
+---
+
+fix backspace behavior with formatted numbers (#5712)

--- a/packages/components/number-input/__tests__/number-input.test.tsx
+++ b/packages/components/number-input/__tests__/number-input.test.tsx
@@ -592,5 +592,63 @@ describe("NumberInput with React Hook Form", () => {
         await user.keyboard("1234");
       });
     });
+
+    describe("Backspace behavior with formatted numbers", () => {
+      it("should handle backspace when cursor is between first digit and comma", async () => {
+        const {container} = render(
+          <NumberInput
+            defaultValue={1234}
+            formatOptions={{
+              style: "decimal",
+              useGrouping: true,
+            }}
+            label="test number input"
+          />,
+        );
+
+        const input = container.querySelector("input[type='text']") as HTMLInputElement;
+
+        expect(input.value).toBe("1,234");
+
+        act(() => {
+          input.focus();
+          input.setSelectionRange(1, 1);
+        });
+
+        act(() => {
+          fireEvent.keyDown(input, {key: "Backspace", code: "Backspace"});
+        });
+
+        expect(input.value).toBe("234");
+      });
+
+      it("should handle backspace for other formatted number scenarios", async () => {
+        const {container} = render(
+          <NumberInput
+            defaultValue={1234567}
+            formatOptions={{
+              style: "decimal",
+              useGrouping: true,
+            }}
+            label="test number input"
+          />,
+        );
+
+        const input = container.querySelector("input[type='text']") as HTMLInputElement;
+
+        expect(input.value).toBe("1,234,567");
+
+        act(() => {
+          input.focus();
+          input.setSelectionRange(5, 5);
+        });
+
+        act(() => {
+          fireEvent.keyDown(input, {key: "Backspace", code: "Backspace"});
+        });
+
+        expect(input.value).toBe("123,567");
+      });
+    });
   });
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5712

## 📝 Description

<!--- Add a brief description -->

The problem occurred when the cursor was  positioned between the first digit and the first comma in a formatted number (e.g., between "1" and "," in "1,234"). Pressing backspace in this position would do nothing.

This PR is to add the handling for such case.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
