### PR TITLE
fix(heroui-table): update virtualization examples to use @heroui/reac…

### DIFF
--- a/apps/docs/content/components/table/virtualization-custom-max-table-height.raw.jsx
+++ b/apps/docs/content/components/table/virtualization-custom-max-table-height.raw.jsx
@@ -1,4 +1,4 @@
-import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@nextui-org/react";
+import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@heroui/react";
 
 function generateRows(count) {
   return Array.from({length: count}, (_, index) => ({

--- a/apps/docs/content/components/table/virtualization-custom-row-height.raw.jsx
+++ b/apps/docs/content/components/table/virtualization-custom-row-height.raw.jsx
@@ -1,4 +1,4 @@
-import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@nextui-org/react";
+import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@heroui/react";
 
 function generateRows(count) {
   return Array.from({length: count}, (_, index) => ({

--- a/apps/docs/content/components/table/virtualization-ten-thousand.raw.jsx
+++ b/apps/docs/content/components/table/virtualization-ten-thousand.raw.jsx
@@ -1,4 +1,4 @@
-import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@nextui-org/react";
+import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@heroui/react";
 
 function generateRows(count) {
   return Array.from({length: count}, (_, index) => ({

--- a/apps/docs/content/components/table/virtualization.raw.jsx
+++ b/apps/docs/content/components/table/virtualization.raw.jsx
@@ -1,4 +1,4 @@
-import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@nextui-org/react";
+import {Table, TableBody, TableCell, TableColumn, TableHeader, TableRow} from "@heroui/react";
 
 function generateRows(count) {
   return Array.from({length: count}, (_, index) => ({


### PR DESCRIPTION
Closes #5832

## 📝 Description

This pull request updates the imports of virtualization components. Previously, the components were incorrectly importing from `@nextui-org/react`. All imports have now been updated to `@heroui/react` to align with the current HeroUI package structure. This ensures consistency and resolves potential issues caused by incorrect imports.

## ⛳️ Current behavior (updates)

Before the fix, virtualization components were importing from `@nextui-org/react`, which could cause unexpected behavior or errors.

**Before:**  
<img width="1366" height="721" alt="Before fixing imports" src="https://github.com/user-attachments/assets/da55e939-082d-4a73-acad-b5fe25e628f7" />

## 🚀 New behavior

After this fix, all virtualization components correctly import from `@heroui/react`, ensuring proper functionality and consistency across the project.

**After:**  
<img width="1366" height="720" alt="After fixing imports" src="https://github.com/user-attachments/assets/21bf3ecf-1182-4792-adc1-70227112b638" />

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

No additional information. Images above illustrate the issue and the resolved state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation examples for table virtualization features across multiple sample files to align with current library dependencies. All component functionality, rendering logic, and demonstrated capabilities remain identical. Examples continue to accurately showcase table virtualization configuration options and performance patterns without changes to actual behavior or component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->