### PR TITLE
fix(toast): trigger onClose after timeout

### DIFF
--- a/.changeset/strong-needles-kneel.md
+++ b/.changeset/strong-needles-kneel.md
@@ -1,0 +1,5 @@
+---
+"@heroui/toast": patch
+---
+
+trigger onClose after toast timeout (#5609)

--- a/packages/components/toast/__tests__/toast.test.tsx
+++ b/packages/components/toast/__tests__/toast.test.tsx
@@ -174,4 +174,69 @@ describe("Toast", () => {
 
     expect(loadingIcon).toBeTruthy();
   });
+
+  it("should call onClose when toast times out", async () => {
+    const onCloseMock = jest.fn();
+
+    const wrapper = render(
+      <>
+        <ToastProvider disableAnimation />
+        <button
+          data-testid="button"
+          onClick={() => {
+            addToast({
+              title: title,
+              description: description,
+              timeout: 500,
+              onClose: onCloseMock,
+            });
+          }}
+        >
+          Show Toast
+        </button>
+      </>,
+    );
+
+    const button = wrapper.getByTestId("button");
+
+    await user.click(button);
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onClose when close button is clicked", async () => {
+    const onCloseMock = jest.fn();
+
+    const wrapper = render(
+      <>
+        <ToastProvider disableAnimation maxVisibleToasts={1} />
+        <button
+          data-testid="button"
+          onClick={() => {
+            addToast({
+              title: title,
+              description: description,
+              onClose: onCloseMock,
+            });
+          }}
+        >
+          Show Toast
+        </button>
+      </>,
+    );
+
+    const button = wrapper.getByTestId("button");
+
+    await user.click(button);
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const closeButtons = wrapper.getAllByRole("button");
+
+    await user.click(closeButtons[0]);
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5609

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Ensures toast onClose is reliably invoked after auto-timeout and when manually closed.
  * Prevents duplicate onClose calls and aligns behavior with or without animations.

* Tests
  * Added coverage for onClose firing after timeout.
  * Added coverage for onClose firing on close button click.

* Chores
  * Prepared a patch release for @heroui/toast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->