### PR TITLE
fix(codeblock): codeblock flickering issue

### DIFF
--- a/apps/docs/components/docs/components/codeblock.tsx
+++ b/apps/docs/components/docs/components/codeblock.tsx
@@ -124,18 +124,10 @@ const CodeBlockHighlight = ({
                   preRef.current = element;
                 }
               }}
-              // eslint-disable-next-line prettier/prettier
-              className={clsx(
-                className,
-                classNameProp,
-                `language-${codeLang}`,
-                "max-w-full",
-                {
+              className={clsx(className, classNameProp, `language-${codeLang}`, "max-w-full", {
                 "flex-col": isMultiLine,
                 "overflow-x-scroll scrollbar-hide": hideScrollBar,
-                // eslint-disable-next-line prettier/prettier
-                },
-              )}
+              })}
               data-language={language}
               style={style}
             >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes [Issue](https://github.com/heroui-inc/heroui/issues/5844)

## 📝 Description
When scrolling inside the Code tab of the any component section on the documentation page, the content flickers or flashes repeatedly.

## ⛳️ Current behavior (updates)

It does not allows users to scroll smoothly.

## 🚀 New behavior

The code block now scroll smoothly with no flickering or repaint artifacts.

## 💣 Is this a breaking change (Yes/No):

No

https://github.com/user-attachments/assets/502c888d-65d2-41d5-bcaf-d179266ac70c



## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Minor adjustment to code block rendering to more consistently preserve layout and horizontal scrolling for long lines by removing an unnecessary container class.

* **Style**
  * Tweaked code block container classes to refine overflow handling and whitespace preservation for improved readability without changing syntax highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->