### PR TITLE
fix(style): keyboard focus visible

### DIFF
--- a/packages/styles/components/accordion.css
+++ b/packages/styles/components/accordion.css
@@ -81,7 +81,7 @@
   }
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -18,7 +18,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/close-button.css
+++ b/packages/styles/components/close-button.css
@@ -19,7 +19,7 @@
   @apply transform-gpu motion-reduce:transition-none;
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/combobox.css
+++ b/packages/styles/components/combobox.css
@@ -61,7 +61,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply rounded ring-2 ring-focus ring-offset-2 ring-offset-background outline-none;
   }
@@ -94,7 +94,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/disclosure.css
+++ b/packages/styles/components/disclosure.css
@@ -12,7 +12,7 @@
   @apply no-highlight;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -23,7 +23,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -53,7 +53,7 @@
   min-width: 220px;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/input.css
+++ b/packages/styles/components/input.css
@@ -31,7 +31,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 
@@ -66,7 +66,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -27,7 +27,7 @@
   }
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
 

--- a/packages/styles/components/listbox-item.css
+++ b/packages/styles/components/listbox-item.css
@@ -32,7 +32,7 @@
   }
 
   /* Focus visible state (keyboard focus only) */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/menu-item.css
+++ b/packages/styles/components/menu-item.css
@@ -41,7 +41,7 @@
   }
 
   /* Focus visible state (keyboard focus only) */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -109,7 +109,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -53,7 +53,7 @@
 
 /* Popover dialog */
 .popover__dialog {
-  @apply p-4;
+  @apply p-4 outline-none;
 }
 
 /* Popover heading */
@@ -76,7 +76,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -52,7 +52,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
     border-color: var(--color-field-border-focus);
@@ -89,7 +89,7 @@
     }
   }
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     background-color: var(--color-on-surface-focus);
   }
@@ -130,7 +130,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -125,7 +125,7 @@
   }
 
   /* Focus states - comprehensive fallback */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/tag.css
+++ b/packages/styles/components/tag.css
@@ -31,7 +31,7 @@
 }
 
 /* Focus visible state (keyboard focus only) */
-.tag:is(:focus-visible:not(:focus), [data-focus-visible]) {
+.tag:is(:focus-visible, [data-focus-visible]) {
   @apply status-focused;
 }
 
@@ -99,7 +99,7 @@
   }
 
   /* Focus visible state */
-  &:is(:focus-visible:not(:focus), [data-focus-visible]) {
+  &:is(:focus-visible, [data-focus-visible]) {
     background-color: var(--color-on-surface-focus);
   }
 }

--- a/packages/styles/components/textarea.css
+++ b/packages/styles/components/textarea.css
@@ -33,7 +33,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 
@@ -67,7 +67,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -66,7 +66,7 @@
 
   cursor: var(--cursor-interactive);
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixed the conflict with `focus-visible` selector by removing `:not(:focus)`. In CSS, if you’re in `focus-visible`, you’re always in `focus` anyway.

Also removed the `outline` from the popover dialog.

## ⛳️ Current behavior (updates)

N/A

## 🚀 New behavior

N/A

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
