### PR TITLE
fix(use-image): resolve race condition with cached images on Firefox/Safari

### DIFF
--- a/.changeset/fix-use-image-race-condition.md
+++ b/.changeset/fix-use-image-race-condition.md
@@ -13,6 +13,7 @@ Event handlers (`onload`/`onerror`) were attached AFTER setting the image `src`.
 - Attach `onload`/`onerror` handlers BEFORE setting `src`
 - Check both `naturalWidth` AND `naturalHeight` (per CodeRabbit review feedback on #4523)
 - Handle synchronous error callbacks for failed cached images
-- Add comprehensive test coverage including synchronous callback scenarios
+- Include `ignoreFallback` in useCallback dependencies to prevent stale closures when prop changes dynamically
+- Add comprehensive test coverage including synchronous callback scenarios and dynamic `ignoreFallback` changes
 
 Fixes #4534, #2259

--- a/packages/hooks/use-image/src/index.ts
+++ b/packages/hooks/use-image/src/index.ts
@@ -144,7 +144,18 @@ export function useImage(props: UseImageProps = {}) {
     }
 
     return "loading";
-  }, [src, crossOrigin, srcSet, sizes, onLoad, onError, loading, shouldBypassImageLoad, flush]);
+  }, [
+    src,
+    crossOrigin,
+    srcSet,
+    sizes,
+    onLoad,
+    onError,
+    ignoreFallback,
+    loading,
+    shouldBypassImageLoad,
+    flush,
+  ]);
 
   useSafeLayoutEffect(() => {
     if (isHydrated) {


### PR DESCRIPTION
Closes #4534
Closes #2259

## Summary

This PR fixes a race condition in the `use-image` hook that caused cached images to remain invisible (stuck at `opacity-0`) on Firefox and Safari. The issue has been reported multiple times and persists despite previous fix attempts.

## Root Cause

The bug occurred because event handlers (`onload`/`onerror`) were attached in a separate `useEffect` that ran **after** setting the image `src`. For cached images, browsers may fire `onload` synchronously when `src` is set, causing the event to be missed entirely since the handler wasn't attached yet.

```javascript
// Previous implementation (problematic)
useEffect(() => {
  imageRef.current.onload = ...  // Attached too late for cached images
}, [imageRef.current]);

const load = () => {
  img.src = src;  // Cached images fire onload HERE, synchronously
}
```

## Solution

Attach handlers **before** setting `src`, ensuring callbacks are caught even for synchronously-loaded cached images:

```javascript
const load = () => {
  img.onload = ...;   // Handlers first
  img.onerror = ...;
  img.src = src;      // Then set src
}
```

Additional improvements:
- Check both `naturalWidth` and `naturalHeight` per feedback on PR #4523
- Handle synchronous error callbacks for cached failed images
- Add comprehensive test coverage for edge cases

## Test Coverage

Added 15 tests (previously 5) covering:
- Basic loading states (pending, loading, loaded, failed)
- Asynchronously cached images
- **Synchronously cached images (Firefox/Safari race condition)**
- **Synchronous error for cached failed images**
- Dynamic `src` changes (undefined → valid, valid → different valid)
- Bypass options (`ignoreFallback`, `shouldBypassImageLoad`)
- Callback invocation (`onLoad`, `onError`)
- Image properties (`crossOrigin`, `srcSet`, `sizes`, `loading`)

## Verification

- All 43 related tests pass (use-image, avatar, image components)
- TypeScript compiles without errors
- ESLint passes with zero warnings
- Build succeeds

## Breaking Changes

None. The hook's public API remains unchanged.

---

Thank you for maintaining HeroUI! Please let me know if you have any questions or would like any changes to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading reliability and eliminated race conditions with cached images
  * Better detection of successful vs failed loads via dimension checks
  * More robust handling of synchronous load/error callbacks

* **Tests**
  * Expanded coverage for loading states, cached-image scenarios, dynamic src changes, and callback/property propagation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->