### PR TITLE
Update switch component styles

### DIFF
--- a/packages/react/src/components/switch/switch.styles.ts
+++ b/packages/react/src/components/switch/switch.styles.ts
@@ -13,9 +13,9 @@ export const switchVariants = tv({
       "transition-all duration-200",
       focusRingClasses,
       // Default (off) state
-      "border-muted/30 bg-muted/20",
+      "border-default/30 bg-default",
       // Hover state (off)
-      "group-data-[hovered=true]:border-muted/40 group-data-[hovered=true]:bg-muted/30",
+      "group-data-[hovered=true]:border-default/40 group-data-[hovered=true]:bg-default/90",
       // Pressed state
       "group-data-[pressed=true]:scale-[0.97]",
       // Selected (on) state
@@ -27,15 +27,15 @@ export const switchVariants = tv({
       "group-data-[focus-visible=true]:border-foreground/60",
       // Disabled state
       "group-data-[disabled=true]:cursor-not-allowed group-data-[disabled=true]:opacity-[var(--disabled-opacity)]",
-      "group-data-[disabled=true]:group-data-[hovered=true]:border-muted/30",
+      "group-data-[disabled=true]:group-data-[hovered=true]:border-default/30",
     ],
     thumb: [
       "absolute left-0.5 block h-4 w-4",
-      "rounded-full bg-white",
+      "bg-default-foreground/20 rounded-full",
       "shadow-sm",
       "transition-transform duration-200",
-      // Selected (on) state - move thumb to right
-      "group-data-[selected=true]:translate-x-5",
+      // Selected (on) state - move thumb to right and change color
+      "group-data-[selected=true]:bg-accent-foreground group-data-[selected=true]:translate-x-5",
       // Pressed state
       "group-data-[pressed=true]:w-5 group-data-[selected=true]:group-data-[pressed=true]:translate-x-4",
     ],


### PR DESCRIPTION
Closes #

## 📝 Description

Updates the styling of the switch component to align with new design specifications, primarily focusing on background and thumb colors for both off and on states.

## ⛳️ Current behavior (updates)

-   **Off state**: Background was `bg-muted/20` with `border-muted/30`. The thumb was `bg-white`.
-   **On state**: The thumb was `bg-white`.

## 🚀 New behavior

-   **Off state**: Background is now `bg-default` with `border-default/30`. The thumb is `bg-default-foreground/20` (20% opacity). Hover states also updated to use `default` variants.
-   **On state**: The thumb is now `bg-accent-foreground`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The original request mentioned icon color updates, but the current switch component implementation does not include built-in icons. This PR addresses the background and thumb color updates as specified.

---
[Slack Thread](https://heroui.slack.com/archives/C09G6GFJV7G/p1758314320074359?thread_ts=1758314320.074359&cid=C09G6GFJV7G)

<a href="https://cursor.com/background-agent?bcId=bc-78fd4cc1-b6c2-4878-bc25-3ebf04f2691b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78fd4cc1-b6c2-4878-bc25-3ebf04f2691b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

