### PR TITLE
refactor: replace react-aria-components prop types with ComponentProp…

### DIFF
--- a/apps/docs/src/components/color-swatch-picker.tsx
+++ b/apps/docs/src/components/color-swatch-picker.tsx
@@ -10,11 +10,10 @@ import {
 } from "react-aria-components";
 import {tv} from "tailwind-variants";
 
-import {composeTailwindRenderProps, focusRing} from "@/utils/compose-tw-render";
+import {composeTailwindRenderProps} from "@/utils/compose-tw-render";
 
 const itemStyles = tv({
   base: "rounded-xs relative",
-  extend: focusRing,
 });
 
 const focusIndicator = tv({

--- a/apps/docs/src/demos/select/custom-value.tsx
+++ b/apps/docs/src/demos/select/custom-value.tsx
@@ -65,7 +65,7 @@ export function CustomValue() {
               return `${selectedItems.length} users selected`;
             }
 
-            const selectedItem = users.find((user) => user.id === selectedItems[0].key);
+            const selectedItem = users.find((user) => user.id === selectedItems[0]?.key);
 
             if (!selectedItem) {
               return defaultChildren;

--- a/packages/react/src/components/accordion/accordion.tsx
+++ b/packages/react/src/components/accordion/accordion.tsx
@@ -2,12 +2,7 @@
 
 import type {AccordionVariants} from "./accordion.styles";
 import type {Booleanish} from "../../utils/assertion";
-import type {
-  ButtonProps,
-  DisclosureGroupProps,
-  DisclosurePanelProps,
-  DisclosureProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
@@ -32,7 +27,9 @@ const AccordionContext = createContext<{slots?: ReturnType<typeof accordionVaria
 /* -------------------------------------------------------------------------------------------------
  * Accordion Root
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionRootProps extends DisclosureGroupProps, AccordionVariants {}
+interface AccordionRootProps
+  extends ComponentPropsWithRef<typeof DisclosureGroup>,
+    AccordionVariants {}
 
 const AccordionRoot = ({children, className, ...originalProps}: AccordionRootProps) => {
   const [props, variantProps] = mapPropsVariants(originalProps, accordionVariants.variantKeys);
@@ -69,7 +66,7 @@ const AccordionRoot = ({children, className, ...originalProps}: AccordionRootPro
 /* -------------------------------------------------------------------------------------------------
  * AccordionItem
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionItemProps extends DisclosureProps {}
+interface AccordionItemProps extends ComponentPropsWithRef<typeof Disclosure> {}
 
 const AccordionItem = ({className, ...props}: AccordionItemProps) => {
   const {slots} = useContext(AccordionContext);
@@ -88,7 +85,7 @@ const AccordionItem = ({className, ...props}: AccordionItemProps) => {
 /* -------------------------------------------------------------------------------------------------
  * AccordionIndicator
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionIndicatorProps extends React.ComponentProps<"svg"> {
+interface AccordionIndicatorProps extends ComponentPropsWithRef<"svg"> {
   className?: string;
 }
 
@@ -125,7 +122,7 @@ const AccordionIndicator = ({children, className, ...props}: AccordionIndicatorP
 /* -------------------------------------------------------------------------------------------------
  * AccordionHeading
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionHeadingProps extends React.ComponentProps<typeof DisclosureHeading> {
+interface AccordionHeadingProps extends ComponentPropsWithRef<typeof DisclosureHeading> {
   className?: string;
 }
 
@@ -144,7 +141,7 @@ const AccordionHeading = ({className, ...props}: AccordionHeadingProps) => {
 /* -------------------------------------------------------------------------------------------------
  * AccordionTrigger
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionTriggerProps extends ButtonProps {}
+interface AccordionTriggerProps extends ComponentPropsWithRef<typeof Button> {}
 
 const AccordionTrigger = ({className, ...props}: AccordionTriggerProps) => {
   const {slots} = useContext(AccordionContext);
@@ -166,7 +163,7 @@ const AccordionTrigger = ({className, ...props}: AccordionTriggerProps) => {
 /* -------------------------------------------------------------------------------------------------
  * AccordionBody
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionBodyProps extends React.ComponentProps<"div"> {
+interface AccordionBodyProps extends ComponentPropsWithRef<"div"> {
   className?: string;
 }
 
@@ -183,7 +180,7 @@ const AccordionBody = ({children, className, ...props}: AccordionBodyProps) => {
 /* -------------------------------------------------------------------------------------------------
  * AccordionPanel
  * -----------------------------------------------------------------------------------------------*/
-interface AccordionPanelProps extends DisclosurePanelProps {}
+interface AccordionPanelProps extends ComponentPropsWithRef<typeof DisclosurePanel> {}
 
 const AccordionPanel = ({children, className, ...props}: AccordionPanelProps) => {
   const {slots} = useContext(AccordionContext);

--- a/packages/react/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/alert-dialog/alert-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {AlertDialogVariants} from "./alert-dialog.styles";
-import type {ComponentProps, HTMLAttributes, ReactNode} from "react";
+import type {ComponentPropsWithRef, HTMLAttributes, ReactNode} from "react";
 import type {
   ButtonProps as ButtonPrimitiveProps,
   DialogProps as DialogPrimitiveProps,
@@ -42,7 +42,7 @@ const AlertDialogContext = createContext<AlertDialogContext>({});
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog Root
  * -----------------------------------------------------------------------------------------------*/
-interface AlertDialogRootProps extends ComponentProps<typeof AlertDialogTriggerPrimitive> {}
+interface AlertDialogRootProps extends ComponentPropsWithRef<typeof AlertDialogTriggerPrimitive> {}
 
 const AlertDialogRoot = ({children, ...props}: AlertDialogRootProps) => {
   const alertDialogContext = useMemo<AlertDialogContext>(
@@ -84,7 +84,7 @@ const AlertDialogTrigger = ({children, className, ...props}: AlertDialogTriggerP
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog Container
  * -----------------------------------------------------------------------------------------------*/
-interface AlertDialogContainerProps extends ComponentProps<typeof ModalPrimitive> {
+interface AlertDialogContainerProps extends ComponentPropsWithRef<typeof ModalPrimitive> {
   /**
    * The placement of the alert dialog on the screen.
    * @default "auto"
@@ -98,7 +98,7 @@ interface AlertDialogContainerProps extends ComponentProps<typeof ModalPrimitive
   /**
    * Additional CSS classes to apply to the backdrop overlay.
    */
-  backdropClassName?: ComponentProps<typeof ModalOverlayPrimitive>["className"];
+  backdropClassName?: ComponentPropsWithRef<typeof ModalOverlayPrimitive>["className"];
   /**
    * Whether to close the alert dialog when the user interacts outside it.
    * Alert dialogs typically require explicit action, so this defaults to false.
@@ -194,7 +194,7 @@ const AlertDialogHeader = ({children, className, ...props}: AlertDialogHeaderPro
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog Heading
  * -----------------------------------------------------------------------------------------------*/
-interface AlertDialogHeadingProps extends ComponentProps<typeof HeadingPrimitive> {}
+interface AlertDialogHeadingProps extends ComponentPropsWithRef<typeof HeadingPrimitive> {}
 
 const AlertDialogHeading = ({children, className, ...props}: AlertDialogHeadingProps) => {
   const {slots} = useContext(AlertDialogContext);
@@ -244,7 +244,7 @@ const AlertDialogFooter = ({children, className, ...props}: AlertDialogFooterPro
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog Icon
  * -----------------------------------------------------------------------------------------------*/
-interface AlertDialogIconProps extends ComponentProps<"div"> {
+interface AlertDialogIconProps extends ComponentPropsWithRef<"div"> {
   /**
    * The semantic status of the icon, affects background color and default icon
    * @default "danger"
@@ -294,7 +294,7 @@ interface AlertDialogCloseTriggerProps {
 }
 
 interface AlertDialogCloseTrigger {
-  (props: {asChild: true} & ComponentProps<"button">): React.JSX.Element;
+  (props: {asChild: true} & ComponentPropsWithRef<"button">): React.JSX.Element;
   (props: {asChild?: false} & ButtonPrimitiveProps): React.JSX.Element;
 }
 

--- a/packages/react/src/components/alert/alert.tsx
+++ b/packages/react/src/components/alert/alert.tsx
@@ -2,6 +2,7 @@
 
 import type {AlertVariants} from "./alert.styles";
 import type {SurfaceVariants} from "../surface";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import React, {createContext, useContext} from "react";
@@ -24,7 +25,7 @@ const AlertContext = createContext<AlertContext>({});
 /* ------------------------------------------------------------------------------------------------
  * Alert Root
  * --------------------------------------------------------------------------------------------- */
-interface AlertRootProps extends React.ComponentProps<"div">, AlertVariants {
+interface AlertRootProps extends ComponentPropsWithRef<"div">, AlertVariants {
   asChild?: boolean;
 }
 
@@ -50,7 +51,7 @@ const AlertRoot = ({asChild, children, className, status, ...rest}: AlertRootPro
 /* ------------------------------------------------------------------------------------------------
  * Alert Indicator
  * --------------------------------------------------------------------------------------------- */
-type AlertIndicatorProps = React.ComponentProps<"div"> & {
+type AlertIndicatorProps = ComponentPropsWithRef<"div"> & {
   asChild?: boolean;
 };
 
@@ -84,7 +85,7 @@ const AlertIndicator = ({asChild, children, className, ...rest}: AlertIndicatorP
 /* ------------------------------------------------------------------------------------------------
  * Alert Content
  * --------------------------------------------------------------------------------------------- */
-type AlertContentProps = React.ComponentProps<"div"> & {
+type AlertContentProps = ComponentPropsWithRef<"div"> & {
   asChild?: boolean;
 };
 
@@ -102,7 +103,7 @@ const AlertContent = ({asChild, children, className, ...rest}: AlertContentProps
 /* ------------------------------------------------------------------------------------------------
  * Alert Title
  * --------------------------------------------------------------------------------------------- */
-type AlertTitleProps = React.ComponentProps<"p"> & {
+type AlertTitleProps = ComponentPropsWithRef<"p"> & {
   asChild?: boolean;
 };
 
@@ -120,7 +121,7 @@ const AlertTitle = ({asChild, children, className, ...rest}: AlertTitleProps) =>
 /* ------------------------------------------------------------------------------------------------
  * Alert Description
  * --------------------------------------------------------------------------------------------- */
-type AlertDescriptionProps = React.ComponentProps<"span"> & {
+type AlertDescriptionProps = ComponentPropsWithRef<"span"> & {
   asChild?: boolean;
 };
 

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -2,6 +2,7 @@
 
 import type {AvatarVariants} from "./avatar.styles";
 import type {UseImageProps} from "../../hooks";
+import type {ComponentPropsWithRef} from "react";
 
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
@@ -25,7 +26,7 @@ const AvatarContext = createContext<AvatarContext>({});
  * Avatar Root
  * -----------------------------------------------------------------------------------------------*/
 interface AvatarRootProps
-  extends Omit<React.ComponentProps<typeof AvatarPrimitive.Root>, "color">,
+  extends Omit<ComponentPropsWithRef<typeof AvatarPrimitive.Root>, "color">,
     AvatarVariants {}
 
 const AvatarRoot = ({children, className, color, size, variant, ...props}: AvatarRootProps) => {
@@ -44,7 +45,7 @@ const AvatarRoot = ({children, className, color, size, variant, ...props}: Avata
  * Avatar Image
  * -----------------------------------------------------------------------------------------------*/
 interface AvatarImageProps
-  extends Omit<React.ComponentProps<typeof AvatarPrimitive.Image>, "onLoadingStatusChange"> {
+  extends Omit<ComponentPropsWithRef<typeof AvatarPrimitive.Image>, "onLoadingStatusChange"> {
   asChild?: boolean;
   ignoreFallback?: UseImageProps["ignoreFallback"];
   shouldBypassImageLoad?: UseImageProps["shouldBypassImageLoad"];
@@ -106,7 +107,7 @@ const AvatarImage = ({
 /* -------------------------------------------------------------------------------------------------
  * Avatar Fallback
  * -----------------------------------------------------------------------------------------------*/
-interface AvatarFallbackProps extends React.ComponentProps<typeof AvatarPrimitive.Fallback> {
+interface AvatarFallbackProps extends ComponentPropsWithRef<typeof AvatarPrimitive.Fallback> {
   color?: AvatarVariants["color"];
 }
 

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {ButtonVariants} from "./button.styles";
-import type {ButtonProps as ButtonPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import {Button as ButtonPrimitive} from "react-aria-components";
@@ -13,7 +13,7 @@ import {buttonVariants} from "./button.styles";
 /* -------------------------------------------------------------------------------------------------
  * Button Root
  * -----------------------------------------------------------------------------------------------*/
-interface ButtonRootProps extends ButtonPrimitiveProps, ButtonVariants {
+interface ButtonRootProps extends ComponentPropsWithRef<typeof ButtonPrimitive>, ButtonVariants {
   asChild?: boolean;
 }
 

--- a/packages/react/src/components/calendar/calendar.tsx
+++ b/packages/react/src/components/calendar/calendar.tsx
@@ -1,16 +1,8 @@
 "use client";
 
 import type {CalendarVariants} from "./calendar.styles";
-import type {
-  ButtonProps as ButtonPrimitiveProps,
-  CalendarCellProps as CalendarCellPrimitiveProps,
-  CalendarGridHeaderProps as CalendarGridHeaderPrimitiveProps,
-  CalendarGridProps as CalendarGridPrimitiveProps,
-  CalendarHeaderCellProps as CalendarHeaderCellPrimitiveProps,
-  CalendarProps as CalendarPrimitiveProps,
-  DateValue,
-  HeadingProps as HeadingPrimitiveProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
+import type {DateValue} from "react-aria-components";
 
 import React, {createContext, useContext} from "react";
 import {
@@ -41,7 +33,7 @@ const CalendarContext = createContext<CalendarContext>({});
  * Calendar Root
  * -----------------------------------------------------------------------------------------------*/
 interface CalendarRootProps<T extends DateValue = DateValue>
-  extends CalendarPrimitiveProps<T>,
+  extends ComponentPropsWithRef<typeof CalendarPrimitive<T>>,
     CalendarVariants {}
 
 function CalendarRoot<T extends DateValue = DateValue>({
@@ -69,7 +61,7 @@ function CalendarRoot<T extends DateValue = DateValue>({
 /* -------------------------------------------------------------------------------------------------
  * Calendar Header
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarHeaderProps extends React.ComponentProps<"header"> {
+interface CalendarHeaderProps extends ComponentPropsWithRef<"header"> {
   className?: string;
 }
 
@@ -86,7 +78,7 @@ const CalendarHeader = ({children, className, ...props}: CalendarHeaderProps) =>
 /* -------------------------------------------------------------------------------------------------
  * Calendar Heading
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarHeadingProps extends HeadingPrimitiveProps {}
+interface CalendarHeadingProps extends ComponentPropsWithRef<typeof HeadingPrimitive> {}
 
 const CalendarHeading = ({className, ...props}: CalendarHeadingProps) => {
   const {slots} = useContext(CalendarContext);
@@ -103,7 +95,7 @@ const CalendarHeading = ({className, ...props}: CalendarHeadingProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Calendar Nav Button
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarNavButtonProps extends ButtonPrimitiveProps {
+interface CalendarNavButtonProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {
   slot?: "previous" | "next";
 }
 
@@ -125,7 +117,7 @@ const CalendarNavButton = ({children, className, slot, ...props}: CalendarNavBut
 /* -------------------------------------------------------------------------------------------------
  * Calendar Grid
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarGridProps extends CalendarGridPrimitiveProps {}
+interface CalendarGridProps extends ComponentPropsWithRef<typeof CalendarGridPrimitive> {}
 
 const CalendarGrid = ({className, ...props}: CalendarGridProps) => {
   const {slots} = useContext(CalendarContext);
@@ -149,7 +141,8 @@ const CalendarGrid = ({className, ...props}: CalendarGridProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Calendar Grid Header
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarGridHeaderProps extends CalendarGridHeaderPrimitiveProps {}
+interface CalendarGridHeaderProps
+  extends ComponentPropsWithRef<typeof CalendarGridHeaderPrimitive> {}
 
 const CalendarGridHeader = ({className, ...props}: CalendarGridHeaderProps) => {
   const {slots} = useContext(CalendarContext);
@@ -166,7 +159,8 @@ const CalendarGridHeader = ({className, ...props}: CalendarGridHeaderProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Calendar Header Cell
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarHeaderCellProps extends CalendarHeaderCellPrimitiveProps {}
+interface CalendarHeaderCellProps
+  extends ComponentPropsWithRef<typeof CalendarHeaderCellPrimitive> {}
 
 const CalendarHeaderCell = ({className, ...props}: CalendarHeaderCellProps) => {
   const {slots} = useContext(CalendarContext);
@@ -183,7 +177,7 @@ const CalendarHeaderCell = ({className, ...props}: CalendarHeaderCellProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Calendar Cell
  * -----------------------------------------------------------------------------------------------*/
-interface CalendarCellProps extends CalendarCellPrimitiveProps {}
+interface CalendarCellProps extends ComponentPropsWithRef<typeof CalendarCellPrimitive> {}
 
 const CalendarCell = ({children, className, ...props}: CalendarCellProps) => {
   const {slots} = useContext(CalendarContext);

--- a/packages/react/src/components/card/card.tsx
+++ b/packages/react/src/components/card/card.tsx
@@ -2,6 +2,7 @@
 
 import type {CardVariants} from "./card.styles";
 import type {SurfaceVariants} from "../surface";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot} from "@radix-ui/react-slot";
 import React, {createContext, useContext} from "react";
@@ -21,7 +22,7 @@ const CardContext = createContext<CardContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Card Root
  * -----------------------------------------------------------------------------------------------*/
-interface CardRootProps extends React.ComponentProps<"div">, CardVariants {
+interface CardRootProps extends ComponentPropsWithRef<"div">, CardVariants {
   asChild?: boolean;
 }
 
@@ -62,7 +63,7 @@ const CardRoot = ({
 /* -------------------------------------------------------------------------------------------------
  * Card Header
  * -----------------------------------------------------------------------------------------------*/
-interface CardHeaderProps extends React.ComponentProps<"div"> {
+interface CardHeaderProps extends ComponentPropsWithRef<"div"> {
   asChild?: boolean;
 }
 
@@ -76,7 +77,7 @@ const CardHeader = ({asChild = false, className, ...props}: CardHeaderProps) => 
 /* -------------------------------------------------------------------------------------------------
  * Card Title
  * -----------------------------------------------------------------------------------------------*/
-interface CardTitleProps extends React.ComponentProps<"h3"> {
+interface CardTitleProps extends ComponentPropsWithRef<"h3"> {
   asChild?: boolean;
 }
 
@@ -90,7 +91,7 @@ const CardTitle = ({asChild = false, className, ...props}: CardTitleProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Card Description
  * -----------------------------------------------------------------------------------------------*/
-interface CardDescriptionProps extends React.ComponentProps<"p"> {
+interface CardDescriptionProps extends ComponentPropsWithRef<"p"> {
   asChild?: boolean;
 }
 
@@ -106,7 +107,7 @@ const CardDescription = ({asChild = false, className, ...props}: CardDescription
 /* -------------------------------------------------------------------------------------------------
  * Card Content
  * -----------------------------------------------------------------------------------------------*/
-interface CardContentProps extends React.ComponentProps<"div"> {
+interface CardContentProps extends ComponentPropsWithRef<"div"> {
   asChild?: boolean;
 }
 
@@ -120,7 +121,7 @@ const CardContent = ({asChild = false, className, ...props}: CardContentProps) =
 /* -------------------------------------------------------------------------------------------------
  * Card Footer
  * -----------------------------------------------------------------------------------------------*/
-interface CardFooterProps extends React.ComponentProps<"div"> {
+interface CardFooterProps extends ComponentPropsWithRef<"div"> {
   asChild?: boolean;
 }
 

--- a/packages/react/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/react/src/components/checkbox-group/checkbox-group.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {CheckboxGroupVariants} from "./checkbox-group.styles";
-import type {CheckboxGroupProps as CheckboxGroupPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {CheckboxGroup as CheckboxGroupPrimitive} from "react-aria-components";
@@ -10,7 +10,9 @@ import {composeTwRenderProps} from "../../utils/compose";
 
 import {checkboxGroupVariants} from "./checkbox-group.styles";
 
-interface CheckboxGroupProps extends CheckboxGroupPrimitiveProps, CheckboxGroupVariants {}
+interface CheckboxGroupProps
+  extends ComponentPropsWithRef<typeof CheckboxGroupPrimitive>,
+    CheckboxGroupVariants {}
 
 const CheckboxGroup = ({children, className, ...props}: CheckboxGroupProps) => {
   const styles = React.useMemo(() => checkboxGroupVariants(), []);

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import type {CheckboxVariants} from "./checkbox.styles";
-import type {
-  CheckboxProps as CheckboxPrimitiveProps,
-  CheckboxRenderProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
+import type {CheckboxRenderProps} from "react-aria-components";
 
 import React, {createContext, useContext} from "react";
 import {Checkbox as CheckboxPrimitive} from "react-aria-components";
@@ -21,7 +19,9 @@ interface CheckboxContext {
 
 const CheckboxContext = createContext<CheckboxContext>({});
 
-interface CheckboxRootProps extends CheckboxPrimitiveProps, CheckboxVariants {
+interface CheckboxRootProps
+  extends ComponentPropsWithRef<typeof CheckboxPrimitive>,
+    CheckboxVariants {
   /** The name of the checkbox, used when submitting an HTML form. */
   name?: string;
 }
@@ -51,7 +51,7 @@ const CheckboxRoot = ({children, className, isOnSurface, ...props}: CheckboxRoot
 
 /* -----------------------------------------------------------------------------------------------*/
 
-interface CheckboxControlProps extends React.HTMLAttributes<HTMLSpanElement> {}
+interface CheckboxControlProps extends ComponentPropsWithRef<"span"> {}
 
 const CheckboxControl = ({children, className, ...props}: CheckboxControlProps) => {
   const {slots} = useContext(CheckboxContext);
@@ -65,7 +65,7 @@ const CheckboxControl = ({children, className, ...props}: CheckboxControlProps) 
 
 /* -----------------------------------------------------------------------------------------------*/
 
-interface CheckboxIndicatorProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+interface CheckboxIndicatorProps extends Omit<ComponentPropsWithRef<"span">, "children"> {
   children?: React.ReactNode | ((props: CheckboxRenderProps) => React.ReactNode);
 }
 
@@ -126,7 +126,7 @@ const CheckboxIndicator = ({children, className, ...props}: CheckboxIndicatorPro
 
 /* -----------------------------------------------------------------------------------------------*/
 
-interface CheckboxContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface CheckboxContentProps extends ComponentPropsWithRef<"div"> {}
 
 const CheckboxContent = ({children, className, ...props}: CheckboxContentProps) => {
   const {slots} = useContext(CheckboxContext);

--- a/packages/react/src/components/chip/chip.tsx
+++ b/packages/react/src/components/chip/chip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {ChipVariants} from "./chip.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 
@@ -9,9 +10,7 @@ import {chipVariants} from "./chip.styles";
 /* -------------------------------------------------------------------------------------------------
  * Chip Root
  * -----------------------------------------------------------------------------------------------*/
-interface ChipRootProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "type" | "color">,
-    ChipVariants {
+interface ChipRootProps extends Omit<ComponentPropsWithRef<"div">, "type" | "color">, ChipVariants {
   className?: string;
   children: React.ReactNode;
   asChild?: boolean;

--- a/packages/react/src/components/close-button/close-button.tsx
+++ b/packages/react/src/components/close-button/close-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {CloseButtonVariants} from "./close-button.styles";
-import type {ButtonProps as ButtonPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import {Button as ButtonPrimitive} from "react-aria-components";
@@ -14,7 +14,9 @@ import {closeButtonVariants} from "./close-button.styles";
 /* -------------------------------------------------------------------------------------------------
  * Close Button Root
  * -----------------------------------------------------------------------------------------------*/
-interface CloseButtonRootProps extends ButtonPrimitiveProps, CloseButtonVariants {
+interface CloseButtonRootProps
+  extends ComponentPropsWithRef<typeof ButtonPrimitive>,
+    CloseButtonVariants {
   asChild?: boolean;
 }
 

--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -2,8 +2,8 @@
 
 import type {ComboBoxVariants} from "./combobox.styles";
 import type {SurfaceVariants} from "../surface";
-import type {ComponentProps, ReactNode} from "react";
-import type {ButtonProps, ComboBoxProps as ComboBoxPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef, ReactNode} from "react";
+import type {ButtonProps} from "react-aria-components";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import React, {createContext, useContext} from "react";
@@ -34,7 +34,9 @@ const ComboBoxContext = createContext<ComboBoxContext>({});
 /* -------------------------------------------------------------------------------------------------
  * ComboBox Root
  * -----------------------------------------------------------------------------------------------*/
-interface ComboBoxRootProps<T extends object> extends ComboBoxPrimitiveProps<T>, ComboBoxVariants {
+interface ComboBoxRootProps<T extends object>
+  extends ComponentPropsWithRef<typeof ComboBoxPrimitive<T>>,
+    ComboBoxVariants {
   items?: Iterable<T>;
 }
 
@@ -84,7 +86,7 @@ interface ComboBoxTriggerProps {
 }
 
 interface ComboBoxTrigger {
-  (props: {asChild: true} & ComponentProps<"button">): React.JSX.Element;
+  (props: {asChild: true} & ComponentPropsWithRef<"button">): React.JSX.Element;
   (props: {asChild?: false} & ButtonProps): React.JSX.Element;
 }
 
@@ -128,7 +130,7 @@ const ComboBoxTrigger: ComboBoxTrigger = (props) => {
  * ComboBox Popover
  * -----------------------------------------------------------------------------------------------*/
 interface ComboBoxPopoverProps
-  extends Omit<React.ComponentProps<typeof PopoverPrimitive>, "children"> {
+  extends Omit<ComponentPropsWithRef<typeof PopoverPrimitive>, "children"> {
   children: React.ReactNode;
 }
 

--- a/packages/react/src/components/description/description.tsx
+++ b/packages/react/src/components/description/description.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {DescriptionVariants} from "./description.styles";
+import type {ComponentPropsWithRef} from "react";
 import type {TextProps} from "react-aria-components";
 
 import {Text} from "react-aria-components";
@@ -10,7 +11,10 @@ import {descriptionVariants} from "./description.styles";
 /* -------------------------------------------------------------------------------------------------
  * Description Root
  * -----------------------------------------------------------------------------------------------*/
-interface DescriptionRootProps extends TextProps, DescriptionVariants {}
+interface DescriptionRootProps
+  extends ComponentPropsWithRef<typeof Text>,
+    TextProps,
+    DescriptionVariants {}
 
 const DescriptionRoot = ({children, className, ...rest}: DescriptionRootProps) => {
   return (

--- a/packages/react/src/components/disclosure-group/disclosure-group.tsx
+++ b/packages/react/src/components/disclosure-group/disclosure-group.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {DisclosureGroupVariants} from "./disclosure-group.styles";
-import type {DisclosureGroupProps as DisclosureGroupPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext} from "react";
 import {DisclosureGroup as DisclosureGroupPrimitive} from "react-aria-components";
@@ -23,7 +23,9 @@ const DisclosureGroupContext = createContext<DisclosureGroupContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Disclosure Group Root
  * -----------------------------------------------------------------------------------------------*/
-interface DisclosureGroupRootProps extends DisclosureGroupPrimitiveProps, DisclosureGroupVariants {}
+interface DisclosureGroupRootProps
+  extends ComponentPropsWithRef<typeof DisclosureGroupPrimitive>,
+    DisclosureGroupVariants {}
 
 const DisclosureGroupRoot = ({children, className, ...originalProps}: DisclosureGroupRootProps) => {
   const [props, variantProps] = mapPropsVariants(

--- a/packages/react/src/components/disclosure/disclosure.tsx
+++ b/packages/react/src/components/disclosure/disclosure.tsx
@@ -2,11 +2,8 @@
 
 import type {DisclosureVariants} from "./disclosure.styles";
 import type {Booleanish} from "../../utils/assertion";
-import type {
-  ButtonProps,
-  DisclosurePanelProps,
-  DisclosureProps as DisclosurePrimitiveProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
+import type {ButtonProps} from "react-aria-components";
 
 import React, {createContext, useContext, useRef} from "react";
 import {
@@ -36,7 +33,9 @@ const DisclosureContext = createContext<DisclosureContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Disclosure Root
  * -----------------------------------------------------------------------------------------------*/
-interface DisclosureRootProps extends DisclosurePrimitiveProps, DisclosureVariants {}
+interface DisclosureRootProps
+  extends ComponentPropsWithRef<typeof DisclosurePrimitive>,
+    DisclosureVariants {}
 
 const DisclosureRoot = ({children, className, ...originalProps}: DisclosureRootProps) => {
   const [props, variantProps] = mapPropsVariants(originalProps, disclosureVariants.variantKeys);
@@ -62,7 +61,7 @@ const DisclosureRoot = ({children, className, ...originalProps}: DisclosureRootP
 /* -------------------------------------------------------------------------------------------------
  * Disclosure Heading
  * -----------------------------------------------------------------------------------------------*/
-interface DisclosureHeadingProps extends React.ComponentProps<typeof DisclosureHeadingPrimitive> {
+interface DisclosureHeadingProps extends ComponentPropsWithRef<typeof DisclosureHeadingPrimitive> {
   className?: string;
 }
 
@@ -103,7 +102,7 @@ const DisclosureTrigger = ({className, ...props}: DisclosureTriggerProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Disclosure Content
  * -----------------------------------------------------------------------------------------------*/
-interface DisclosureContentProps extends DisclosurePanelProps {}
+interface DisclosureContentProps extends ComponentPropsWithRef<typeof DisclosurePanel> {}
 
 const DisclosureContent = ({children, className, ...props}: DisclosureContentProps) => {
   const {slots} = useContext(DisclosureContext);
@@ -126,7 +125,7 @@ const DisclosureContent = ({children, className, ...props}: DisclosureContentPro
 /* -------------------------------------------------------------------------------------------------
  * Disclosure Body
  * -----------------------------------------------------------------------------------------------*/
-interface DisclosureBodyContentProps extends React.ComponentProps<"div"> {
+interface DisclosureBodyContentProps extends ComponentPropsWithRef<"div"> {
   className?: string;
 }
 
@@ -143,7 +142,7 @@ const DisclosureBody = ({children, className, ...props}: DisclosureBodyContentPr
 /* -------------------------------------------------------------------------------------------------
  * Disclosure Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface DisclosureIndicatorProps extends React.ComponentProps<"svg"> {
+interface DisclosureIndicatorProps extends ComponentPropsWithRef<"svg"> {
   className?: string;
 }
 

--- a/packages/react/src/components/dropdown/dropdown.tsx
+++ b/packages/react/src/components/dropdown/dropdown.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import type {DropdownVariants} from "./dropdown.styles";
-import type {MenuItemIndicatorProps, MenuItemRootProps} from "../menu-item";
-import type {MenuSectionRootProps} from "../menu-section";
 import type {SurfaceVariants} from "../surface";
-import type {
-  ButtonProps,
-  MenuProps as MenuPrimitiveProps,
-  MenuTriggerProps as MenuTriggerPrimitiveProps,
-  PopoverProps as PopoverPrimitiveProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
@@ -39,7 +32,9 @@ const DropdownContext = createContext<DropdownContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Root (MenuTrigger wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownRootProps extends MenuTriggerPrimitiveProps, DropdownVariants {
+interface DropdownRootProps
+  extends ComponentPropsWithRef<typeof MenuTriggerPrimitive>,
+    DropdownVariants {
   className?: string;
 }
 
@@ -56,7 +51,7 @@ const DropdownRoot = ({children, ...props}: DropdownRootProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Trigger (Button wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownTriggerProps extends ButtonProps {}
+interface DropdownTriggerProps extends ComponentPropsWithRef<typeof Button> {}
 
 const DropdownTrigger = ({children, className, ...props}: DropdownTriggerProps) => {
   const {slots} = useContext(DropdownContext);
@@ -75,7 +70,9 @@ const DropdownTrigger = ({children, className, ...props}: DropdownTriggerProps) 
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Popover (Popover wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownPopoverProps extends Omit<PopoverPrimitiveProps, "children">, DropdownVariants {
+interface DropdownPopoverProps
+  extends Omit<ComponentPropsWithRef<typeof PopoverPrimitive>, "children">,
+    DropdownVariants {
   children: React.ReactNode;
 }
 
@@ -102,7 +99,9 @@ const DropdownPopover = ({children, className, placement, ...props}: DropdownPop
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Menu (Menu wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownMenuProps<T extends object> extends MenuPrimitiveProps<T>, DropdownVariants {
+interface DropdownMenuProps<T extends object>
+  extends ComponentPropsWithRef<typeof MenuPrimitive<T>>,
+    DropdownVariants {
   className?: string;
 }
 
@@ -122,7 +121,7 @@ function DropdownMenu<T extends object>({className, ...props}: DropdownMenuProps
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Item (MenuItem wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownItemProps extends MenuItemRootProps {}
+interface DropdownItemProps extends ComponentPropsWithRef<typeof MenuItemRoot> {}
 
 const DropdownItem = (props: DropdownItemProps) => {
   return <MenuItemRoot {...props} />;
@@ -132,7 +131,7 @@ const DropdownItem = (props: DropdownItemProps) => {
  * Dropdown Submenu Indicator (MenuItemSubmenuIndicator wrapper)
  * -----------------------------------------------------------------------------------------------*/
 interface DropdownSubmenuIndicatorProps
-  extends React.ComponentProps<typeof MenuItemSubmenuIndicator> {}
+  extends ComponentPropsWithRef<typeof MenuItemSubmenuIndicator> {}
 
 const DropdownSubmenuIndicator = (props: DropdownSubmenuIndicatorProps) => {
   return <MenuItemSubmenuIndicator {...props} />;
@@ -141,7 +140,8 @@ const DropdownSubmenuIndicator = (props: DropdownSubmenuIndicatorProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Submenu Trigger
  * -----------------------------------------------------------------------------------------------*/
-type DropdownSubmenuTriggerProps = React.ComponentProps<typeof SubmenuTriggerPrimitive>;
+interface DropdownSubmenuTriggerProps
+  extends ComponentPropsWithRef<typeof SubmenuTriggerPrimitive> {}
 
 const DropdownSubmenuTrigger = ({children, ...props}: DropdownSubmenuTriggerProps) => {
   return (
@@ -154,7 +154,7 @@ const DropdownSubmenuTrigger = ({children, ...props}: DropdownSubmenuTriggerProp
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Item Indicator (MenuItemIndicator wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownItemIndicatorProps extends MenuItemIndicatorProps {}
+interface DropdownItemIndicatorProps extends ComponentPropsWithRef<typeof MenuItemIndicator> {}
 
 const DropdownItemIndicator = (props: DropdownItemIndicatorProps) => {
   return <MenuItemIndicator {...props} />;
@@ -163,7 +163,7 @@ const DropdownItemIndicator = (props: DropdownItemIndicatorProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Section (MenuSection wrapper)
  * -----------------------------------------------------------------------------------------------*/
-interface DropdownSectionProps extends MenuSectionRootProps {}
+interface DropdownSectionProps extends ComponentPropsWithRef<typeof MenuSectionRoot> {}
 
 const DropdownSection = (props: DropdownSectionProps) => {
   return <MenuSectionRoot {...props} />;

--- a/packages/react/src/components/empty-state/empty-state.tsx
+++ b/packages/react/src/components/empty-state/empty-state.tsx
@@ -1,5 +1,5 @@
 import type {EmptyStateVariants} from "./empty-state.styles";
-import type {HTMLAttributes} from "react";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 
@@ -8,7 +8,7 @@ import {emptyStateVariants} from "./empty-state.styles";
 /* -------------------------------------------------------------------------------------------------
  * EmptyState Root
  * -----------------------------------------------------------------------------------------------*/
-interface EmptyStateRootProps extends HTMLAttributes<HTMLDivElement>, EmptyStateVariants {}
+interface EmptyStateRootProps extends ComponentPropsWithRef<"div">, EmptyStateVariants {}
 
 const EmptyStateRoot = ({children, className, ...rest}: EmptyStateRootProps) => {
   return (

--- a/packages/react/src/components/field-error/field-error.tsx
+++ b/packages/react/src/components/field-error/field-error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {FieldErrorVariants} from "./field-error.styles";
-import type {FieldErrorProps as FieldErrorPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {FieldError as FieldErrorPrimitive} from "react-aria-components";
 
@@ -12,7 +12,9 @@ import {fieldErrorVariants} from "./field-error.styles";
 /* -------------------------------------------------------------------------------------------------
  * Field Error Root
  * -----------------------------------------------------------------------------------------------*/
-interface FieldErrorRootProps extends FieldErrorPrimitiveProps, FieldErrorVariants {}
+interface FieldErrorRootProps
+  extends ComponentPropsWithRef<typeof FieldErrorPrimitive>,
+    FieldErrorVariants {}
 
 const FieldErrorRoot = ({children, className, ...rest}: FieldErrorRootProps) => {
   return (

--- a/packages/react/src/components/fieldset/fieldset.tsx
+++ b/packages/react/src/components/fieldset/fieldset.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {FieldsetVariants} from "./fieldset.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot} from "@radix-ui/react-slot";
 import React, {createContext, useContext} from "react";
@@ -19,7 +20,7 @@ const FieldsetContext = createContext<FieldsetContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Fieldset Root
  * -----------------------------------------------------------------------------------------------*/
-interface FieldsetRootProps extends React.ComponentProps<"fieldset">, FieldsetVariants {
+interface FieldsetRootProps extends ComponentPropsWithRef<"fieldset">, FieldsetVariants {
   asChild?: boolean;
 }
 
@@ -38,7 +39,7 @@ const FieldsetRoot = ({asChild = false, className, ...props}: FieldsetRootProps)
 /* -------------------------------------------------------------------------------------------------
  * Fieldset Legend
  * -----------------------------------------------------------------------------------------------*/
-interface FieldsetLegendProps extends React.ComponentProps<"legend"> {
+interface FieldsetLegendProps extends ComponentPropsWithRef<"legend"> {
   asChild?: boolean;
 }
 
@@ -53,7 +54,7 @@ const FieldsetLegend = ({asChild = false, className, ...props}: FieldsetLegendPr
 /* -------------------------------------------------------------------------------------------------
  * Field Group
  * -----------------------------------------------------------------------------------------------*/
-interface FieldGroupProps extends React.ComponentProps<"div"> {
+interface FieldGroupProps extends ComponentPropsWithRef<"div"> {
   asChild?: boolean;
 }
 
@@ -70,7 +71,7 @@ const FieldGroup = ({asChild = false, className, ...rest}: FieldGroupProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Field Actions
  * -----------------------------------------------------------------------------------------------*/
-interface FieldsetActionsProps extends React.ComponentProps<"div"> {
+interface FieldsetActionsProps extends ComponentPropsWithRef<"div"> {
   asChild?: boolean;
 }
 

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type {FormProps as FormPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {Form as FormPrimitive} from "react-aria-components";
@@ -8,7 +8,7 @@ import {Form as FormPrimitive} from "react-aria-components";
 /* -------------------------------------------------------------------------------------------------
  * Form Root
  * -----------------------------------------------------------------------------------------------*/
-interface FormRootProps extends FormPrimitiveProps {}
+interface FormRootProps extends ComponentPropsWithRef<typeof FormPrimitive> {}
 
 const FormRoot = ({...props}: FormRootProps) => {
   return <FormPrimitive {...props} />;

--- a/packages/react/src/components/header/header.tsx
+++ b/packages/react/src/components/header/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type {ComponentProps} from "react";
+import type {ComponentPropsWithRef} from "react";
 
 import {Header as HeaderPrimitive} from "react-aria-components";
 
@@ -9,7 +9,7 @@ import {headerVariants} from "./header.styles";
 /* -------------------------------------------------------------------------------------------------
  * Header Root
  * -----------------------------------------------------------------------------------------------*/
-interface HeaderRootProps extends ComponentProps<typeof HeaderPrimitive> {}
+interface HeaderRootProps extends ComponentPropsWithRef<typeof HeaderPrimitive> {}
 
 const HeaderRoot = ({children, className, ...rest}: HeaderRootProps) => {
   return (

--- a/packages/react/src/components/input-group/input-group.tsx
+++ b/packages/react/src/components/input-group/input-group.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {InputGroupVariants} from "./input-group.styles";
-import type {GroupProps, InputProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
@@ -28,7 +28,9 @@ const InputGroupContext = createContext<InputGroupContext>({});
 /* -------------------------------------------------------------------------------------------------
  * InputGroup Root
  * -----------------------------------------------------------------------------------------------*/
-interface InputGroupRootProps extends GroupProps, InputGroupVariants {}
+interface InputGroupRootProps
+  extends ComponentPropsWithRef<typeof GroupPrimitive>,
+    InputGroupVariants {}
 
 const InputGroupRoot = ({children, className, isOnSurface, ...props}: InputGroupRootProps) => {
   const surfaceContext = useContext(SurfaceContext);
@@ -59,7 +61,7 @@ const InputGroupRoot = ({children, className, isOnSurface, ...props}: InputGroup
 /* -------------------------------------------------------------------------------------------------
  * InputGroup Input
  * -----------------------------------------------------------------------------------------------*/
-interface InputGroupInputProps extends InputProps {
+interface InputGroupInputProps extends ComponentPropsWithRef<typeof InputPrimitive> {
   isOnSurface?: boolean;
 }
 
@@ -80,7 +82,7 @@ const InputGroupInput = ({className, isOnSurface, ...props}: InputGroupInputProp
 /* -------------------------------------------------------------------------------------------------
  * InputGroup Prefix
  * -----------------------------------------------------------------------------------------------*/
-interface InputGroupPrefixProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface InputGroupPrefixProps extends ComponentPropsWithRef<"div"> {}
 
 const InputGroupPrefix = ({children, className, ...props}: InputGroupPrefixProps) => {
   const {slots} = useContext(InputGroupContext);
@@ -95,7 +97,7 @@ const InputGroupPrefix = ({children, className, ...props}: InputGroupPrefixProps
 /* -------------------------------------------------------------------------------------------------
  * InputGroup Suffix
  * -----------------------------------------------------------------------------------------------*/
-interface InputGroupSuffixProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface InputGroupSuffixProps extends ComponentPropsWithRef<"div"> {}
 
 const InputGroupSuffix = ({children, className, ...props}: InputGroupSuffixProps) => {
   const {slots} = useContext(InputGroupContext);

--- a/packages/react/src/components/input-otp/input-otp.tsx
+++ b/packages/react/src/components/input-otp/input-otp.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {InputOTPVariants} from "./input-otp.styles";
+import type {ComponentPropsWithRef} from "react";
 import type {ValidationResult} from "react-aria-components";
 
 import {OTPInput, OTPInputContext} from "input-otp";
@@ -30,7 +31,10 @@ const InputOTPContext = createContext<InputOTPContext>({
  * Input OTP Root
  * -----------------------------------------------------------------------------------------------*/
 interface InputOTPRootProps
-  extends Omit<React.ComponentProps<typeof OTPInput>, "disabled" | "containerClassName" | "render">,
+  extends Omit<
+      ComponentPropsWithRef<typeof OTPInput>,
+      "disabled" | "containerClassName" | "render"
+    >,
     InputOTPVariants {
   isDisabled?: boolean;
   isInvalid?: boolean;
@@ -89,7 +93,7 @@ const InputOTPRoot = ({
  * Input OTP Group
  * -----------------------------------------------------------------------------------------------*/
 
-interface InputOTPGroupProps extends React.ComponentProps<"div"> {}
+interface InputOTPGroupProps extends ComponentPropsWithRef<"div"> {}
 
 const InputOTPGroup = ({className, ...props}: InputOTPGroupProps) => {
   const {slots} = useContext(InputOTPContext);
@@ -100,7 +104,7 @@ const InputOTPGroup = ({className, ...props}: InputOTPGroupProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Input OTP Slot
  * -----------------------------------------------------------------------------------------------*/
-interface InputOTPSlotProps extends React.ComponentProps<"div"> {
+interface InputOTPSlotProps extends ComponentPropsWithRef<"div"> {
   index: number;
 }
 
@@ -135,7 +139,7 @@ const InputOTPSlot = ({className, index, ...props}: InputOTPSlotProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Input OTP Separator
  * -----------------------------------------------------------------------------------------------*/
-interface InputOTPSeparatorProps {
+interface InputOTPSeparatorProps extends ComponentPropsWithRef<"div"> {
   className?: string;
 }
 

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -22,11 +22,13 @@ export const Default: Story = {
 };
 
 export const OnSurface: Story = {
-  render: () => (
-    <div className="bg-surface flex h-[180px] w-[280px] items-center justify-center rounded-3xl p-4">
-      <Surface className="w-full">
-        <Input className="w-full" placeholder="Your name" />
-      </Surface>
-    </div>
-  ),
+  render: () => {
+    return (
+      <div className="bg-surface flex h-[180px] w-[280px] items-center justify-center rounded-3xl p-4">
+        <Surface className="w-full">
+          <Input className="w-full" placeholder="Your name" />
+        </Surface>
+      </div>
+    );
+  },
 };

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {InputVariants} from "./input.styles";
-import type {InputProps as InputPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {useContext} from "react";
 import {Input as InputPrimitive} from "react-aria-components";
@@ -14,7 +14,7 @@ import {inputVariants} from "./input.styles";
 /* -------------------------------------------------------------------------------------------------
  * Input Root
  * -----------------------------------------------------------------------------------------------*/
-interface InputRootProps extends InputPrimitiveProps, InputVariants {}
+interface InputRootProps extends ComponentPropsWithRef<typeof InputPrimitive>, InputVariants {}
 
 const InputRoot = ({className, isOnSurface, ...rest}: InputRootProps) => {
   const surfaceContext = useContext(SurfaceContext);

--- a/packages/react/src/components/kbd/kbd.tsx
+++ b/packages/react/src/components/kbd/kbd.tsx
@@ -2,6 +2,7 @@
 
 import type {KbdKey} from "./kbd.constants";
 import type {KbdVariants} from "./kbd.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 
@@ -20,7 +21,7 @@ const KbdContext = createContext<KbdContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Kbd Root
  * -----------------------------------------------------------------------------------------------*/
-interface KbdRootProps extends React.HTMLAttributes<HTMLElement>, KbdVariants {
+interface KbdRootProps extends ComponentPropsWithRef<"kbd">, KbdVariants {
   children: React.ReactNode;
   className?: string;
 }
@@ -40,7 +41,7 @@ const KbdRoot = ({children, className, variant, ...props}: KbdRootProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Kbd Abbr
  * -----------------------------------------------------------------------------------------------*/
-interface KbdAbbrProps extends React.HTMLAttributes<HTMLElement> {
+interface KbdAbbrProps extends ComponentPropsWithRef<"abbr"> {
   className?: string;
   /**
    * The keyboard key to display
@@ -61,7 +62,7 @@ const KbdAbbr = ({className, keyValue, ...props}: KbdAbbrProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Kbd Content
  * -----------------------------------------------------------------------------------------------*/
-interface KbdContentProps extends React.ComponentProps<"span"> {
+interface KbdContentProps extends ComponentPropsWithRef<"span"> {
   children: React.ReactNode;
   className?: string;
 }

--- a/packages/react/src/components/label/label.tsx
+++ b/packages/react/src/components/label/label.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {LabelVariants} from "./label.styles";
-import type {LabelProps as LabelPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {Label as LabelPrimitive} from "react-aria-components";
 
@@ -10,7 +10,7 @@ import {labelVariants} from "./label.styles";
 /* -------------------------------------------------------------------------------------------------
  * Label Root
  * -----------------------------------------------------------------------------------------------*/
-interface LabelRootProps extends LabelPrimitiveProps, LabelVariants {}
+interface LabelRootProps extends ComponentPropsWithRef<typeof LabelPrimitive>, LabelVariants {}
 
 const LabelRoot = ({
   children,

--- a/packages/react/src/components/link/link.tsx
+++ b/packages/react/src/components/link/link.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {LinkVariants} from "./link.styles";
-import type {LinkProps as LinkPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import React, {createContext, useContext} from "react";
@@ -25,7 +25,7 @@ const LinkContext = createContext<LinkContext>({});
 /* ------------------------------------------------------------------------------------------------
  * Link Root
  * --------------------------------------------------------------------------------------------- */
-interface LinkRootProps extends LinkPrimitiveProps, LinkVariants {
+interface LinkRootProps extends ComponentPropsWithRef<typeof LinkPrimitive>, LinkVariants {
   asChild?: boolean;
 }
 
@@ -75,7 +75,7 @@ const LinkRoot = ({
 /* ------------------------------------------------------------------------------------------------
  * Link Icon
  * --------------------------------------------------------------------------------------------- */
-type LinkIconProps = React.ComponentProps<"span"> & {
+type LinkIconProps = ComponentPropsWithRef<"span"> & {
   asChild?: boolean;
 };
 

--- a/packages/react/src/components/listbox-item/listbox-item.tsx
+++ b/packages/react/src/components/listbox-item/listbox-item.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import type {ListBoxItemVariants} from "./listbox-item.styles";
-import type {
-  ListBoxItemProps as ListBoxItemPrimitiveProps,
-  ListBoxItemRenderProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
+import type {ListBoxItemRenderProps} from "react-aria-components";
 
 import React, {createContext, useContext} from "react";
 import {ListBoxItem as ListBoxItemPrimitive} from "react-aria-components";
@@ -26,7 +24,9 @@ const ListBoxItemContext = createContext<ListBoxItemContext>({});
 /* -------------------------------------------------------------------------------------------------
  * ListBox Item Root
  * -----------------------------------------------------------------------------------------------*/
-interface ListBoxItemRootProps extends ListBoxItemPrimitiveProps, ListBoxItemVariants {
+interface ListBoxItemRootProps
+  extends ComponentPropsWithRef<typeof ListBoxItemPrimitive>,
+    ListBoxItemVariants {
   className?: string;
 }
 
@@ -51,8 +51,7 @@ const ListBoxItemRoot = ({children, className, variant, ...props}: ListBoxItemRo
 /* -------------------------------------------------------------------------------------------------
  * ListBox Item Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface ListBoxItemIndicatorProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+interface ListBoxItemIndicatorProps extends Omit<ComponentPropsWithRef<"span">, "children"> {
   children?: React.ReactNode | ((props: ListBoxItemRenderProps) => React.ReactNode);
 }
 

--- a/packages/react/src/components/listbox-section/listbox-section.tsx
+++ b/packages/react/src/components/listbox-section/listbox-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type {ComponentProps} from "react";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {ListBoxSection as ListBoxSectionPrimitive} from "react-aria-components";
@@ -10,7 +10,7 @@ import {listboxSectionVariants} from "./listbox-section.styles";
 /* -------------------------------------------------------------------------------------------------
  * ListBox Section Root
  * -----------------------------------------------------------------------------------------------*/
-interface ListBoxSectionRootProps extends ComponentProps<typeof ListBoxSectionPrimitive> {
+interface ListBoxSectionRootProps extends ComponentPropsWithRef<typeof ListBoxSectionPrimitive> {
   className?: string;
 }
 

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {ListBoxVariants} from "./listbox.styles";
-import type {ListBoxProps as ListBoxPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {ListBox as ListBoxPrimitive} from "react-aria-components";
@@ -13,7 +13,9 @@ import {listboxVariants} from "./listbox.styles";
 /* -------------------------------------------------------------------------------------------------
  * ListBox Root
  * -----------------------------------------------------------------------------------------------*/
-interface ListBoxRootProps<T extends object> extends ListBoxPrimitiveProps<T>, ListBoxVariants {
+interface ListBoxRootProps<T extends object>
+  extends ComponentPropsWithRef<typeof ListBoxPrimitive<T>>,
+    ListBoxVariants {
   className?: string;
 }
 

--- a/packages/react/src/components/menu-item/menu-item.tsx
+++ b/packages/react/src/components/menu-item/menu-item.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import type {MenuItemVariants} from "./menu-item.styles";
-import type {
-  MenuItemProps as MenuItemPrimitiveProps,
-  MenuItemRenderProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
+import type {MenuItemRenderProps} from "react-aria-components";
 
 import React, {createContext, useContext} from "react";
 import {MenuItem as MenuItemPrimitive} from "react-aria-components";
@@ -27,7 +25,9 @@ const MenuItemContext = createContext<MenuItemContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Menu Item Root
  * -----------------------------------------------------------------------------------------------*/
-interface MenuItemRootProps extends MenuItemPrimitiveProps, MenuItemVariants {
+interface MenuItemRootProps
+  extends ComponentPropsWithRef<typeof MenuItemPrimitive>,
+    MenuItemVariants {
   className?: string;
 }
 
@@ -52,7 +52,7 @@ const MenuItemRoot = ({children, className, variant, ...props}: MenuItemRootProp
 /* -------------------------------------------------------------------------------------------------
  * Menu Item Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface MenuItemIndicatorProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+interface MenuItemIndicatorProps extends Omit<ComponentPropsWithRef<"span">, "children"> {
   children?: React.ReactNode | ((props: MenuItemRenderProps) => React.ReactNode);
   type?: "checkmark" | "dot";
 }
@@ -118,8 +118,7 @@ const MenuItemIndicator = ({
 /* -------------------------------------------------------------------------------------------------
  * Menu Item Submenu Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface MenuItemSubmenuIndicatorProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+interface MenuItemSubmenuIndicatorProps extends Omit<ComponentPropsWithRef<"span">, "children"> {
   children?: React.ReactNode;
 }
 

--- a/packages/react/src/components/menu-section/menu-section.tsx
+++ b/packages/react/src/components/menu-section/menu-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type {ComponentProps} from "react";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {MenuSection as MenuSectionPrimitive} from "react-aria-components";
@@ -10,7 +10,7 @@ import {menuSectionVariants} from "./menu-section.styles";
 /* -------------------------------------------------------------------------------------------------
  * Menu Section Root
  * -----------------------------------------------------------------------------------------------*/
-interface MenuSectionRootProps extends ComponentProps<typeof MenuSectionPrimitive> {
+interface MenuSectionRootProps extends ComponentPropsWithRef<typeof MenuSectionPrimitive> {
   className?: string;
 }
 

--- a/packages/react/src/components/menu/menu.tsx
+++ b/packages/react/src/components/menu/menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {MenuVariants} from "./menu.styles";
-import type {MenuProps as MenuPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {Menu as MenuPrimitive} from "react-aria-components";
@@ -13,7 +13,9 @@ import {menuVariants} from "./menu.styles";
 /* -------------------------------------------------------------------------------------------------
  * Menu Root
  * -----------------------------------------------------------------------------------------------*/
-interface MenuRootProps<T extends object> extends MenuPrimitiveProps<T>, MenuVariants {
+interface MenuRootProps<T extends object>
+  extends ComponentPropsWithRef<typeof MenuPrimitive<T>>,
+    MenuVariants {
   className?: string;
 }
 

--- a/packages/react/src/components/modal/modal.tsx
+++ b/packages/react/src/components/modal/modal.tsx
@@ -3,9 +3,9 @@
 import type {ModalVariants} from "./modal.styles";
 import type {UseOverlayStateProps, UseOverlayStateReturn} from "../../hooks/use-overlay-state";
 import type {SurfaceVariants} from "../surface";
-import type {ComponentProps, HTMLAttributes, ReactNode} from "react";
+import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {
-  ButtonProps as ButtonPrimitiveProps,
+  Button as ButtonPrimitive,
   DialogProps as DialogPrimitiveProps,
 } from "react-aria-components";
 
@@ -43,7 +43,7 @@ const ModalContext = createContext<ModalContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Modal Root
  * -----------------------------------------------------------------------------------------------*/
-interface ModalRootProps extends ComponentProps<typeof ModalTriggerPrimitive> {
+interface ModalRootProps extends ComponentPropsWithRef<typeof ModalTriggerPrimitive> {
   state?: UseOverlayStateReturn;
 }
 
@@ -70,7 +70,7 @@ const ModalRoot = ({children, state, ...props}: ModalRootProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Modal Trigger
  * -----------------------------------------------------------------------------------------------*/
-interface ModalTriggerProps extends HTMLAttributes<HTMLDivElement> {}
+interface ModalTriggerProps extends ComponentPropsWithRef<"div"> {}
 
 const ModalTrigger = ({children, className, ...props}: ModalTriggerProps) => {
   const {slots} = useContext(ModalContext);
@@ -92,7 +92,7 @@ const ModalTrigger = ({children, className, ...props}: ModalTriggerProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Modal Container
  * -----------------------------------------------------------------------------------------------*/
-interface ModalContainerProps extends ComponentProps<typeof ModalPrimitive> {
+interface ModalContainerProps extends ComponentPropsWithRef<typeof ModalPrimitive> {
   placement?: ModalPlacement;
   scroll?: ModalVariants["scroll"];
   variant?: ModalVariants["variant"];
@@ -101,7 +101,7 @@ interface ModalContainerProps extends ComponentProps<typeof ModalPrimitive> {
    * @default true
    */
   isDismissable?: boolean;
-  backdropClassName?: ComponentProps<typeof ModalOverlayPrimitive>["className"];
+  backdropClassName?: ComponentPropsWithRef<typeof ModalOverlayPrimitive>["className"];
 }
 
 const ModalContainer = ({
@@ -167,7 +167,7 @@ const ModalDialog = ({children, className, ...props}: ModalDialogProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Modal Header
  * -----------------------------------------------------------------------------------------------*/
-interface ModalHeaderProps extends HTMLAttributes<HTMLDivElement> {}
+interface ModalHeaderProps extends ComponentPropsWithRef<"div"> {}
 
 const ModalHeader = ({children, className, ...props}: ModalHeaderProps) => {
   const {slots} = useContext(ModalContext);
@@ -182,7 +182,7 @@ const ModalHeader = ({children, className, ...props}: ModalHeaderProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Modal Body
  * -----------------------------------------------------------------------------------------------*/
-interface ModalBodyProps extends HTMLAttributes<HTMLDivElement> {}
+interface ModalBodyProps extends ComponentPropsWithRef<"div"> {}
 
 const ModalBody = ({children, className, ...props}: ModalBodyProps) => {
   const {slots} = useContext(ModalContext);
@@ -197,7 +197,7 @@ const ModalBody = ({children, className, ...props}: ModalBodyProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Modal Footer
  * -----------------------------------------------------------------------------------------------*/
-interface ModalFooterProps extends HTMLAttributes<HTMLDivElement> {}
+interface ModalFooterProps extends ComponentPropsWithRef<"div"> {}
 
 const ModalFooter = ({children, className, ...props}: ModalFooterProps) => {
   const {slots} = useContext(ModalContext);
@@ -212,7 +212,7 @@ const ModalFooter = ({children, className, ...props}: ModalFooterProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Modal Heading
  * -----------------------------------------------------------------------------------------------*/
-interface ModalHeadingProps extends ComponentProps<typeof HeadingPrimitive> {}
+interface ModalHeadingProps extends ComponentPropsWithRef<typeof HeadingPrimitive> {}
 
 const ModalHeading = ({children, className, ...props}: ModalHeadingProps) => {
   const {slots} = useContext(ModalContext);
@@ -232,7 +232,7 @@ const ModalHeading = ({children, className, ...props}: ModalHeadingProps) => {
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog Icon
  * -----------------------------------------------------------------------------------------------*/
-interface ModalIconProps extends ComponentProps<"div"> {}
+interface ModalIconProps extends ComponentPropsWithRef<"div"> {}
 
 const ModalIcon = ({children, className, ...props}: ModalIconProps) => {
   const {slots} = useContext(ModalContext);
@@ -254,8 +254,8 @@ interface ModalCloseTriggerProps {
 }
 
 interface ModalCloseTrigger {
-  (props: {asChild: true} & ComponentProps<"button">): React.JSX.Element;
-  (props: {asChild?: false} & ButtonPrimitiveProps): React.JSX.Element;
+  (props: {asChild: true} & ComponentPropsWithRef<"button">): React.JSX.Element;
+  (props: {asChild?: false} & ComponentPropsWithRef<typeof ButtonPrimitive>): React.JSX.Element;
 }
 
 const ModalCloseTrigger: ModalCloseTrigger = (props) => {

--- a/packages/react/src/components/number-field/number-field.tsx
+++ b/packages/react/src/components/number-field/number-field.tsx
@@ -1,15 +1,11 @@
 "use client";
 
 import type {NumberFieldVariants} from "./number-field.styles";
-import type {
-  ButtonProps,
-  InputProps,
-  NumberFieldProps as NumberFieldPrimitiveProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
-  Button,
+  Button as ButtonPrimitive,
   Group as GroupPrimitive,
   Input as InputPrimitive,
   NumberField as NumberFieldPrimitive,
@@ -33,7 +29,9 @@ const NumberFieldContext = createContext<NumberFieldContext>({});
 /* -------------------------------------------------------------------------------------------------
  * NumberField Root
  * -----------------------------------------------------------------------------------------------*/
-interface NumberFieldRootProps extends NumberFieldPrimitiveProps, NumberFieldVariants {}
+interface NumberFieldRootProps
+  extends ComponentPropsWithRef<typeof NumberFieldPrimitive>,
+    NumberFieldVariants {}
 
 const NumberFieldRoot = ({children, className, isOnSurface, ...props}: NumberFieldRootProps) => {
   const surfaceContext = useContext(SurfaceContext);
@@ -60,7 +58,7 @@ const NumberFieldRoot = ({children, className, isOnSurface, ...props}: NumberFie
 /* -------------------------------------------------------------------------------------------------
  * NumberField Group
  * -----------------------------------------------------------------------------------------------*/
-interface NumberFieldGroupProps extends React.ComponentProps<typeof GroupPrimitive> {}
+interface NumberFieldGroupProps extends ComponentPropsWithRef<typeof GroupPrimitive> {}
 
 const NumberFieldGroup = ({children, className, ...props}: NumberFieldGroupProps) => {
   const {slots} = useContext(NumberFieldContext);
@@ -79,7 +77,7 @@ const NumberFieldGroup = ({children, className, ...props}: NumberFieldGroupProps
 /* -------------------------------------------------------------------------------------------------
  * NumberField Input
  * -----------------------------------------------------------------------------------------------*/
-interface NumberFieldInputProps extends InputProps {
+interface NumberFieldInputProps extends ComponentPropsWithRef<typeof InputPrimitive> {
   isOnSurface?: boolean;
 }
 
@@ -100,7 +98,7 @@ const NumberFieldInput = ({className, isOnSurface, ...props}: NumberFieldInputPr
 /* -------------------------------------------------------------------------------------------------
  * NumberField Increment Button
  * -----------------------------------------------------------------------------------------------*/
-interface NumberFieldIncrementButtonProps extends ButtonProps {}
+interface NumberFieldIncrementButtonProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
 const NumberFieldIncrementButton = ({
   children,
@@ -110,7 +108,7 @@ const NumberFieldIncrementButton = ({
   const {slots} = useContext(NumberFieldContext);
 
   return (
-    <Button
+    <ButtonPrimitive
       className={composeTwRenderProps(className, slots?.incrementButton())}
       data-slot="number-field-increment-button"
       slot="increment"
@@ -121,14 +119,14 @@ const NumberFieldIncrementButton = ({
       ) : (
         <IconPlus data-slot="number-field-increment-button-icon" />
       )}
-    </Button>
+    </ButtonPrimitive>
   );
 };
 
 /* -------------------------------------------------------------------------------------------------
  * NumberField Decrement Button
  * -----------------------------------------------------------------------------------------------*/
-interface NumberFieldDecrementButtonProps extends ButtonProps {}
+interface NumberFieldDecrementButtonProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
 const NumberFieldDecrementButton = ({
   children,
@@ -138,7 +136,7 @@ const NumberFieldDecrementButton = ({
   const {slots} = useContext(NumberFieldContext);
 
   return (
-    <Button
+    <ButtonPrimitive
       className={composeTwRenderProps(className, slots?.decrementButton())}
       data-slot="number-field-decrement-button"
       slot="decrement"
@@ -149,7 +147,7 @@ const NumberFieldDecrementButton = ({
       ) : (
         <IconMinus data-slot="number-field-decrement-button-icon" />
       )}
-    </Button>
+    </ButtonPrimitive>
   );
 };
 

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -2,7 +2,7 @@
 
 import type {PopoverVariants} from "./popover.styles";
 import type {SurfaceVariants} from "../surface";
-import type {PopoverProps as PopoverPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
@@ -31,12 +31,12 @@ const PopoverContext = createContext<PopoverContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Popover Root
  * -----------------------------------------------------------------------------------------------*/
-type PopoverRootProps = React.ComponentProps<typeof PopoverTriggerPrimitive>;
+type PopoverRootProps = ComponentPropsWithRef<typeof PopoverTriggerPrimitive>;
 
 const PopoverRoot = ({
   children,
   ...props
-}: React.ComponentProps<typeof PopoverTriggerPrimitive>) => {
+}: ComponentPropsWithRef<typeof PopoverTriggerPrimitive>) => {
   const slots = React.useMemo(() => popoverVariants(), []);
 
   return (
@@ -51,7 +51,9 @@ const PopoverRoot = ({
 /* -------------------------------------------------------------------------------------------------
  * Popover Content
  * -----------------------------------------------------------------------------------------------*/
-interface PopoverContentProps extends Omit<PopoverPrimitiveProps, "children">, PopoverVariants {
+interface PopoverContentProps
+  extends Omit<ComponentPropsWithRef<typeof PopoverPrimitive>, "children">,
+    PopoverVariants {
   children: React.ReactNode;
 }
 
@@ -76,7 +78,7 @@ const PopoverContent = ({children, className, ...props}: PopoverContentProps) =>
 /* -------------------------------------------------------------------------------------------------
  * Popover Arrow
  * -----------------------------------------------------------------------------------------------*/
-type PopoverArrowProps = Omit<React.ComponentProps<typeof OverlayArrow>, "children"> & {
+type PopoverArrowProps = Omit<ComponentPropsWithRef<typeof OverlayArrow>, "children"> & {
   children?: React.ReactNode;
 };
 
@@ -109,7 +111,7 @@ const PopoverArrow = ({children, className, ...props}: PopoverArrowProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Popover Dialog
  * -----------------------------------------------------------------------------------------------*/
-type PopoverDialogProps = Omit<React.ComponentProps<typeof DialogPrimitive>, "children"> & {
+type PopoverDialogProps = Omit<ComponentPropsWithRef<typeof DialogPrimitive>, "children"> & {
   children: React.ReactNode;
 };
 
@@ -126,7 +128,7 @@ const PopoverDialog = ({children, className, ...props}: PopoverDialogProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Popover Trigger
  * -----------------------------------------------------------------------------------------------*/
-type PopoverTriggerProps = React.HTMLAttributes<HTMLDivElement>;
+type PopoverTriggerProps = ComponentPropsWithRef<"div">;
 
 const PopoverTrigger = ({children, className, ...props}: PopoverTriggerProps) => {
   const {slots} = useContext(PopoverContext);
@@ -148,7 +150,7 @@ const PopoverTrigger = ({children, className, ...props}: PopoverTriggerProps) =>
 /* -------------------------------------------------------------------------------------------------
  * Popover Heading
  * -----------------------------------------------------------------------------------------------*/
-type PopoverHeadingProps = React.ComponentProps<typeof HeadingPrimitive> & {};
+type PopoverHeadingProps = ComponentPropsWithRef<typeof HeadingPrimitive> & {};
 
 const PopoverHeading = ({children, className, ...props}: PopoverHeadingProps) => {
   const {slots} = useContext(PopoverContext);

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {RadioGroupVariants} from "./radio-group.styles";
-import type {RadioGroupProps as RadioGroupPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {useContext} from "react";
 import {RadioGroup as RadioGroupPrimitive} from "react-aria-components";
@@ -14,7 +14,9 @@ import {radioGroupVariants} from "./radio-group.styles";
 /* -------------------------------------------------------------------------------------------------
  * Radio Group Root
  * -----------------------------------------------------------------------------------------------*/
-interface RadioGroupRootProps extends RadioGroupPrimitiveProps, RadioGroupVariants {}
+interface RadioGroupRootProps
+  extends ComponentPropsWithRef<typeof RadioGroupPrimitive>,
+    RadioGroupVariants {}
 
 const RadioGroupRoot = ({children, className, isOnSurface, ...props}: RadioGroupRootProps) => {
   const surfaceContext = useContext(SurfaceContext);

--- a/packages/react/src/components/radio/radio.tsx
+++ b/packages/react/src/components/radio/radio.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type {RadioProps as RadioPrimitiveProps, RadioRenderProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
+import type {RadioRenderProps} from "react-aria-components";
 
 import React, {createContext, useContext} from "react";
 import {Radio as RadioPrimitive} from "react-aria-components";
@@ -22,7 +23,7 @@ const RadioContext = createContext<RadioContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Radio Root
  * -----------------------------------------------------------------------------------------------*/
-interface RadioRootProps extends RadioPrimitiveProps {
+interface RadioRootProps extends ComponentPropsWithRef<typeof RadioPrimitive> {
   /** The name of the radio button, used when submitting an HTML form. */
   name?: string;
 }
@@ -48,7 +49,7 @@ const RadioRoot = ({children, className, ...props}: RadioRootProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Radio Control
  * -----------------------------------------------------------------------------------------------*/
-interface RadioControlProps extends React.HTMLAttributes<HTMLSpanElement> {}
+interface RadioControlProps extends ComponentPropsWithRef<"span"> {}
 
 const RadioControl = ({children, className, ...props}: RadioControlProps) => {
   const {slots} = useContext(RadioContext);
@@ -63,7 +64,7 @@ const RadioControl = ({children, className, ...props}: RadioControlProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Radio Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface RadioIndicatorProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+interface RadioIndicatorProps extends Omit<ComponentPropsWithRef<"span">, "children"> {
   children?: React.ReactNode | ((props: RadioRenderProps) => React.ReactNode);
 }
 
@@ -87,7 +88,7 @@ const RadioIndicator = ({children, className, ...props}: RadioIndicatorProps) =>
 /* -------------------------------------------------------------------------------------------------
  * Radio Content
  * -----------------------------------------------------------------------------------------------*/
-interface RadioContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface RadioContentProps extends ComponentPropsWithRef<"div"> {}
 
 const RadioContent = ({children, className, ...props}: RadioContentProps) => {
   const {slots} = useContext(RadioContext);

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -3,11 +3,11 @@
 import type {SelectVariants} from "./select.styles";
 import type {Booleanish} from "../../utils/assertion";
 import type {SurfaceVariants} from "../surface";
-import type {ButtonProps, SelectProps as SelectPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
-  Button,
+  Button as ButtonPrimitive,
   Popover as PopoverPrimitive,
   Select as SelectPrimitive,
   SelectStateContext,
@@ -34,7 +34,7 @@ const SelectContext = createContext<SelectContext>({});
  * Select Root
  * -----------------------------------------------------------------------------------------------*/
 interface SelectRootProps<T extends object, M extends "single" | "multiple" = "single">
-  extends SelectPrimitiveProps<T, M>,
+  extends ComponentPropsWithRef<typeof SelectPrimitive<T, M>>,
     SelectVariants {
   items?: Iterable<T, M>;
 }
@@ -68,26 +68,26 @@ const SelectRoot = <T extends object = object, M extends "single" | "multiple" =
 /* -------------------------------------------------------------------------------------------------
  * Select Trigger
  * -----------------------------------------------------------------------------------------------*/
-interface SelectTriggerProps extends ButtonProps {}
+interface SelectTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
 const SelectTrigger = ({children, className, ...props}: SelectTriggerProps) => {
   const {slots} = useContext(SelectContext);
 
   return (
-    <Button
+    <ButtonPrimitive
       className={composeTwRenderProps(className, slots?.trigger())}
       data-slot="select-trigger"
       {...props}
     >
       {(values) => <>{typeof children === "function" ? children(values) : children}</>}
-    </Button>
+    </ButtonPrimitive>
   );
 };
 
 /* -------------------------------------------------------------------------------------------------
  * Select Value
  * -----------------------------------------------------------------------------------------------*/
-interface SelectValueProps extends React.ComponentProps<typeof SelectValuePrimitive> {}
+interface SelectValueProps extends ComponentPropsWithRef<typeof SelectValuePrimitive> {}
 
 const SelectValue = ({children, className, ...props}: SelectValueProps) => {
   const {slots} = useContext(SelectContext);
@@ -106,7 +106,7 @@ const SelectValue = ({children, className, ...props}: SelectValueProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Select Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface SelectIndicatorProps extends React.ComponentProps<"svg"> {
+interface SelectIndicatorProps extends ComponentPropsWithRef<"svg"> {
   className?: string;
 }
 
@@ -144,7 +144,7 @@ const SelectIndicator = ({children, className, ...props}: SelectIndicatorProps) 
  * Select Popover
  * -----------------------------------------------------------------------------------------------*/
 interface SelectPopoverProps
-  extends Omit<React.ComponentProps<typeof PopoverPrimitive>, "children"> {
+  extends Omit<ComponentPropsWithRef<typeof PopoverPrimitive>, "children"> {
   children: React.ReactNode;
 }
 

--- a/packages/react/src/components/separator/separator.tsx
+++ b/packages/react/src/components/separator/separator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {SeparatorVariants} from "./separator.styles";
-import type {SeparatorProps as SeparatorPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {useContext} from "react";
 import {Separator as SeparatorPrimitive} from "react-aria-components";
@@ -13,7 +13,9 @@ import {separatorVariants} from "./separator.styles";
 /* -------------------------------------------------------------------------------------------------
  * Separator Root
  * -----------------------------------------------------------------------------------------------*/
-interface SeparatorRootProps extends SeparatorPrimitiveProps, SeparatorVariants {}
+interface SeparatorRootProps
+  extends ComponentPropsWithRef<typeof SeparatorPrimitive>,
+    SeparatorVariants {}
 
 const SeparatorRoot = ({
   className,

--- a/packages/react/src/components/skeleton/skeleton.tsx
+++ b/packages/react/src/components/skeleton/skeleton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {SkeletonVariants} from "./skeleton.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 
@@ -12,7 +13,7 @@ import {skeletonVariants} from "./skeleton.styles";
  * Skeleton Root
  * -----------------------------------------------------------------------------------------------*/
 interface SkeletonRootProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
+  extends Omit<ComponentPropsWithRef<"div">, "children">,
     SkeletonVariants {}
 
 const SkeletonRoot = ({animationType, className, ...props}: SkeletonRootProps) => {

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {SliderVariants} from "./slider.styles";
+import type {ComponentPropsWithRef} from "react";
 import type {SliderRenderProps} from "react-aria-components";
 
 import React, {createContext, useContext} from "react";
@@ -37,7 +38,7 @@ const SliderContext = createContext<SliderContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Slider Root
  * -----------------------------------------------------------------------------------------------*/
-interface SliderRootProps extends React.ComponentProps<typeof SliderPrimitive>, SliderVariants {}
+interface SliderRootProps extends ComponentPropsWithRef<typeof SliderPrimitive>, SliderVariants {}
 
 const SliderRoot = ({
   children,
@@ -66,7 +67,7 @@ const SliderRoot = ({
 /* -------------------------------------------------------------------------------------------------
  * Slider Output
  * -----------------------------------------------------------------------------------------------*/
-interface SliderOutputProps extends React.ComponentProps<typeof SliderOutputPrimitive> {}
+interface SliderOutputProps extends ComponentPropsWithRef<typeof SliderOutputPrimitive> {}
 
 const SliderOutput = ({children, className, ...props}: SliderOutputProps) => {
   const {slots} = useContext(SliderContext);
@@ -87,7 +88,7 @@ const SliderOutput = ({children, className, ...props}: SliderOutputProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Slider Track
  * -----------------------------------------------------------------------------------------------*/
-interface SliderTrackProps extends React.ComponentProps<typeof SliderTrackPrimitive> {}
+interface SliderTrackProps extends ComponentPropsWithRef<typeof SliderTrackPrimitive> {}
 
 const SliderTrack = ({children, className, ...props}: SliderTrackProps) => {
   const {slots, state} = useContext(SliderContext);
@@ -127,7 +128,7 @@ const SliderTrack = ({children, className, ...props}: SliderTrackProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Slider Fill
  * -----------------------------------------------------------------------------------------------*/
-interface SliderFillProps extends React.ComponentProps<"div"> {}
+interface SliderFillProps extends ComponentPropsWithRef<"div"> {}
 
 const SliderFill = ({className, style, ...props}: SliderFillProps) => {
   const {slots, state} = useContext(SliderContext);
@@ -166,7 +167,7 @@ const SliderFill = ({className, style, ...props}: SliderFillProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Slider Thumb
  * -----------------------------------------------------------------------------------------------*/
-interface SliderThumbProps extends React.ComponentProps<typeof SliderThumbPrimitive> {}
+interface SliderThumbProps extends ComponentPropsWithRef<typeof SliderThumbPrimitive> {}
 
 const SliderThumb = ({children, className, ...props}: SliderThumbProps) => {
   const {slots} = useContext(SliderContext);
@@ -185,7 +186,7 @@ const SliderThumb = ({children, className, ...props}: SliderThumbProps) => {
 /* -------------------------------------------------------------------------------------------------
  * TODO: Slider Marks
  * -----------------------------------------------------------------------------------------------*/
-interface SliderMarksProps extends React.ComponentProps<"div"> {}
+interface SliderMarksProps extends ComponentPropsWithRef<"div"> {}
 
 const SliderMarks = ({className, ...props}: SliderMarksProps) => {
   const {slots} = useContext(SliderContext);

--- a/packages/react/src/components/spinner/spinner.tsx
+++ b/packages/react/src/components/spinner/spinner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {SpinnerVariants} from "./spinner.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import {useId} from "react";
 
@@ -11,7 +12,7 @@ import {spinnerVariants} from "./spinner.styles";
  * -------------------------------------------------------------------------------------------------
  * Spinner Primitive
  * -----------------------------------------------------------------------------------------------*/
-interface SpinnerPrimitiveProps extends React.SVGProps<SVGSVGElement> {}
+interface SpinnerPrimitiveProps extends ComponentPropsWithRef<"svg"> {}
 
 const SpinnerPrimitive = ({...props}: SpinnerPrimitiveProps) => {
   const id = useId();
@@ -61,7 +62,7 @@ const SpinnerPrimitive = ({...props}: SpinnerPrimitiveProps) => {
  * Spinner Root
  * -----------------------------------------------------------------------------------------------*/
 interface SpinnerRootProps
-  extends Omit<React.ComponentProps<"svg">, "display" | "opacity" | "color">,
+  extends Omit<ComponentPropsWithRef<"svg">, "display" | "opacity" | "color">,
     SpinnerVariants {}
 
 const SpinnerRoot = ({className, color, size, ...props}: SpinnerRootProps) => {

--- a/packages/react/src/components/surface/surface.tsx
+++ b/packages/react/src/components/surface/surface.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {SurfaceVariants} from "./surface.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import React, {createContext} from "react";
@@ -19,7 +20,7 @@ const SurfaceContext = createContext<SurfaceContext>({});
 /* ------------------------------------------------------------------------------------------------
  * Surface Root
  * --------------------------------------------------------------------------------------------- */
-interface SurfaceRootProps extends React.ComponentProps<"div">, SurfaceVariants {
+interface SurfaceRootProps extends ComponentPropsWithRef<"div">, SurfaceVariants {
   asChild?: boolean;
 }
 

--- a/packages/react/src/components/switch-group/switch-group.tsx
+++ b/packages/react/src/components/switch-group/switch-group.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {SwitchGroupVariants} from "./switch-group.styles";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 
@@ -9,7 +10,7 @@ import {switchGroupVariants} from "./switch-group.styles";
 /* -------------------------------------------------------------------------------------------------
  * Switch Group Root
  * -----------------------------------------------------------------------------------------------*/
-interface SwitchGroupRootProps extends React.HTMLAttributes<HTMLDivElement>, SwitchGroupVariants {}
+interface SwitchGroupRootProps extends ComponentPropsWithRef<"div">, SwitchGroupVariants {}
 
 const SwitchGroupRoot = ({children, className, orientation, ...props}: SwitchGroupRootProps) => {
   const slots = React.useMemo(() => switchGroupVariants({orientation}), [orientation]);

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {SwitchVariants} from "./switch.styles";
-import type {SwitchProps as SwitchPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {Switch as SwitchPrimitive} from "react-aria-components";
@@ -23,7 +23,7 @@ const SwitchContext = createContext<SwitchContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Switch Root
  * -----------------------------------------------------------------------------------------------*/
-interface SwitchRootProps extends SwitchPrimitiveProps, SwitchVariants {}
+interface SwitchRootProps extends ComponentPropsWithRef<typeof SwitchPrimitive>, SwitchVariants {}
 
 const SwitchRoot = ({children, className, ...originalProps}: SwitchRootProps) => {
   const [props, variantProps] = mapPropsVariants(originalProps, switchVariants.variantKeys);
@@ -48,7 +48,7 @@ const SwitchRoot = ({children, className, ...originalProps}: SwitchRootProps) =>
 /* -------------------------------------------------------------------------------------------------
  * Switch Control
  * -----------------------------------------------------------------------------------------------*/
-interface SwitchControlProps extends React.HTMLAttributes<HTMLSpanElement> {}
+interface SwitchControlProps extends ComponentPropsWithRef<"span"> {}
 
 const SwitchControl = ({children, className, ...props}: SwitchControlProps) => {
   const {slots} = useContext(SwitchContext);
@@ -63,7 +63,7 @@ const SwitchControl = ({children, className, ...props}: SwitchControlProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Switch Thumb
  * -----------------------------------------------------------------------------------------------*/
-interface SwitchThumbProps extends React.HTMLAttributes<HTMLSpanElement> {}
+interface SwitchThumbProps extends ComponentPropsWithRef<"span"> {}
 
 const SwitchThumb = ({children, className, ...props}: SwitchThumbProps) => {
   const {slots} = useContext(SwitchContext);
@@ -78,7 +78,7 @@ const SwitchThumb = ({children, className, ...props}: SwitchThumbProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Switch Icon
  * -----------------------------------------------------------------------------------------------*/
-interface SwitchIconProps extends React.HTMLAttributes<HTMLSpanElement> {}
+interface SwitchIconProps extends ComponentPropsWithRef<"span"> {}
 
 const SwitchIcon = ({children, className, ...props}: SwitchIconProps) => {
   const {slots} = useContext(SwitchContext);

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import type {TabsVariants} from "./tabs.styles";
-import type {
-  TabListProps as TabListPrimitiveProps,
-  TabPanelProps as TabPanelPrimitiveProps,
-  TabProps as TabPrimitiveProps,
-  TabsProps as TabsPrimitiveProps,
-} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {createContext, useContext} from "react";
 import {
@@ -34,7 +29,7 @@ const TabsContext = createContext<TabsContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Tabs Root
  * -----------------------------------------------------------------------------------------------*/
-interface TabsRootProps extends TabsPrimitiveProps, TabsVariants {
+interface TabsRootProps extends ComponentPropsWithRef<typeof TabsPrimitive>, TabsVariants {
   children: React.ReactNode;
   className?: string;
 }
@@ -59,7 +54,7 @@ const TabsRoot = ({children, className, orientation = "horizontal", ...props}: T
 /* -------------------------------------------------------------------------------------------------
  * Tabs List Container
  * -----------------------------------------------------------------------------------------------*/
-interface TabListContainerProps extends React.ComponentProps<"div"> {
+interface TabListContainerProps extends ComponentPropsWithRef<"div"> {
   className?: string;
 }
 
@@ -80,7 +75,7 @@ const TabListContainer = ({children, className, ...props}: TabListContainerProps
 /* -------------------------------------------------------------------------------------------------
  * Tabs List
  * -----------------------------------------------------------------------------------------------*/
-interface TabListProps extends TabListPrimitiveProps<object> {
+interface TabListProps extends ComponentPropsWithRef<typeof TabListPrimitive<object>> {
   children: React.ReactNode;
   className?: string;
 }
@@ -102,7 +97,7 @@ const TabList = ({children, className, ...props}: TabListProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Tab
  * -----------------------------------------------------------------------------------------------*/
-interface TabProps extends TabPrimitiveProps {
+interface TabProps extends ComponentPropsWithRef<typeof TabPrimitive> {
   className?: string;
 }
 
@@ -123,7 +118,7 @@ const Tab = ({children, className, ...props}: TabProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Tab Indicator
  * -----------------------------------------------------------------------------------------------*/
-interface TabIndicatorProps extends React.ComponentProps<typeof SelectionIndicatorPrimitive> {
+interface TabIndicatorProps extends ComponentPropsWithRef<typeof SelectionIndicatorPrimitive> {
   className?: string;
 }
 
@@ -142,7 +137,7 @@ const TabIndicator = ({className, ...props}: TabIndicatorProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Tab Panel
  * -----------------------------------------------------------------------------------------------*/
-interface TabPanelProps extends Omit<TabPanelPrimitiveProps, "children"> {
+interface TabPanelProps extends Omit<ComponentPropsWithRef<typeof TabPanelPrimitive>, "children"> {
   children: React.ReactNode;
   className?: string;
 }

--- a/packages/react/src/components/text-field/text-field.tsx
+++ b/packages/react/src/components/text-field/text-field.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {TextFieldVariants} from "./text-field.styles";
-import type {TextFieldProps as TextFieldPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React from "react";
 import {TextField as TextFieldPrimitive} from "react-aria-components";
@@ -13,7 +13,9 @@ import {textFieldVariants} from "./text-field.styles";
 /* -------------------------------------------------------------------------------------------------
  * TextField Root
  * -----------------------------------------------------------------------------------------------*/
-interface TextFieldRootProps extends TextFieldPrimitiveProps, TextFieldVariants {}
+interface TextFieldRootProps
+  extends ComponentPropsWithRef<typeof TextFieldPrimitive>,
+    TextFieldVariants {}
 
 const TextFieldRoot = ({children, className, ...props}: TextFieldRootProps) => {
   const styles = React.useMemo(() => textFieldVariants({}), []);

--- a/packages/react/src/components/text/text.tsx
+++ b/packages/react/src/components/text/text.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {TextVariants} from "./text.styles";
-import type {TextProps as TextPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import {Text as TextPrimitive} from "react-aria-components";
@@ -11,7 +11,7 @@ import {textVariants} from "./text.styles";
 /* -------------------------------------------------------------------------------------------------
  * Text Root
  * -----------------------------------------------------------------------------------------------*/
-interface TextRootProps extends TextPrimitiveProps, TextVariants {
+interface TextRootProps extends ComponentPropsWithRef<typeof TextPrimitive>, TextVariants {
   asChild?: boolean;
 }
 

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {TextAreaVariants} from "./textarea.styles";
-import type {TextAreaProps as TextAreaPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import React, {useContext} from "react";
 import {TextArea as TextAreaPrimitive} from "react-aria-components";
@@ -12,9 +12,11 @@ import {SurfaceContext} from "../surface";
 import {textAreaVariants} from "./textarea.styles";
 
 /* -------------------------------------------------------------------------------------------------
- * Exports
+ * TextArea Root
  * -----------------------------------------------------------------------------------------------*/
-interface TextAreaRootProps extends TextAreaPrimitiveProps, TextAreaVariants {}
+interface TextAreaRootProps
+  extends ComponentPropsWithRef<typeof TextAreaPrimitive>,
+    TextAreaVariants {}
 
 const TextAreaRoot = ({className, isOnSurface, ...rest}: TextAreaRootProps) => {
   const surfaceContext = useContext(SurfaceContext);

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {TooltipVariants} from "./tooltip.styles";
-import type {TooltipProps as TooltipPrimitiveProps} from "react-aria-components";
+import type {ComponentPropsWithRef} from "react";
 
 import {Slot as SlotPrimitive} from "@radix-ui/react-slot";
 import React, {createContext, useContext} from "react";
@@ -28,12 +28,12 @@ const TooltipContext = createContext<TooltipContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Root
  * -----------------------------------------------------------------------------------------------*/
-type TooltipRootProps = React.ComponentProps<typeof TooltipTriggerPrimitive>;
+type TooltipRootProps = ComponentPropsWithRef<typeof TooltipTriggerPrimitive>;
 
 const TooltipRoot = ({
   children,
   ...props
-}: React.ComponentProps<typeof TooltipTriggerPrimitive>) => {
+}: ComponentPropsWithRef<typeof TooltipTriggerPrimitive>) => {
   const slots = React.useMemo(() => tooltipVariants(), []);
 
   return (
@@ -48,7 +48,9 @@ const TooltipRoot = ({
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Content
  * -----------------------------------------------------------------------------------------------*/
-interface TooltipContentProps extends Omit<TooltipPrimitiveProps, "children">, TooltipVariants {
+interface TooltipContentProps
+  extends Omit<ComponentPropsWithRef<typeof TooltipPrimitive>, "children">,
+    TooltipVariants {
   showArrow?: boolean;
   children: React.ReactNode;
 }
@@ -77,7 +79,7 @@ const TooltipContent = ({
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Arrow
  * -----------------------------------------------------------------------------------------------*/
-type TooltipArrowProps = Omit<React.ComponentProps<typeof OverlayArrow>, "children"> & {
+type TooltipArrowProps = Omit<ComponentPropsWithRef<typeof OverlayArrow>, "children"> & {
   children?: React.ReactNode;
 };
 
@@ -110,7 +112,7 @@ const TooltipArrow = ({children, className, ...props}: TooltipArrowProps) => {
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Trigger
  * -----------------------------------------------------------------------------------------------*/
-interface TooltipTriggerProps extends React.HTMLAttributes<HTMLDivElement> {
+interface TooltipTriggerProps extends ComponentPropsWithRef<"div"> {
   asChild?: boolean;
 }
 


### PR DESCRIPTION

Closes # <!-- Github issue # here -->

## 📝 Description

This PR refactors component prop type definitions across all HeroUI components to use React's `ComponentPropsWithRef` utility type instead of directly importing prop types from `react-aria-components`. This change standardizes the typing approach and improves ref forwarding support throughout the component library.

## ⛳️ Current behavior (updates)

Previously, components were using prop types directly imported from `react-aria-components` (e.g., `ButtonProps`, `InputProps`, `SelectProps`). While functional, this approach lacked consistency and didn't provide optimal ref forwarding support.

## 🚀 New behavior
All components now use `ComponentPropsWithRef<typeof ComponentPrimitive>` pattern, which:

- Provides consistent typing across all components
- Ensures proper ref forwarding support
- Maintains full type safety and IntelliSense support
- Aligns with React best practices for component prop typing

## 💣 Is this a breaking change (Yes/No):

**No**

This is a refactoring change that maintains the same public API. The component interfaces remain functionally identical, only the internal type definitions have changed. Existing code using HeroUI components will continue to work without modifications.

## 📝 Additional Information

- Updated 54 component files across the codebase
- All components maintain backward compatibility
- Type checking and linting pass successfully
- No runtime behavior changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors component prop typings to use React’s ComponentPropsWithRef across the library, with minor docs/demo tweaks and a small null‑safety fix.
> 
> - **Refactor: props typing standardization**
>   - Replace `react-aria-components`-specific prop types with `ComponentPropsWithRef<typeof Component>` (and intrinsic elements) across `packages/react` components (e.g., `Accordion`, `AlertDialog`, `Alert`, `Avatar`, `Button`, `Calendar`, `Card`, `Checkbox(Group)`, `Chip`, `CloseButton`, `ComboBox`, `Description`, `Disclosure(Group)`, `Dropdown`, `EmptyState`, `FieldError`, `Fieldset`, `Form`, `Header`, `Input(Group/OTP)`, `Kbd`, `Label`, `Link`, `ListBox(Section/Item)`, `Menu(Section/Item)`, `Modal`, `NumberField`, `Popover`, `Radio(Group)`, `Select`, `Separator`, `Skeleton`, `Slider`, `Spinner`, `Surface`, `Switch(Group)`, `Tabs`, `Text(Field)`, `TextArea`, `Tooltip`).
>   - Adjust related generics/overloads and wrapper types (e.g., triggers, indicators, popovers), preserving public APIs and ref forwarding.
> - **Docs/Examples**
>   - `apps/docs` select demo: add null-safe access `selectedItems[0]?.key`.
>   - `color-swatch-picker`: remove `focusRing` utility usage and related class extension.
>   - Minor Storybook render wrapper change in `Input` story.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c2f85bd3062c5feb9fbdab9953dd89dd4e8ac6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->