### PR TITLE
fix(theme): hide password reveal button

### DIFF
--- a/.changeset/forty-melons-cover.md
+++ b/.changeset/forty-melons-cover.md
@@ -1,0 +1,6 @@
+---
+"@heroui/input": patch
+"@heroui/theme": patch
+---
+
+hide password reveal button (#5984)

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "@heroui/theme": ">=2.4.23",
+    "@heroui/theme": ">=2.4.24",
     "@heroui/system": ">=2.4.18"
   },
   "dependencies": {

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -50,6 +50,7 @@ const input = tv({
       "autofill:bg-transparent bg-clip-text",
       // Safari autofill styling fix - ensures text color is visible in dark mode
       "dark:autofill:[-webkit-text-fill-color:hsl(var(--heroui-foreground))]",
+      "[&::-ms-reveal]:hidden",
     ],
     clearButton: [
       "p-2",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #5984

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password reveal button in input fields is now hidden for consistent rendering across browsers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->