### PR TITLE
fix(docs): submenu selected item indicator

### DIFF
--- a/apps/docs/components/docs/toc.tsx
+++ b/apps/docs/components/docs/toc.tsx
@@ -87,6 +87,7 @@ export const DocsToc: FC<DocsTocProps> = ({headings}) => {
                 <li
                   key={i}
                   className={clsx(
+                    "relative",
                     "transition-colors",
                     "font-normal",
                     "flex items-center text-tiny font-normal text-default-500",


### PR DESCRIPTION
## 📝 Description

aligned the selected menu item and the indicator

## ⛳️ Current behavior (updates)

On scroll, the indicator of the selected item moves

## 🚀 New behavior

On scroll, the indicator of the selected item is fixed beside the item

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout positioning in the documentation table of contents for nested headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->