### PR TITLE
build(react): reorder package.json exports fields for consistency

### DIFF
--- a/packages/react/clean-package.config.json
+++ b/packages/react/clean-package.config.json
@@ -8,8 +8,8 @@
     "sideEffects": false,
     "exports": {
       ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       },
       "./styles": {
         "style": "./dist/styles.css",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,8 +31,8 @@
     },
     "./package.json": "./package.json",
     "./styles": {
-      "default": "./src/styles.css",
-      "style": "./src/styles.css"
+      "style": "./src/styles.css",
+      "default": "./src/styles.css"
     }
   },
   "repository": {

--- a/packages/react/scripts/generate-exports.mjs
+++ b/packages/react/scripts/generate-exports.mjs
@@ -17,13 +17,13 @@ async function generateExports() {
   // Start with base exports
   const exports = {
     ".": {
-      import: "./dist/index.js",
       types: "./dist/index.d.ts",
+      import: "./dist/index.js",
     },
     "./package.json": "./package.json",
     "./styles": {
-      default: "./dist/styles.css",
       style: "./dist/styles.css",
+      default: "./dist/styles.css",
     },
   };
 
@@ -46,8 +46,8 @@ async function generateExports() {
 
         // Add export for this component
         exports[`./${item}`] = {
-          import: `./dist/components/${item}/index.js`,
           types: `./dist/components/${item}/index.d.ts`,
+          import: `./dist/components/${item}/index.js`,
         };
       }
     }

--- a/packages/react/scripts/remove-exports.mjs
+++ b/packages/react/scripts/remove-exports.mjs
@@ -21,8 +21,8 @@ async function removeExports() {
     },
     "./package.json": "./package.json",
     "./styles": {
-      default: "./src/styles.css",
       style: "./src/styles.css",
+      default: "./src/styles.css",
     },
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

<!-- No specific issue - this is a proactive code quality improvement -->

## 📝 Description

Reorder `package.json` exports fields for consistency across the `@heroui/react` package.
This change ensures that `types` is always placed first and `default` is always placed last in the exports field ordering, following Node.js package exports best practices.

## ⛳️ Current behavior (updates)

The exports fields in `package.json` and related build scripts had inconsistent ordering:
- Some entries had `import` before `types`
- Some entries had `default` before `style`

## 🚀 New behavior

All exports fields now follow a consistent ordering convention:
- `types` always comes first (for better TypeScript resolution)
- `default` always comes last (as per Node.js resolution algorithm best practices)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This change improves consistency across the codebase and follows the official Node.js package exports best practices as documented at [https://nodejs.org/api/packages.html](https://nodejs.org/api/packages.html).

1. **`types`**
   > "types" - can be used by typing systems to resolve the typing file for the given export. *This condition should always be included first*.

2. **`default`**
   > "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. *This condition should always come last*.
