### PR TITLE
build(react): reorder package.json exports fields for consistency

### DIFF
--- a/packages/react/clean-package.config.json
+++ b/packages/react/clean-package.config.json
@@ -8,8 +8,8 @@
     "sideEffects": false,
     "exports": {
       ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
       },
       "./styles": {
         "style": "./dist/styles.css",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,8 +31,8 @@
     },
     "./package.json": "./package.json",
     "./styles": {
-      "default": "./src/styles.css",
-      "style": "./src/styles.css"
+      "style": "./src/styles.css",
+      "default": "./src/styles.css"
     }
   },
   "repository": {

--- a/packages/react/scripts/generate-exports.mjs
+++ b/packages/react/scripts/generate-exports.mjs
@@ -17,13 +17,13 @@ async function generateExports() {
   // Start with base exports
   const exports = {
     ".": {
-      import: "./dist/index.js",
       types: "./dist/index.d.ts",
+      import: "./dist/index.js",
     },
     "./package.json": "./package.json",
     "./styles": {
-      default: "./dist/styles.css",
       style: "./dist/styles.css",
+      default: "./dist/styles.css",
     },
   };
 
@@ -46,8 +46,8 @@ async function generateExports() {
 
         // Add export for this component
         exports[`./${item}`] = {
-          import: `./dist/components/${item}/index.js`,
           types: `./dist/components/${item}/index.d.ts`,
+          import: `./dist/components/${item}/index.js`,
         };
       }
     }

--- a/packages/react/scripts/remove-exports.mjs
+++ b/packages/react/scripts/remove-exports.mjs
@@ -21,8 +21,8 @@ async function removeExports() {
     },
     "./package.json": "./package.json",
     "./styles": {
-      default: "./src/styles.css",
       style: "./src/styles.css",
+      default: "./src/styles.css",
     },
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Reorder `package.json` exports fields for consistency across the `@heroui/react` package.
This change ensures that `types` is always placed first and `default` is always placed last in the exports field ordering, following Node.js package exports best practices.

## ⛳️ Current behavior (updates)

The exports fields in `package.json` and related build scripts had inconsistent ordering:
- Some entries had `import` before `types`
- Some entries had `default` before `style`

## 🚀 New behavior

All exports fields now follow a consistent ordering convention:
- `types` always comes first (for better TypeScript resolution)
- `default` always comes last (as per Node.js resolution algorithm best practices)

<details>
<summary><code>package.json</code> after running <code>cd packages/react && pnpm turbo run build && pnpm run prepack</code></summary>

```json
{
  "name": "@heroui/react",
  "version": "3.0.0-alpha.35",
  "description": "🚀 Beautiful and modern React UI library built with Tailwind CSS 4.0.",
  "license": "MIT",
  "type": "module",
  "sideEffects": false,
  "main": "./dist/index.js",
  "module": "./dist/index.js",
  "types": "./dist/index.d.ts",
  "author": "HeroUI <support@heroui.com>",
  "homepage": "https://heroui.com",
  "keywords": [
    "next",
    "next ui",
    "hero ui",
    "components",
    "modern components",
    "react components",
    "react ui"
  ],
  "files": [
    "dist"
  ],
  "publishConfig": {
    "access": "public"
  },
  "exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "import": "./dist/index.js"
    },
    "./styles": {
      "style": "./dist/styles.css",
      "default": "./dist/styles.css"
    },
    "./package.json": "./package.json"
  },
  "repository": {
    "type": "git",
    "url": "git+https://github.com/heroui-inc/heroui.git",
    "directory": "packages/react"
  },
  "bugs": {
    "url": "https://github.com/heroui-inc/heroui/issues"
  },
  "dependencies": {
    "@internationalized/date": "3.10.0",
    "@radix-ui/react-avatar": "1.1.10",
    "@radix-ui/react-slot": "1.2.3",
    "@react-aria/ssr": "3.9.10",
    "@react-aria/utils": "3.31.0",
    "@react-types/shared": "3.32.1",
    "clsx": "2.1.1",
    "input-otp": "1.4.2",
    "react-aria-components": "1.13.0",
    "tailwind-merge": "3.3.1",
    "tailwind-variants": "3.1.1"
  },
  "peerDependencies": {
    "react": ">=19.0.0",
    "react-dom": ">=19.0.0",
    "tailwindcss": ">=4.0.0"
  }
}
```

</details>

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This change improves consistency across the codebase and follows the official Node.js package exports best practices as documented at [https://nodejs.org/api/packages.html](https://nodejs.org/api/packages.html).

1. **`types`**
   > "types" - can be used by typing systems to resolve the typing file for the given export. *This condition should always be included first*.

2. **`default`**
   > "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. *This condition should always come last*.
