### PR TITLE
fix: update focus-visible selectors to exclude :focus state

### DIFF
--- a/packages/styles/components/accordion.css
+++ b/packages/styles/components/accordion.css
@@ -77,7 +77,7 @@
   }
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -15,7 +15,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus  state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -18,7 +18,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/close-button.css
+++ b/packages/styles/components/close-button.css
@@ -19,7 +19,7 @@
   @apply transform-gpu motion-reduce:transition-none;
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/combobox.css
+++ b/packages/styles/components/combobox.css
@@ -61,7 +61,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply ring-focus ring-offset-background rounded outline-none ring-2 ring-offset-2;
   }
@@ -94,7 +94,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply outline-none;
   }

--- a/packages/styles/components/disclosure.css
+++ b/packages/styles/components/disclosure.css
@@ -11,7 +11,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -23,7 +23,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }
@@ -53,7 +53,7 @@
   min-width: 220px;
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply outline-none;
   }

--- a/packages/styles/components/input.css
+++ b/packages/styles/components/input.css
@@ -22,7 +22,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused-field;
     border-color: var(--color-field-border-focus);
@@ -46,7 +46,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     background-color: var(--color-on-surface-focus);
   }

--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -27,7 +27,7 @@
   }
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
 

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -15,7 +15,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus  state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -107,7 +107,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
   }
 

--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -76,7 +76,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -52,7 +52,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
     border-color: var(--color-field-border-focus);
@@ -92,7 +92,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     background-color: var(--color-on-surface-focus);
   }
@@ -134,7 +134,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply outline-none;
   }

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -120,7 +120,7 @@
   }
 
   /* Focus states - comprehensive fallback */
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }

--- a/packages/styles/components/textarea.css
+++ b/packages/styles/components/textarea.css
@@ -24,7 +24,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused-field;
     border-color: var(--color-field-border-focus);
@@ -48,7 +48,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     background-color: var(--color-on-surface-focus);
   }

--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -66,7 +66,7 @@
 
   cursor: var(--cursor-interactive);
 
-  &:focus-visible,
+  &:focus-visible:not(:focus),
   &[data-focus-visible] {
     @apply status-focused;
   }


### PR DESCRIPTION
## Fix: Update focus-visible selectors to exclude :focus state

Updates `:focus-visible` selectors to `:focus-visible:not(:focus)` across 16 component CSS files to prevent focus-visible styles from applying when elements are already in the `:focus` state, avoiding style conflicts.

### Changed Files
- accordion, alert-dialog, button, close-button, combobox, disclosure, dropdown, input, link, modal, number-field, popover, select, tabs, textarea, tooltip

### Change
/* Before */
```css
&:focus-visible,
```

/* After */
```css
&:focus-visible:not(:focus)
```

This ensures focus-visible styles only apply for keyboard navigation focus, not when elements are already programmatically focused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `:focus-visible` selectors to `:focus-visible:not(:focus)` across multiple component CSS files to prevent overlap with `:focus` styles.
> 
> - **Styles**:
>   - Update focus-visible selectors to exclude `:focus` in:
>     - `accordion.css`, `alert-dialog.css`, `button.css`, `close-button.css`, `combobox.css` (trigger, popover), `disclosure.css`, `dropdown.css` (trigger, popover), `input.css`, `link.css`, `modal.css`, `number-field.css` (inc/dec buttons), `popover.css` (trigger), `select.css` (trigger, popover), `tabs.css`, `textarea.css`, `tooltip.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b25dd93ff05a2e7f9a72188370f0520eb6cf0a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->