### PR TITLE
feat(input-group): focus input when decorative elements are clicked

### DIFF
--- a/packages/react/src/components/input-group/input-group.tsx
+++ b/packages/react/src/components/input-group/input-group.tsx
@@ -36,6 +36,7 @@ const InputGroupRoot = ({
   className,
   fullWidth,
   inSurface,
+  onClick,
   ...props
 }: InputGroupRootProps) => {
   const textFieldContext = useContext(TextFieldContext);
@@ -55,6 +56,8 @@ const InputGroupRoot = ({
     if (input && target !== input && !input.contains(target)) {
       input.focus();
     }
+
+    onClick?.(e);
   };
 
   return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

For a better user experience, all decorative elements inside InputGroup should focus the Input when clicked.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr6091.webm](https://github.com/user-attachments/assets/c9fca000-a1b4-452a-a184-27a5b87320b2)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
