### PR TITLE
fix(docs): incorrect regex extracting CIELAB values

### DIFF
--- a/apps/docs/src/components/color-swatch.tsx
+++ b/apps/docs/src/components/color-swatch.tsx
@@ -18,7 +18,7 @@ interface ColorSwatchProps {
 }
 
 const getLabValue = (value: string): LAB | null => {
-  const match = value.match(/\d+/g);
+  const match = value.match(/-?\d*\.?\d+/g);
 
   if (match && match.length >= 3) {
     return [Number(match[0]), Number(match[1]), Number(match[2])];


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

This PR is to fix the regex extracting CIELAB values. Currently, in [Colors](https://v3.heroui.com/docs/react/getting-started/colors) page, clicking the color circle would set an incorrect value `#FF00FF` in your clipboard. The reason is the current regex doesn't handle negative values and values like `98.9676` would unexpectedly break into `98` and `9676`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

```
lab(100%, 0, 0) -> [100, 0, 0]
lab(98.9676% -.0000298023 -.0000119209) -> [98, 9676, 298023]
lab(47.8738% 1.41454 -4.98644) -> [47, 8738, 1]
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

```
lab(100%, 0, 0) -> [100, 0, 0]
lab(98.9676% -.0000298023 -.0000119209) -> [98.9676, -0.0000298023, -0.0000119209]
lab(47.8738% 1.41454 -4.98644) -> [47.8738, 1.41454, -4.98644]
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
