### PR TITLE
fix(docs): incorrect date value type in api

### DIFF
--- a/apps/docs/content/docs/components/date-picker.mdx
+++ b/apps/docs/content/docs/components/date-picker.mdx
@@ -365,7 +365,7 @@ import {I18nProvider} from "@react-aria/i18n";
     },
     {
       attribute: "placeholderValue",
-      type: "ZonedDateTime | CalendarDate | CalendarDateTime | undefined | null",
+      type: "DateValue | null",
       description: "The placeholder of the date-picker.",
       default: "-"
     },

--- a/apps/docs/content/docs/components/date-range-picker.mdx
+++ b/apps/docs/content/docs/components/date-range-picker.mdx
@@ -406,13 +406,13 @@ You can customize the `DateRangePicker` component by passing custom Tailwind CSS
     },
     {
       attribute: "minValue",
-      type: "RangeValue<CalendarDate | CalendarDateTime | ZonedDateTime> | undefined | null",
+      type: "DateValue | null",
       description: "The minimum value of the date-range-picker.",
       default: "-"
     },
     {
       attribute: "maxValue",
-      type: "RangeValue<CalendarDate | CalendarDateTime | ZonedDateTime> | undefined | null",
+      type: "DateValue | null",
       description: "The maximum value of the date-range-picker.",
       default: "-"
     },
@@ -424,7 +424,7 @@ You can customize the `DateRangePicker` component by passing custom Tailwind CSS
     },
     {
       attribute: "placeholderValue",
-      type: "ZonedDateTime | CalendarDate | CalendarDateTime | undefined | null",
+      type: "DateValue | null",
       description: "The placeholder of the date-range-picker.",
       default: "-"
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated DatePicker API docs: value and placeholder types narrowed to DateValue | null; defaultValue broadened to DateValue | null for consistency.
  * Updated DateRangePicker API docs: value/minValue/maxValue/placeholder types standardized to DateValue-based types; defaultValue updated to a Range of DateValue | null.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->