### PR TITLE
fix(styles): dropdown popover width

### DIFF
--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -48,9 +48,8 @@
 
 /* Similar to select popover styles */
 .dropdown__popover {
-  @apply origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain rounded-3xl bg-overlay p-0 text-sm will-change-[opacity,transform];
+  @apply max-w-[48svw] origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain rounded-3xl bg-overlay p-0 text-sm will-change-[opacity,transform] md:min-w-55;
   box-shadow: var(--shadow-overlay);
-  min-width: 220px;
 
   /* Focus state */
   &:focus-visible,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

I believe multi-level design would be a better approach. As a workaround, the original min-width (220px) will be applied on tablet and larger viewport only.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="415" height="636" alt="image" src="https://github.com/user-attachments/assets/0c577cbf-8ab8-40bc-9811-b119c66c21c0" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="403" height="630" alt="image" src="https://github.com/user-attachments/assets/9f0dccb0-c65c-4d5c-8c76-11bc95ed1cf2" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
