### PR TITLE
fix(tooltip): prevent tooltip from staying visible when clicking triggers that open overlays

### DIFF
--- a/.changeset/tooltip-popover-fix.md
+++ b/.changeset/tooltip-popover-fix.md
@@ -1,0 +1,5 @@
+---
+"@heroui/react": patch
+---
+
+Fixed tooltip staying visible when clicking buttons that open overlays (popovers, menus, dialogs). Tooltips now properly close and stay closed for 500ms to prevent race condition with React Aria's reopen behavior.

--- a/packages/react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/react/src/components/tooltip/tooltip.stories.tsx
@@ -4,6 +4,7 @@ import {Icon} from "@iconify/react";
 import React from "react";
 
 import {Button} from "../button";
+import {Popover} from "../popover";
 
 import {Tooltip} from "./index";
 
@@ -86,4 +87,41 @@ export const Default = {
 export const WithTrigger = {
   args: defaultArgs,
   render: TemplateWithTrigger,
+};
+
+// Test for issue #5912: Tooltip should close when button with popover is clicked
+const TooltipWithPopoverTemplate = (props: Tooltip["ContentProps"]) => (
+  <div className="flex flex-col items-center gap-8 p-8">
+    <div className="text-sm text-gray-600">
+      <p><strong>Test for Issue #5912:</strong></p>
+      <p>1. Hover over the button below to show tooltip</p>
+      <p>2. Click the button to open popover</p>
+      <p>3. Tooltip should close immediately (not stay visible)</p>
+    </div>
+
+    <Tooltip delay={0}>
+      <Popover>
+        <Button variant="secondary">Hover & Click Me</Button>
+        <Popover.Content className="max-w-64" placement="bottom">
+          <Popover.Dialog>
+            <Popover.Arrow />
+            <Popover.Heading>Popover Content</Popover.Heading>
+            <p className="text-sm mt-2">
+              The tooltip should have closed when you clicked the button!
+              If you can still see the tooltip, the bug is NOT fixed.
+            </p>
+          </Popover.Dialog>
+        </Popover.Content>
+      </Popover>
+      <Tooltip.Content {...props}>
+        <Tooltip.Arrow />
+        <p>This tooltip should close on click</p>
+      </Tooltip.Content>
+    </Tooltip>
+  </div>
+);
+
+export const WithPopover = {
+  args: defaultArgs,
+  render: TooltipWithPopoverTemplate,
 };

--- a/packages/react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/react/src/components/tooltip/tooltip.stories.tsx
@@ -67,7 +67,7 @@ const TemplateWithTrigger = (props: Tooltip["ContentProps"]) => (
   <div className="flex items-center gap-3">
     <Tooltip delay={0}>
       <Tooltip.Trigger aria-label="Tooltip trigger">
-        <div className="bg-accent-soft rounded-full p-2">
+        <div className="rounded-full bg-accent-soft p-2">
           <Icon icon="gravity-ui:circle-info" />
         </div>
       </Tooltip.Trigger>
@@ -89,33 +89,25 @@ export const WithTrigger = {
   render: TemplateWithTrigger,
 };
 
-// Test for issue #5912: Tooltip should close when button with popover is clicked
 const TooltipWithPopoverTemplate = (props: Tooltip["ContentProps"]) => (
-  <div className="flex flex-col items-center gap-8 p-8">
-    <div className="text-sm text-gray-600">
-      <p><strong>Test for Issue #5912:</strong></p>
-      <p>1. Hover over the button below to show tooltip</p>
-      <p>2. Click the button to open popover</p>
-      <p>3. Tooltip should close immediately (not stay visible)</p>
-    </div>
-
+  <div className="flex items-center gap-3">
     <Tooltip delay={0}>
       <Popover>
-        <Button variant="secondary">Hover & Click Me</Button>
-        <Popover.Content className="max-w-64" placement="bottom">
+        <Button variant="secondary">
+          <Icon icon="gravity-ui:gear" />
+          Settings
+        </Button>
+        <Popover.Content className="w-64" placement="bottom">
           <Popover.Dialog>
             <Popover.Arrow />
-            <Popover.Heading>Popover Content</Popover.Heading>
-            <p className="text-sm mt-2">
-              The tooltip should have closed when you clicked the button!
-              If you can still see the tooltip, the bug is NOT fixed.
-            </p>
+            <Popover.Heading>Settings</Popover.Heading>
+            <p className="mt-2 text-sm">Configure your preferences</p>
           </Popover.Dialog>
         </Popover.Content>
       </Popover>
       <Tooltip.Content {...props}>
         <Tooltip.Arrow />
-        <p>This tooltip should close on click</p>
+        <p>Open settings</p>
       </Tooltip.Content>
     </Tooltip>
   </div>

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -35,10 +35,31 @@ const TooltipRoot = ({
   ...props
 }: React.ComponentProps<typeof TooltipTriggerPrimitive>) => {
   const slots = React.useMemo(() => tooltipVariants(), []);
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  // Intercept clicks on any child element to close the tooltip
+  const handleClick = React.useCallback((e: React.MouseEvent) => {
+    // Close tooltip when any child is clicked
+    // This fixes the issue where tooltip stays open when clicking a button with popover
+    if (rootRef.current && rootRef.current.contains(e.target as Node)) {
+      // Dispatch a mouseLeave event to trigger React Aria's tooltip close logic
+      const mouseLeaveEvent = new MouseEvent('mouseleave', { bubbles: true, cancelable: true });
+      e.currentTarget.dispatchEvent(mouseLeaveEvent);
+    }
+  }, []);
+
+  const contextValue = React.useMemo(() => ({
+    slots,
+  }), [slots]);
 
   return (
-    <TooltipContext value={{slots}}>
-      <TooltipTriggerPrimitive data-slot="tooltip-root" {...props}>
+    <TooltipContext value={contextValue}>
+      <TooltipTriggerPrimitive
+        ref={rootRef}
+        data-slot="tooltip-root"
+        {...props}
+        onClick={handleClick}
+      >
         {children}
       </TooltipTriggerPrimitive>
     </TooltipContext>

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -41,27 +41,28 @@ const TooltipRoot = ({
   const [internalIsOpen, setInternalIsOpen] = React.useState(false);
   const clearTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
-  // Intercept onOpenChange to implement "close and stay closed" behavior
-  // This fixes issue #5912 where tooltips stay open when clicking buttons with popovers
+  // Prevent tooltip from immediately reopening after close.
+  // Fixes issue where tooltips stay visible when clicking triggers that open overlays.
+  // See: https://github.com/heroui-inc/heroui/issues/5912
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
       if (open) {
-        // Tooltip wants to open
         if (forceHide) {
-          // We're in force-hide mode - block reopening
+          // Block reopening while in force-hide mode
           setInternalIsOpen(false);
 
           return;
         }
-        // Allow normal open
         setInternalIsOpen(true);
         setForceHide(false);
       } else {
-        // Tooltip is closing - enter force-hide mode to prevent immediate reopening
+        // Enter force-hide mode to prevent immediate reopening
         setInternalIsOpen(false);
         setForceHide(true);
 
-        // Clear force-hide after a delay to allow normal tooltip behavior on next hover
+        // Clear force-hide after 500ms to restore normal tooltip behavior.
+        // This delay is long enough to prevent the race condition but short
+        // enough to not impact user experience on subsequent hovers.
         if (clearTimeoutRef.current) {
           clearTimeout(clearTimeoutRef.current);
         }


### PR DESCRIPTION
## Description

Fixes #5912 

This PR resolves an issue where tooltips remain visible when clicking a button that opens other overlays (popovers, menus, dialogs, etc.).

## The Problem

When a user:
1. Hovers over a button with a tooltip (tooltip shows)
2. Clicks the button to open a popover
3. The tooltip stays visible, overlapping the popover content

This happens because React Aria attempts to reopen the tooltip immediately after it closes (since the mouse is still hovering), creating a race condition.

## The Solution

Implements a "force-hide" mechanism that:
- Closes the tooltip when clicked
- Prevents immediate reopening for 500ms
- Allows normal tooltip behavior after the delay

The fix uses React Aria's official controlled state API (`isOpen`/`onOpenChange`) and is completely generic—it works with all overlays (popovers, menus, dialogs) and any click action.

## Changes

- **tooltip.tsx**: Added controlled state management with force-hide logic
- **tooltip.stories.tsx**: Added `WithPopover` story demonstrating the fix

## Testing

Test in Storybook:
1. Navigate to **Components/Overlays/Tooltip → WithPopover**
2. Hover over the Settings button (tooltip appears)
3. Click the button (popover opens, tooltip closes immediately)
4. ✅ Tooltip should not overlap the popover

## Notes

- No breaking changes—backward compatible with all existing usage
- Works universally with any overlay component
- 500ms delay is long enough to prevent race condition but short enough to not impact UX