### PR TITLE
fix(a11y): increase sidebar text contrast to meet WCAG AA accessibility

### DIFF
--- a/apps/docs/components/docs/toc.tsx
+++ b/apps/docs/components/docs/toc.tsx
@@ -89,7 +89,7 @@ export const DocsToc: FC<DocsTocProps> = ({headings}) => {
                   className={clsx(
                     "transition-colors",
                     "font-normal",
-                    "flex items-center text-tiny font-normal text-default-500 dark:text-default-300",
+                    "flex items-center text-tiny font-normal text-default-500",
                     "data-[active=true]:text-foreground",
                     "dark:data-[active=true]:text-foreground",
                     "before:content-['']",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5818 

## 📝 Description

This PR fixes a low-contrast accessibility issue in the `On this page` side navigation of HeroUI docs.
Inactive sidebar link text previously had insufficient contrast against dark backgrounds, failing WCAG 2.1 Level AA requirements.
The colour has been updated to provide a compliant contrast ratio for improved readability and accessibility.

## ⛳️ Current behavior (updates)

Non-active (unselected) links use the light gray `(hsl(--heroui-default-300)` colour, resulting in a contrast ratio of ~2.6:1 against the dark background, which fails WCAG 2.1 Level AA accessibility standards for normal text.

## 🚀 New behavior

Updated the colour to `text-default-500` for both light and dark modes, resulting in a contrast ratio of 7.8 : 1, meeting WCAG 2.1 AA guidelines for normal text.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Before:

<img width="292" height="463" alt="Screenshot 2025-10-17 at 12 02 35 AM" src="https://github.com/user-attachments/assets/f7874671-b48b-4e4d-b86d-86f83a94793e" />

After

<img width="303" height="464" alt="Screenshot 2025-10-17 at 12 01 45 AM" src="https://github.com/user-attachments/assets/16a88ea1-c73f-4444-80f8-6000589c9e8b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the dark mode styling of the documentation table of contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->