### PR TITLE
fix(system-rsc): incorrect typing in extendVariants

### DIFF
--- a/.changeset/ten-socks-shave.md
+++ b/.changeset/ten-socks-shave.md
@@ -1,0 +1,5 @@
+---
+"@heroui/system-rsc": patch
+---
+
+fix incorrect typing when using ref (#5753) and as (#5754)

--- a/packages/core/system-rsc/src/extend-variants.d.ts
+++ b/packages/core/system-rsc/src/extend-variants.d.ts
@@ -3,7 +3,6 @@ import type {
   ForwardRefExoticComponent,
   JSXElementConstructor,
   PropsWithoutRef,
-  ReactElement,
   RefAttributes,
 } from "react";
 
@@ -78,6 +77,13 @@ export type ExtendVariantWithSlotsProps = {
   compoundVariants?: Array<Record<string, boolean | string | Record<string, string>>>;
 };
 
+type InferRef<C> =
+  C extends ForwardRefExoticComponent<RefAttributes<infer R>>
+    ? R
+    : C extends new (...args: any[]) => infer I
+      ? I
+      : any;
+
 export type ExtendVariants = {
   <
     C extends JSXElementConstructor<any>,
@@ -97,12 +103,12 @@ export type ExtendVariants = {
     },
     opts?: Options,
   ): ForwardRefExoticComponent<
-    PropsWithoutRef<{
-      [key in keyof CP | keyof V]?:
-        | (key extends keyof CP ? CP[key] : never)
-        | (key extends keyof V ? StringToBoolean<keyof V[key]> : never);
-    }> &
-      RefAttributes<ReactElement>
+    PropsWithoutRef<
+      CP & {
+        [key in keyof V]?: StringToBoolean<keyof V[key]>;
+      }
+    > &
+      RefAttributes<InferRef<C>>
   >;
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #5753
- Closes #5754
- Closes #4789

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects TypeScript typings for ref and as in @heroui/system-rsc, improving ref inference and prop compatibility for wrapped components and variant props. This enhances editor IntelliSense and prevents false type errors.

- Chores
  - Adds a changeset entry to publish a patch release of @heroui/system-rsc, documenting the fix and linking related work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->