### PR TITLE
fix(extendVariants): return component type error

### DIFF
--- a/.changeset/rich-horses-dress.md
+++ b/.changeset/rich-horses-dress.md
@@ -1,0 +1,5 @@
+---
+"@heroui/system-rsc": patch
+---
+
+fix extendVariants return type error(#5778)

--- a/packages/core/system-rsc/src/extend-variants.d.ts
+++ b/packages/core/system-rsc/src/extend-variants.d.ts
@@ -103,11 +103,11 @@ export type ExtendVariants = {
     },
     opts?: Options,
   ): ForwardRefExoticComponent<
-    PropsWithoutRef<
-      CP & {
-        [key in keyof V]?: StringToBoolean<keyof V[key]>;
-      }
-    > &
+    PropsWithoutRef<{
+      [key in keyof CP | keyof V]?:
+        | (key extends keyof CP ? CP[key] : never)
+        | (key extends keyof V ? StringToBoolean<keyof V[key]> : never);
+    }> &
       RefAttributes<InferRef<C>>
   >;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5778 

## 📝 Description

<!--- Add a brief description -->
Only the types related to the attributes of the returned component have been modified.
## ⛳️ Current behavior (updates)
incorrect variant type 
<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):
no
<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed a TypeScript typing issue in extendVariants that could cause return type errors (issue #5778), improving IDE IntelliSense and reducing compile-time warnings. No runtime behavior changes.
- Chores
  - Applied a patch update to the @heroui/system-rsc dependency.
  - Added a changeset entry documenting the fix and release impact.
- Documentation
  - Clarified the typing adjustments to ensure more accurate prop inference for extended variants, without altering the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->