### PR TITLE
fix(autocomplete): duplicate id in clear & selector button

### DIFF
--- a/.changeset/slow-maps-confess.md
+++ b/.changeset/slow-maps-confess.md
@@ -1,0 +1,5 @@
+---
+"@heroui/autocomplete": patch
+---
+
+duplicate id in clear & selector button in autocomplete (#5738)

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -446,7 +446,9 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   const getClearButtonProps = () =>
     ({
-      ...mergeProps(buttonProps, slotsProps.clearButtonProps),
+      ...slotsProps.clearButtonProps,
+      preventFocusOnPress: true,
+      excludeFromTabOrder: true,
       // disable original focus and state toggle from react aria
       onPressStart: () => {
         // this is in PressStart for mobile so that touching the clear button doesn't remove focus from


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5738

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Autocomplete: Fixed duplicate ID on clear and selector buttons to avoid accessibility and interaction conflicts.
  - Updated clear button behavior to not take focus on press and be skipped in tab order, improving keyboard navigation. No visual changes.
- Chores
  - Added changeset for a patch release of @heroui/autocomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->