### PR TITLE
docs(native): update select example content style

### DIFF
--- a/apps/docs/content/docs/native/components/(forms)/select.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/select.mdx
@@ -374,7 +374,7 @@ export default function SelectExample() {
       </Select.Trigger>
       <Select.Portal>
         <Select.Overlay />
-        <Select.Content width={280} className="rounded-2xl" placement="bottom">
+        <Select.Content width={280} className="rounded-2xl h-[250px]" placement="bottom">
           <ScrollView>
             {COUNTRIES.map((item) => (
               <Select.Item


### PR DESCRIPTION
## 📝 Description

Adds a fixed height (`h-[250px]`) to the Select.Content component in the documentation example. This ensures consistent visual presentation and proper scrolling behavior in the Select component demo.

## ⛳️ Current behavior (updates)

The Select.Content component in the documentation example does not have a fixed height, which can cause inconsistent display or scrolling issues in the demo.

## 🚀 New behavior

- Select.Content now has a fixed height of 250px (`h-[250px]`) in the documentation example
- Ensures consistent visual presentation and proper ScrollView behavior

## 💣 Is this a breaking change (Yes/No):

**No** - This change only affects documentation examples and does not modify any component implementation or API.

## 📝 Additional Information

This is a documentation-only change that improves the visual consistency of the Select component example. No dependencies or testing changes required.