### PR TITLE
docs(popover): update shouldCloseOnScroll default to true

### DIFF
--- a/apps/docs/content/docs/components/popover.mdx
+++ b/apps/docs/content/docs/components/popover.mdx
@@ -262,7 +262,7 @@ You can customize the `Popover` component by passing custom Tailwind CSS classes
       attribute: "shouldCloseOnScroll",
       type: "boolean",
       description: "Whether the popover should close on scroll.",
-      default: "false"
+      default: "true"
     },
     {
       attribute: "isKeyboardDismissDisabled",


### PR DESCRIPTION
## 📝 Description

In `popover` docs, the prop `shouldCloseOnScroll` default is false, but it's actually true, based on [this code](https://github.com/heroui-inc/heroui/blob/27c512972a533a66a8e3362a9f9de293deca1a75/packages/components/popover/src/use-aria-popover.ts#L74) and the `use-aria-popover.d.ts` types provided (same applies to Select `popoverProps`):
<img width="566" height="193" alt="image" src="https://github.com/user-attachments/assets/453c4890-3f08-454f-bac1-fe757015fbde" /> 

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

- Default is `false` in the site docs

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

- Changing the default to true in the site docs
<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

- No

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information

Running localhost:
<img width="792" height="107" alt="image" src="https://github.com/user-attachments/assets/294a4497-2f10-43a7-a45d-f8f079572031" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Popover component docs to reflect the new default behavior: shouldCloseOnScroll now defaults to true.
  * Clarified the API table to help users understand scroll-to-close behavior without additional configuration.
  * Improved accuracy and alignment between documented defaults and actual component behavior for a smoother integration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->