### PR TITLE
docs: use consistent font name

### DIFF
--- a/apps/docs/content/docs/native/getting-started/(handbook)/theming.mdx
+++ b/apps/docs/content/docs/native/getting-started/(handbook)/theming.mdx
@@ -306,9 +306,9 @@ After loading the fonts, override the font CSS variables in your `global.css` fi
 
 ```css
 @theme {
-  --font-normal: 'YourFont-Regular';
-  --font-medium: 'YourFont-Medium';
-  --font-semibold: 'YourFont-SemiBold';
+  --font-normal: 'YourFont-400Regular';
+  --font-medium: 'YourFont-500Medium';
+  --font-semibold: 'YourFont-600SemiBold';
 }
 ```
 


### PR DESCRIPTION
The example looked wrong since in the docs it is mentioned: `Note: The font names in CSS variables should match the PostScript names of your loaded fonts. Check your font package documentation or use the font names exactly as they appear in your useFonts hook.`

But actually different names were being used in `useFonts` hook and in `global.css`.