### PR TITLE
fix: rounded link

### DIFF
--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -1,6 +1,6 @@
 /* Base link styles */
 .link {
-  @apply relative inline-flex h-fit w-fit items-center text-sm font-medium text-link no-highlight;
+  @apply relative inline-flex h-fit w-fit items-center rounded-xl text-sm font-medium text-link no-highlight;
 
   /**
    * Transitions


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Added rounded style (`12px`) to the `Link`.

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

<img width="742" height="168" alt="image" src="https://github.com/user-attachments/assets/43de19cc-03da-49a1-ae53-4963113d8c52" />


[Figma Design](https://www.figma.com/design/H0xHxBB8qOKjHHAUCsvgHc/HeroUI-Figma-Kit-V3?node-id=2301-3243&m=dev)

<img width="2521" height="508" alt="image" src="https://github.com/user-attachments/assets/272c5255-6b15-4d95-9f93-c9bc3abb4e6d" />
