### PR TITLE
fix(docs): adjust sidebar positioning for responsive layout

### DIFF
--- a/apps/docs/src/components/fumadocs/layouts/notebook/index.tsx
+++ b/apps/docs/src/components/fumadocs/layouts/notebook/index.tsx
@@ -315,8 +315,8 @@ function DocsNavbar({
     <LayoutHeader
       id="nd-subnav"
       className={cn(
-        "data-[transparent=false]:bg-fd-background/80 layout:[--fd-header-height:--spacing(14)] sticky top-(--fd-docs-row-1) z-10 flex flex-col backdrop-blur-sm transition-colors [grid-area:header]",
-        showLayoutTabs && "lg:layout:[--fd-header-height:--spacing(24)]",
+        "data-[transparent=false]:bg-fd-background/80 layout:[--fd-header-height:--spacing(23)] sticky top-(--fd-docs-row-1) z-10 flex flex-col backdrop-blur-sm transition-colors [grid-area:header]",
+        showLayoutTabs && "md:layout:[--fd-header-height:--spacing(25)]",
       )}
     >
       <div className="flex h-14 gap-2 border-b px-4 md:px-6" data-header-body="">

--- a/apps/docs/src/components/fumadocs/layouts/notebook/sidebar.tsx
+++ b/apps/docs/src/components/fumadocs/layouts/notebook/sidebar.tsx
@@ -59,7 +59,7 @@ export function SidebarContent({
             "md:layout:[--fd-sidebar-width:268px] pointer-events-none sticky z-20 [grid-area:sidebar] *:pointer-events-auto max-md:hidden",
             navMode === "auto"
               ? "top-(--fd-docs-row-1) h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))]"
-              : "top-(--fd-docs-row-2) h-[calc(var(--fd-docs-height)-var(--fd-docs-row-2))] max-lg:top-(--fd-docs-row-3) max-lg:h-[calc(var(--fd-docs-height)-var(--fd-docs-row-3))]",
+              : "top-(--fd-docs-row-2) h-[calc(var(--fd-docs-height)-var(--fd-docs-row-2))]",
           )}
         >
           {!!collapsed && <div className="absolute inset-y-0 start-0 w-4" {...rest} />}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR fixes header and sidebar layout spacing issues in the documentation layout for improved responsiveness. The changes update header height calculations and ensure proper alignment between the header and sidebar across different screen sizes.

## ⛳️ Current behavior (updates)

Previously, the header used inconsistent height values (`--spacing(14)` base, `--spacing(24)` with tabs at `lg` breakpoint) which caused misalignment issues between the header and sidebar on different screen sizes. The sidebar positioning was also inconsistent, requiring responsive overrides to account for layout differences.

## 🚀 New behavior

The header heights have been updated to use more consistent spacing values:
- **Base header height**: Changed from `--spacing(14)` to `--spacing(23)` to better accommodate the header content
- **Header with tabs**: Changed from `lg:layout:[--fd-header-height:--spacing(24)]` to `md:layout:[--fd-header-height:--spacing(25)]`, updating both the breakpoint (from `lg` to `md`) and the height value (from `24` to `25`)

These changes ensure that:
- The header has adequate spacing for its content across all screen sizes
- The sidebar can use consistent positioning (`--fd-docs-row-2`) without needing responsive overrides
- The layout maintains proper alignment between header, sidebar, and content areas

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The fix addresses the root cause by adjusting header heights rather than applying workarounds to the sidebar positioning. This provides a more maintainable solution and ensures consistent spacing throughout the documentation layout.