### PR TITLE
chore(card): use secondary variant for input in surface

### DIFF
--- a/apps/docs/src/demos/card/with-form.tsx
+++ b/apps/docs/src/demos/card/with-form.tsx
@@ -27,11 +27,11 @@ export function WithForm() {
           <div className="flex flex-col gap-4">
             <TextField name="email" type="email">
               <Label>Email</Label>
-              <Input placeholder="email@example.com" />
+              <Input placeholder="email@example.com" variant="secondary" />
             </TextField>
             <TextField name="password" type="password">
               <Label>Password</Label>
-              <Input placeholder="••••••••" />
+              <Input placeholder="••••••••" variant="secondary" />
             </TextField>
           </div>
         </Card.Content>

--- a/packages/react/src/components/card/card.stories.tsx
+++ b/packages/react/src/components/card/card.stories.tsx
@@ -483,11 +483,11 @@ export const WithForm: Story = {
             <div className="flex flex-col gap-4">
               <TextField name="email" type="email">
                 <Label>Email</Label>
-                <Input placeholder="email@example.com" />
+                <Input placeholder="email@example.com" variant="secondary" />
               </TextField>
               <TextField name="password" type="password">
                 <Label>Password</Label>
-                <Input placeholder="••••••••" />
+                <Input placeholder="••••••••" variant="secondary" />
               </TextField>
             </div>
           </Card.Content>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

updated With form example in Card documentation page and storybook by changing input variant to `secondary` to apply the lower emphasis variant suitable for surface backgrounds.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="472" height="326" alt="image" src="https://github.com/user-attachments/assets/ec69fbb9-4c46-4815-ba22-c273a4b18c77" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="479" height="327" alt="image" src="https://github.com/user-attachments/assets/4a05dfb2-d157-413f-87c5-540a653c51d0" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
