### PR TITLE
fix(table): fix broken sorting test that never validated behavior

### DIFF
--- a/packages/components/table/__tests__/table.test.tsx
+++ b/packages/components/table/__tests__/table.test.tsx
@@ -256,32 +256,49 @@ describe("Table", () => {
   });
 
   it("should set the proper aria-sort on an ascending sorted column header", async () => {
-    const wrapper = render(
-      <Table aria-label="Static Table">
-        <TableHeader>
-          <TableColumn allowsSorting data-testid="test-sort-column">
-            Foo
-          </TableColumn>
-          <TableColumn>Bar</TableColumn>
-          <TableColumn>Baz</TableColumn>
-        </TableHeader>
-        <TableBody>
-          <TableRow>
-            <TableCell>Foo 1</TableCell>
-            <TableCell>Bar 1</TableCell>
-            <TableCell>Baz 1</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>,
-    );
+    const TestTable = () => {
+      const [sortDescriptor, setSortDescriptor] = React.useState<
+        | {
+            column: React.Key;
+            direction: "ascending" | "descending";
+          }
+        | undefined
+      >(undefined);
+
+      return (
+        <Table
+          aria-label="Static Table"
+          sortDescriptor={sortDescriptor}
+          onSortChange={(descriptor) => setSortDescriptor(descriptor)}
+        >
+          <TableHeader>
+            <TableColumn allowsSorting data-testid="test-sort-column">
+              Foo
+            </TableColumn>
+            <TableColumn>Bar</TableColumn>
+            <TableColumn>Baz</TableColumn>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>Foo 1</TableCell>
+              <TableCell>Bar 1</TableCell>
+              <TableCell>Baz 1</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      );
+    };
+
+    const wrapper = render(<TestTable />);
 
     const column = wrapper.getByTestId("test-sort-column");
 
     expect(column).toHaveAttribute("aria-sort", "none");
 
-    act(async () => {
-      await userEvent.click(column);
-      expect(column).toHaveAttribute("aria-sort", "ascending");
+    await act(async () => {
+      await user.click(column);
     });
+
+    expect(column).toHaveAttribute("aria-sort", "ascending");
   });
 });


### PR DESCRIPTION
Closes #

## 📝 Description
Fixed the table sorting test which was not properly validating the sorting behavior.

## ⛳️ Current behavior (updates)
The test appeared to pass but was actually broken - it never verified that clicking a sortable column updates the `aria-sort` attribute. The test used an uncontrolled pattern without `sortDescriptor`/`onSortChange`, which doesn't work with React Aria/Stately.

```
console.log("Before click - aria-sort:", column.getAttribute("aria-sort")); // aria-sort = "none" ⭕️
    expect(column).toHaveAttribute("aria-sort", "none");

    act(async () => {
      await userEvent.click(column);
      console.log("After click inside act - aria-sort:", column.getAttribute("aria-sort")); // no tests 💀
      expect(column).toHaveAttribute("aria-sort", "ascending");
    });

    console.log("After act - aria-sort:", column.getAttribute("aria-sort")); // aria-sort = "none" ❌
  });

```
<img width="854" height="573" alt="スクリーンショット 2025-11-17 1 35 30" src="https://github.com/user-attachments/assets/b80716ec-082e-4423-9978-1d1a808119ff" />

## 🚀 New behavior
The test now correctly implements controlled sorting and properly validates that clicking a column header updates the `aria-sort` attribute from "none" to "ascending".

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
