### PR TITLE
fix(docs): status chip with long text in sidebar

### DIFF
--- a/apps/docs/src/components/fumadocs/layouts/notebook/sidebar.tsx
+++ b/apps/docs/src/components/fumadocs/layouts/notebook/sidebar.tsx
@@ -14,7 +14,7 @@ import {cn} from "@/utils/cn";
 import {LayoutContext} from "./client";
 
 const itemVariants = tv({
-  base: "text-fd-muted-foreground relative flex flex-row items-center gap-2 rounded-lg p-2 text-start wrap-anywhere [&_svg]:size-4 [&_svg]:shrink-0",
+  base: "text-fd-muted-foreground relative flex flex-row items-center gap-2 rounded-lg p-2 text-start [&_svg]:size-4 [&_svg]:shrink-0",
   variants: {
     highlight: {
       true: "data-[active=true]:before:bg-fd-primary data-[active=true]:before:absolute data-[active=true]:before:inset-y-2.5 data-[active=true]:before:start-2.5 data-[active=true]:before:w-px data-[active=true]:before:content-['']",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Tried revising the width of the sidebar but it doesn't look good compared with the existing one. Hence, this PR is simply to remove `wrap-anywhere` in sidebar item to keep the layout width same. There may be a problem if the text is super long. Even with `wrap-anywhere` it won't look good. So far we don't have such case tho.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="297" height="196" alt="image" src="https://github.com/user-attachments/assets/7e3e46fe-00e3-4421-87c1-439f09c590fb" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="298" height="208" alt="image" src="https://github.com/user-attachments/assets/d83b54cf-bf10-454e-9bc1-e3e0ceabb7a4" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
