### PR TITLE
test(dropdown): add tests for textValue selection key handling (#6065)

### DIFF
--- a/.changeset/hungry-seahorses-grab.md
+++ b/.changeset/hungry-seahorses-grab.md
@@ -1,0 +1,5 @@
+---
+"@heroui/dropdown": patch
+---
+
+Add tests for selection key handling with textValue and sections

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -216,6 +216,118 @@ describe("Dropdown", () => {
     expect(onOpenChange).toHaveBeenCalled();
   });
 
+  it("should return correct keys with textValue in DropdownSection (bug #6065)", async () => {
+    let onSelectionChange = jest.fn();
+
+    const wrapper = render(
+      <Dropdown>
+        <DropdownTrigger>
+          <Button data-testid="trigger-test">Trigger</Button>
+        </DropdownTrigger>
+        <DropdownMenu
+          aria-label="Actions"
+          selectionMode="single"
+          onSelectionChange={onSelectionChange}
+        >
+          <DropdownSection title="Sidebar control">
+            <DropdownItem key="expanded" textValue="expanded">
+              Expanded
+            </DropdownItem>
+            <DropdownItem key="collapsed" textValue="collapsed">
+              Collapsed
+            </DropdownItem>
+            <DropdownItem key="hover" textValue="hover">
+              Expand on hover
+            </DropdownItem>
+          </DropdownSection>
+        </DropdownMenu>
+      </Dropdown>,
+    );
+
+    let triggerButton = wrapper.getByTestId("trigger-test");
+
+    await act(async () => {
+      await user.click(triggerButton);
+    });
+
+    let menuItems = wrapper.getAllByRole("menuitemradio");
+
+    expect(menuItems.length).toBe(3);
+
+    await act(async () => {
+      await user.click(menuItems[0]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    // Get the Set passed to onSelectionChange
+    const selectionSet = onSelectionChange.mock.calls[0][0];
+    const selectedKey = Array.from(selectionSet)[0];
+
+    // Bug #6065: This should be "expanded", not "react-aria-123"
+    expect(selectedKey).toBe("expanded");
+  });
+
+  it("should return correct keys with textValue in dynamic DropdownSection (bug #6065)", async () => {
+    let onSelectionChange = jest.fn();
+    const items = [
+      {key: "expanded", label: "Expanded"},
+      {key: "collapsed", label: "Collapsed"},
+      {key: "hover", label: "Expand on hover"},
+    ];
+
+    const wrapper = render(
+      <Dropdown>
+        <DropdownTrigger>
+          <Button data-testid="trigger-test">Trigger</Button>
+        </DropdownTrigger>
+        <DropdownMenu
+          aria-label="Actions"
+          items={[{key: "sidebar", title: "Sidebar control", children: items}]}
+          selectionMode="single"
+          onSelectionChange={onSelectionChange}
+        >
+          {(section: any) => (
+            <DropdownSection
+              aria-label={section.title}
+              items={section.children}
+              title={section.title}
+            >
+              {(item: any) => (
+                <DropdownItem key={item.key} textValue={item.label}>
+                  {item.label}
+                </DropdownItem>
+              )}
+            </DropdownSection>
+          )}
+        </DropdownMenu>
+      </Dropdown>,
+    );
+
+    let triggerButton = wrapper.getByTestId("trigger-test");
+
+    await act(async () => {
+      await user.click(triggerButton);
+    });
+
+    let menuItems = wrapper.getAllByRole("menuitemradio");
+
+    expect(menuItems.length).toBe(3);
+
+    await act(async () => {
+      await user.click(menuItems[0]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    // Get the Set passed to onSelectionChange
+    const selectionSet = onSelectionChange.mock.calls[0][0];
+    const selectedKey = Array.from(selectionSet)[0];
+
+    // Bug #6065: This should be "expanded", not "react-aria-123"
+    expect(selectedKey).toBe("expanded");
+  });
+
   it("should work with multiple selection (controlled)", async () => {
     let onOpenChange = jest.fn();
     let onSelectionChange = jest.fn();


### PR DESCRIPTION
Closes #6065

## 📝 Description

Adds tests for selection key handling with `textValue` and `DropdownSection` to verify and document correct behavior for issue #6065.

## ⛳️ Current behavior (updates)

No tests existed for validating selection keys when using `textValue` prop with `DropdownSection`.

## 🚀 New behavior

- Added test for static `DropdownSection` with `textValue` and `selectionMode`
- Added test for dynamic `DropdownSection` with `textValue` and `selectionMode`
- Both tests verify that `onSelectionChange` returns the correct user-provided keys

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Investigation found that the reported issue (#6065) occurs when section objects lack `key`/[id](cci:1://file:///Users/zen/Desktop/open/heroui/packages/components/dropdown/stories/dropdown.stories.tsx:221:0-237:2) properties in dynamic rendering. When using dynamic sections with `selectionMode`, both section objects AND item objects need `key` or [id](cci:1://file:///Users/zen/Desktop/open/heroui/packages/components/dropdown/stories/dropdown.stories.tsx:221:0-237:2) properties:

```tsx
// ✅ Correct
items={[{ key: "section1", title: "Actions", children: items }]}

// ❌ Incorrect - missing section key
items={[{ title: "Actions", children: items }]}