### PR TITLE
fix(color-picker): handle undefined hue in oklch conversion for white color

### DIFF
--- a/apps/docs/src/components/color-picker/utils/color-format.ts
+++ b/apps/docs/src/components/color-picker/utils/color-format.ts
@@ -147,16 +147,7 @@ export const getValuesFromOklch = (
   const oklch = converter("oklch");
   const oklchColor = oklch(hsl);
 
-  if (
-    !oklchColor ||
-    oklchColor.c === undefined ||
-    oklchColor.h === undefined ||
-    oklchColor.l === undefined
-  ) {
-    return {chroma: 0, hue: 0, lightness: 0};
-  }
-
-  return {chroma: oklchColor.c, hue: oklchColor.h, lightness: oklchColor.l};
+  return {chroma: oklchColor?.c ?? 0, hue: oklchColor?.h ?? 0, lightness: oklchColor?.l ?? 0};
 };
 
 /* -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #

## 📝 Description

Fix oklch color conversion returning black when the input color is white.

## ⛳️ Current behavior (updates)

When converting white colors to oklch format, the hue value is `undefined` (since white has no hue). The previous logic checked if **any** of the oklch values (`c`, `h`, or `l`) was undefined, and if so, returned all zeros (`{chroma: 0, hue: 0, lightness: 0}`). This caused white colors to be incorrectly converted to black because the valid lightness value was being overwritten with 0.

## 🚀 New behavior

Using nullish coalescing (`??`) to only default individual undefined values to 0, while preserving valid values. This ensures that white colors (which have high lightness but undefined hue) are correctly handled and no longer converted to black.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The fix simplifies the code from a verbose conditional check to a single line using nullish coalescing operators.