### PR TITLE
refactor(styles): make calculated variables depend only on root vars

### DIFF
--- a/packages/styles/themes/shared/theme.css
+++ b/packages/styles/themes/shared/theme.css
@@ -39,16 +39,16 @@
   --shadow-field: var(--field-shadow);
 
   /* Form Field Tokens */
-  --color-field: var(--field-background, var(--color-default));
+  --color-field: var(--field-background, var(--default));
   --color-field-hover: color-mix(
     in oklab,
-    var(--field-background, var(--color-default)) 90%,
-    var(--field-foreground, var(--color-default-foreground)) 10%
+    var(--field-background, var(--default)) 90%,
+    var(--field-foreground, var(--default-foreground)) 10%
   );
-  --color-field-foreground: var(--field-foreground, var(--color-foreground));
-  --color-field-placeholder: var(--field-placeholder, var(--color-muted));
-  --color-field-border: var(--field-border, var(--color-border));
-  --radius-field: var(--field-radius, var(--radius-xl));
+  --color-field-foreground: var(--field-foreground, var(--foreground));
+  --color-field-placeholder: var(--field-placeholder, var(--muted));
+  --color-field-border: var(--field-border, var(--border));
+  --radius-field: var(--field-radius, calc(var(--radius) * 1.5));
   --border-width-field: var(--field-border-width, var(--border-width));
 
   /* Calculated Variables */
@@ -56,79 +56,51 @@
   /* Colors */
 
   /* --- background shades --- */
-  --color-background-secondary: color-mix(
-    in oklab,
-    var(--color-background) 96%,
-    var(--color-foreground) 4%
-  );
-  --color-background-tertiary: color-mix(
-    in oklab,
-    var(--color-background) 92%,
-    var(--color-foreground) 8%
-  );
-  --color-background-inverse: var(--color-foreground);
+  --color-background-secondary: color-mix(in oklab, var(--background) 96%, var(--foreground) 4%);
+  --color-background-tertiary: color-mix(in oklab, var(--background) 92%, var(--foreground) 8%);
+  --color-background-inverse: var(--foreground);
 
   /* ------------------------- */
-  --color-default-hover: color-mix(
-    in oklab,
-    var(--color-default) 96%,
-    var(--color-default-foreground) 4%
-  );
-  --color-accent-hover: color-mix(
-    in oklab,
-    var(--color-accent) 90%,
-    var(--color-accent-foreground) 10%
-  );
-  --color-success-hover: color-mix(
-    in oklab,
-    var(--color-success) 90%,
-    var(--color-success-foreground) 10%
-  );
-  --color-warning-hover: color-mix(
-    in oklab,
-    var(--color-warning) 90%,
-    var(--color-warning-foreground) 10%
-  );
-  --color-danger-hover: color-mix(
-    in oklab,
-    var(--color-danger) 90%,
-    var(--color-danger-foreground) 10%
-  );
+  --color-default-hover: color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%);
+  --color-accent-hover: color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%);
+  --color-success-hover: color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%);
+  --color-warning-hover: color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%);
+  --color-danger-hover: color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%);
 
   /* Form Field Colors */
   --color-field-hover: color-mix(
     in oklab,
-    var(--color-field) 90%,
-    var(--color-field-foreground) 2%
+    var(--field-background, var(--default)) 90%,
+    var(--field-foreground, var(--foreground)) 2%
   );
-  --color-field-focus: var(--color-field);
+  --color-field-focus: var(--field-background, var(--default));
   --color-field-border-hover: color-mix(
     in oklab,
-    var(--color-field-border) 88%,
-    var(--color-field-foreground) 10%
+    var(--field-border, var(--border)) 88%,
+    var(--field-foreground, var(--foreground)) 10%
   );
   --color-field-border-focus: color-mix(
     in oklab,
-    var(--color-field-border) 74%,
-    var(--color-field-foreground) 22%
+    var(--field-border, var(--border)) 74%,
+    var(--field-foreground, var(--foreground)) 22%
   );
 
   /* Soft Colors */
-  --color-accent-soft: color-mix(in oklab, var(--color-accent) 15%, transparent);
-  --color-accent-soft-foreground: var(--color-accent);
-  --color-accent-soft-hover: color-mix(in oklab, var(--color-accent) 20%, transparent);
+  --color-accent-soft: color-mix(in oklab, var(--accent) 15%, transparent);
+  --color-accent-soft-foreground: var(--accent);
+  --color-accent-soft-hover: color-mix(in oklab, var(--accent) 20%, transparent);
 
-  --color-danger-soft: color-mix(in oklab, var(--color-danger) 15%, transparent);
-  --color-danger-soft-foreground: var(--color-danger);
-  --color-danger-soft-hover: color-mix(in oklab, var(--color-danger) 20%, transparent);
+  --color-danger-soft: color-mix(in oklab, var(--danger) 15%, transparent);
+  --color-danger-soft-foreground: var(--danger);
+  --color-danger-soft-hover: color-mix(in oklab, var(--danger) 20%, transparent);
 
