### PR TITLE
fix(styles): align placeholder color with input

### DIFF
--- a/packages/styles/components/input-group.css
+++ b/packages/styles/components/input-group.css
@@ -52,7 +52,7 @@
 }
 
 .input-group__input {
-  @apply flex-1 rounded-none border-0 bg-transparent px-3 py-2 text-base shadow-none outline-none sm:text-sm;
+  @apply flex-1 rounded-none border-0 bg-transparent px-3 py-2 text-base shadow-none outline-none placeholder:text-field-placeholder sm:text-sm;
 
   /* Remove border radius on left side when prefix is present */
   .input-group:has([data-slot="input-group-prefix"]) & {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

as titled

## ⛳️ Current behavior (updates)

top: InputGroup.Input, botton: Input

<!--- Please describe the current behavior that you are modifying -->

<img width="550" height="212" alt="image" src="https://github.com/user-attachments/assets/97c5578f-3cf0-4131-8d97-b3409c15dcfa" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

top: InputGroup.Input, botton: Input

<img width="555" height="211" alt="image" src="https://github.com/user-attachments/assets/85be3b07-ebad-4d9c-9b82-f5d7b429be07" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
