### PR TITLE
docs(text-field): update anatomy as per latest api

### DIFF
--- a/apps/docs/content/docs/native/components/(forms)/text-field.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/text-field.mdx
@@ -24,10 +24,7 @@ import { TextField } from 'heroui-native';
 ```tsx
 <TextField>
   <TextField.Label>...</TextField.Label>
-  <TextField.Input>
-    <TextField.InputStartContent>...</TextField.InputStartContent>
-    <TextField.InputEndContent>...</TextField.InputEndContent>
-  </TextField.Input>
+  <TextField.Input />
   <TextField.Description>...</TextField.Description>
   <TextField.ErrorMessage>...</TextField.ErrorMessage>
 </TextField>
@@ -36,8 +33,6 @@ import { TextField } from 'heroui-native';
 - **TextField**: Root container that provides spacing and state management
 - **TextField.Label**: Label with optional asterisk for required fields
 - **TextField.Input**: Input container with animated border and background
-- **TextField.InputStartContent**: Optional content at the start of the input
-- **TextField.InputEndContent**: Optional content at the end of the input
 - **TextField.Description**: Helper text displayed below the input
 - **TextField.ErrorMessage**: Error message shown when field is invalid
 


### PR DESCRIPTION
## 📝 Description

Removed `InputStartContent` and `InputEndContent` from the anatomy example and component list as per latest API.

## ⛳️ Current behavior (updates)

The TextField documentation includes `TextField.InputStartContent` and `TextField.InputEndContent` in the anatomy example and component list.

## 🚀 New behavior

- Removed `TextField.InputStartContent` and `TextField.InputEndContent` from the anatomy code example
- Removed these components from the component list documentation

## 💣 Is this a breaking change (Yes/No):

**No** - This is a documentation-only change that does not affect the actual component implementation or API.

## 📝 Additional Information

This change improves documentation. No code changes or dependencies were modified.