### PR TITLE
fix(a11y): resolve empty link issue in HeroUIProCallout overlay link

### DIFF
--- a/apps/docs/components/docs/heroui-pro-callout.tsx
+++ b/apps/docs/components/docs/heroui-pro-callout.tsx
@@ -16,7 +16,10 @@ export const HeroUIProCallout = () => {
   return (
     <div className="relative w-full max-w-[12rem] flex flex-col items-center border border-default/60 hover:border-default/90 rounded-xl py-6 px-2 cursor-pointer">
       <div>
-        <p className="leading-[1.025] tracking-tight text-center text-large font-semibold">
+        <p
+          className="leading-[1.025] tracking-tight text-center text-large font-semibold"
+          id="callout-title"
+        >
           Ship&nbsp;
           <span className="bg-clip-text text-transparent bg-linear-to-b from-[#5EA2EF] to-[#0072F5]">
             faster
@@ -26,7 +29,10 @@ export const HeroUIProCallout = () => {
           <br />
           components
         </p>
-        <p className="text-center text-xs mt-2 px-3 font-medium text-default-500 dark:text-default-400 leading-tight">
+        <p
+          className="text-center text-xs mt-2 px-3 font-medium text-default-500 dark:text-default-400 leading-tight"
+          id="callout-description"
+        >
           Discover 210+ stunning components by HeroUI
         </p>
       </div>
@@ -37,6 +43,7 @@ export const HeroUIProCallout = () => {
         </div>
       </div>
       <NextLink
+        aria-labelledby="callout-title callout-description"
         className="absolute inset-0 z-1"
         href="https://heroui.pro/components?utm_source=heroui.com&utm_medium=callout"
         onClick={handleClick}


### PR DESCRIPTION
Closes #5814 

## 📝 Description

Fixes an accessibility issue where the `HeroUIProCallout` component contained an empty overlay link. The `NextLink` element had a `href` but no accessible name, which causes an “Empty link” error ([WCAG 2.4.4](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)).

This update adds semantic labelling using `aria-labelledby` and improves accessibility compliance and screen reader behaviour.

## ⛳️ Current behavior (updates)

- The `HeroUIProCallout` rendered an absolutely positioned `NextLink` overlay with no text or accessible label.
- This is an “Empty link” violation.
- The clickable area still worked visually but was not correctly announced by screen readers.

## 🚀 New behavior

- Added `aria-labelledby` to the overlay link, referencing the title and description inside the card.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Verified using the WAVE tool. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support by associating the callout link with labeled title and description via aria-labelledby, using newly added, unique IDs for those texts.
* **Style**
  * Enhanced callout copy by adding “with beautiful” and inserting line breaks for better readability.
  * Visual and content updates only; no changes to the component’s public API or behavior beyond improved labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->