-  --color-warning-soft: color-mix(in oklab, var(--color-warning) 15%, transparent);
-  --color-warning-soft-foreground: var(--color-warning);
-  --color-warning-soft-hover: color-mix(in oklab, var(--color-warning) 20%, transparent);
+  --color-warning-soft: color-mix(in oklab, var(--warning) 15%, transparent);
+  --color-warning-soft-foreground: var(--warning);
+  --color-warning-soft-hover: color-mix(in oklab, var(--warning) 20%, transparent);
 
-  --color-success-soft: color-mix(in oklab, var(--color-success) 15%, transparent);
-  --color-success-soft-foreground: var(--color-success);
-  --color-success-soft-hover: color-mix(in oklab, var(--color-success) 20%, transparent);
+  --color-success-soft: color-mix(in oklab, var(--success) 15%, transparent);
+  --color-success-soft-foreground: var(--success);
+  --color-success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
 
   /* Surface Levels - progressively darker/lighter shades for layering */
   --color-surface-secondary: color-mix(in oklab, var(--surface) 94%, var(--surface-foreground) 6%);
@@ -138,7 +110,7 @@
   --color-on-surface: color-mix(in oklab, var(--surface) 93%, var(--surface-foreground) 7%);
   --color-on-surface-foreground: var(--surface-foreground);
   --color-on-surface-hover: color-mix(in oklab, var(--surface) 91%, var(--surface-foreground) 9%);
-  --color-on-surface-focus: var(--color-on-surface);
+  --color-on-surface-focus: color-mix(in oklab, var(--surface) 93%, var(--surface-foreground) 7%);
 
   /* On Surface Colors - Secondary (on secondary surface) */
   --color-on-surface-secondary: color-mix(
@@ -152,7 +124,11 @@
     var(--surface) 85%,
     var(--surface-foreground) 15%
   );
-  --color-on-surface-secondary-focus: var(--color-on-surface-secondary);
+  --color-on-surface-secondary-focus: color-mix(
+    in oklab,
+    var(--surface) 87%,
+    var(--surface-foreground) 13%
+  );
 
   /* On Surface Colors - Tertiary (on tertiary surface) */
   --color-on-surface-tertiary: color-mix(
@@ -166,7 +142,11 @@
     var(--surface) 84%,
     var(--surface-foreground) 16%
   );
-  --color-on-surface-tertiary-focus: var(--color-on-surface-tertiary);
+  --color-on-surface-tertiary-focus: color-mix(
+    in oklab,
+    var(--surface) 85%,
+    var(--surface-foreground) 15%
+  );
 
   /* Separator Colors - Levels */
   --color-separator-secondary: color-mix(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR refactors the theme system to ensure all calculated variables in `theme.css` depend solely on root variables from `variables.css`, eliminating dependencies between calculated variables. This creates a cleaner dependency hierarchy and improves maintainability.

## ⛳️ Current behavior (updates)

Previously, calculated variables could depend on other calculated variables, creating indirect dependency chains. For example:
- `--color-accent-soft` depended on `--color-accent` (which itself was `var(--accent)`)
- `--color-field-focus` depended on `--color-field` (which itself was `var(--field-background, var(--default))`)
- `--color-on-surface-focus` depended on `--color-on-surface` (which was a `color-mix()` calculation)
- `--radius-field` depended on `--radius-xl` (which was `calc(var(--radius) * 1.5)`)

This created unnecessary indirection and made the dependency graph harder to understand.

## 🚀 New behavior

All calculated variables now reference root variables directly:
- `--color-accent-soft` now uses `var(--accent)` directly instead of `var(--color-accent)`
- `--color-field-focus` now uses `var(--field-background, var(--default))` directly instead of `var(--color-field)`
- `--color-on-surface-focus` now uses the full `color-mix()` expression directly instead of `var(--color-on-surface)`
- `--radius-field` now uses `calc(var(--radius) * 1.5)` directly instead of `var(--radius-xl)`

**Important**: All visual outputs remain identical - the same `color-mix()` percentages and fallback values are preserved. This is purely a structural refactoring with no visual changes.

## 💣 Is this a breaking change (Yes/No):

**No** - This is an internal refactoring that maintains 100% visual compatibility. All calculated variables produce the same results, just with cleaner dependencies.

## 📝 Additional Information

### Changes Made:
- **Form Field Variables**: Updated `--color-field-hover`, `--color-field-focus`, `--color-field-border-hover/focus`, and `--radius-field` to use root variables
- **Soft Color Variables**: Updated all `--color-*-soft` variables (accent, danger, warning, success) to reference root variables directly
- **On Surface Focus Variables**: Updated `--color-on-surface-*-focus` variables to use full `color-mix()` expressions instead of referencing other calculated variables

### Verification:
- ✅ No `var(--color-*)` references found in calculated variables
- ✅ No `var(--radius-*)` references found in calculated variables
- ✅ All calculated variables trace back to root variables in `variables.css`
- ✅ All `color-mix()` calculations produce identical visual results