### PR TITLE
fix(docs): broken links in Form page

### DIFF
--- a/apps/docs/content/docs/guide/forms.mdx
+++ b/apps/docs/content/docs/guide/forms.mdx
@@ -39,7 +39,7 @@ Most fields should have a visible label. In rare exceptions, the `aria-label` or
 How you submit form data depends on your framework, application, and server. By default, **HTML** forms are submitted via a full-page refresh in the browser.
 You can call `preventDefault` in the `onSubmit` event to handle form data submission via an API.
 
-Frameworks like [Next.js](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#forms), [Remix](https://remix.run/docs/en/main/guides/forms), and [React Router](https://reactrouter.com/en/main/route/form-submission) provide their own ways to handle form submission.
+Frameworks like [Next.js](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#forms), [Remix](https://v2.remix.run/docs/components/form), and [React Router](https://reactrouter.com/api/components/Form) provide their own ways to handle form submission.
 
 #### Uncontrolled forms
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

This PR fixes broken links on the [Forms guide page](https://www.heroui.com/docs/guide/forms#submitting-data)

## ⛳️ Current behavior (updates)

Links to the guides on form submission in Remix and React Router currently lead to 404 pages

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

I found new pages in the docs of both frameworks that might correspond to the intended URLs:

- Remix: https://v2.remix.run/docs/components/form
  - Also might be: https://v2.remix.run/docs/hooks/use-submit
- React Router: https://reactrouter.com/api/components/Form
  - Also might be: https://reactrouter.com/api/hooks/useSubmit

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
