### PR TITLE
fix(storybook): brand urls

### DIFF
--- a/packages/storybook/.storybook/styles/theme.ts
+++ b/packages/storybook/.storybook/styles/theme.ts
@@ -59,7 +59,7 @@ const lightTheme = create({
   ...storybookThemes.light,
   base: "light",
   brandTitle: `<img src="/logo-dark.svg" style="width: 120px; height: auto;" alt="HeroUI"/>`,
-  brandUrl: "https://heroui.com",
+  // brandUrl: "https://heroui.com",
   brandTarget: "_self",
   // Colors
   colorPrimary: colors.accent.DEFAULT,
@@ -93,7 +93,7 @@ const darkTheme = create({
   ...storybookThemes.dark,
   base: "dark",
   brandTitle: `<img src="/logo-light.svg" style="width: 120px; height: auto;" alt="HeroUI"/>`,
-  brandUrl: "https://heroui.com",
+  // brandUrl: "https://heroui.com",
   brandTarget: "_self",
   // Colors
   colorPrimary: colors.accent.DEFAULT,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixed storybook's brand urls, changed it from `https://heroui.com` to `default`.

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

<img width="876" height="404" alt="image" src="https://github.com/user-attachments/assets/57b60fe7-4e2b-4938-a1bf-9bc2da2730d7" />

