### PR TITLE
fix(style): tab indicator animation

### DIFF
--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -135,6 +135,15 @@
 .tabs__panel {
   @apply w-full p-2 outline-none;
 
+  /* Entering animations */
+  &[data-entering="true"] {
+  }
+
+  /* Exiting animations */
+  &[data-exiting="true"] {
+    @apply absolute top-0 left-0 w-full;
+  }
+
   /* Orientation spacing */
   &[data-orientation="horizontal"] {
     @apply mt-4;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixed tab indicator animation.

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

The new version of react-aria-components added tab panel switch animations support. During the panel animations, the indicator’s position was affected, so we fixed its starting position by adding positioning to the panel’s exiting state.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

https://github.com/user-attachments/assets/f5a48c12-e671-4f83-8e37-c6a295712f79

