### PR TITLE
fix(docs): temporary workaround for error message crash

### DIFF
--- a/apps/docs/src/demos/error-message/basic.tsx
+++ b/apps/docs/src/demos/error-message/basic.tsx
@@ -23,7 +23,7 @@ export function ErrorMessageBasic() {
         <Tag id="shopping">Shopping</Tag>
       </TagGroup.List>
       <Description>Select at least one category</Description>
-      {!!isInvalid && <ErrorMessage>Please select at least one category</ErrorMessage>}
+      <ErrorMessage>{!!isInvalid && <>Please select at least one category</>}</ErrorMessage>
     </TagGroup>
   );
 }

--- a/apps/docs/src/demos/error-message/with-tag-group.tsx
+++ b/apps/docs/src/demos/error-message/with-tag-group.tsx
@@ -24,7 +24,7 @@ export function ErrorMessageWithTagGroup() {
         <Tag id="shopping">Shopping</Tag>
       </TagGroup.List>
       <Description>Select at least one category</Description>
-      {!!isInvalid && <ErrorMessage>Please select at least one category</ErrorMessage>}
+      <ErrorMessage>{!!isInvalid && <>Please select at least one category</>}</ErrorMessage>
     </TagGroup>
   );
 }

--- a/apps/docs/src/demos/tag-group/with-error-message.tsx
+++ b/apps/docs/src/demos/tag-group/with-error-message.tsx
@@ -29,7 +29,7 @@ export function TagGroupWithErrorMessage() {
           ? "Select at least one category"
           : "Selected: " + Array.from(selected).join(", ")}
       </Description>
-      {!!isInvalid && <ErrorMessage>Please select at least one category</ErrorMessage>}
+      <ErrorMessage>{!!isInvalid && <>Please select at least one category</>}</ErrorMessage>
     </TagGroup>
   );
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
Temporary workaround for error message crash.

The crash is caused by a race condition between React and the RAC slot, what we have right now is just a temporary workaround, will revisit the `ErrorMessage` and `TagGroup` composition pattern in the next release.

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

N/A
