### PR TITLE
fix: class name added twice

### DIFF
--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -37,7 +37,6 @@ const ButtonRoot = ({
   const finalFullWidth = fullWidth ?? buttonGroupContext?.fullWidth;
 
   const styles = buttonVariants({
-    class: typeof className === "string" ? className : undefined,
     fullWidth: finalFullWidth,
     isIconOnly,
     size: finalSize,

--- a/packages/react/src/components/close-button/close-button.tsx
+++ b/packages/react/src/components/close-button/close-button.tsx
@@ -25,14 +25,7 @@ const CloseButtonRoot = ({
   variant,
   ...rest
 }: CloseButtonRootProps) => {
-  const styles = useMemo(
-    () =>
-      closeButtonVariants({
-        variant,
-        className: typeof className === "string" ? className : undefined,
-      }),
-    [variant, className],
-  );
+  const styles = useMemo(() => closeButtonVariants({variant}), [variant]);
 
   return (
     <ButtonPrimitive


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes the issue where the class name was being added twice.

## ⛳️ Current behavior (updates)

The issue was caused by the tv class and tw-render-props both applying the `className`.

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
