### PR TITLE
fix(toast): duplicate toasts at multiple positions on placement

### DIFF
--- a/packages/components/toast/src/toast-region.tsx
+++ b/packages/components/toast/src/toast-region.tsx
@@ -77,7 +77,7 @@ export function ToastRegion<T extends ToastProps>({
 
   return (
     <div
-      {...mergeProps(regionProps, hoverProps)}
+      {...(mergeProps(regionProps, hoverProps) as React.HTMLAttributes<HTMLDivElement>)}
       ref={ref}
       className={slots.base({class: baseStyles})}
       data-placement={placement}


### PR DESCRIPTION
Closes #6082 

## 📝 Description

This PR addresses multiple issues with the Toast component. It refactors the internal toast queue management to creating independent queues for each placement position, resolving the bug where toasts would duplicate across different positions.

## ⛳️ Current behavior (updates)

- Duplicate Toasts: triggering a toast with a different placement caused duplicate toasts to appear in multiple rendering regions simultaneously.
- Build Error: The project failed to build due to a TS2322 error caused by incompatible csstype definitions between react and csstype packages in mergeProps. (I came across this build issue while solving the prior bug)

## 🚀 New behavior

- Isolated Queues: ToastProvider now manages separate ToastQueue instances for each placement (e.g., top-left, bottom-right). This ensures that adding a toast to one placement does not affect or duplicate into others.
- Type Safety: Applied a type cast in ToastRegion to resolve the csstype conflict, allowing the project to build successfully.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
- Fixed TS2322 error in toast-region.tsx.
- Refactored toast-provider.tsx to use a Map<ToastPlacement, ToastQueue> instead of a global queue.


## Screencasts

https://github.com/user-attachments/assets/92f46aea-6f8a-4383-b37b-acf0d8504ead


https://github.com/user-attachments/assets/e8f34ed2-5d60-4536-ac30-b85e70a2537f


