### PR TITLE
feat(theme-builder): add keyboard shortcuts for quick actions

### DIFF
--- a/apps/docs/src/app/themes/components/builder-header.tsx
+++ b/apps/docs/src/app/themes/components/builder-header.tsx
@@ -7,11 +7,12 @@ import {
   Link as LinkIcon,
   NodesRight,
 } from "@gravity-ui/icons";
-import {Button, Chip, Separator, Tabs, Tooltip, toast} from "@heroui/react";
+import {Button, Chip, Kbd, Separator, Tabs, Tooltip, toast} from "@heroui/react";
 import Link from "next/link";
 
 import {HeroUILogo} from "@/components/heroui-logo";
 import {useCodePanel} from "@/hooks/use-code-panel";
+import useKeyPress from "@/hooks/use-key-press";
 
 import {tabs} from "../constants";
 import {useUndoRedo} from "../hooks";
@@ -32,6 +33,9 @@ export function BuilderHeader() {
       variant: "success",
     });
   };
+
+  useKeyPress("ArrowLeft", () => undo(), {enabled: canUndo});
+  useKeyPress("ArrowRight", () => redo(), {enabled: canRedo});
 
   return (
     <div className="sticky top-0 z-50 mb-3 flex h-14 w-full items-center justify-center bg-background px-2 min-[1200px]:mb-6 min-[1200px]:px-0">
@@ -55,7 +59,12 @@ export function BuilderHeader() {
               </Tooltip.Trigger>
               <Tooltip.Content>
                 <Tooltip.Arrow />
-                <p>Undo last change</p>
+                <p>
+                  Undo last change{" "}
+                  <Kbd>
+                    <Kbd.Abbr keyValue="left" />
+                  </Kbd>
+                </p>
               </Tooltip.Content>
             </Tooltip>
             <Tooltip closeDelay={0} delay={100}>
@@ -71,7 +80,12 @@ export function BuilderHeader() {
                 </Button>
                 <Tooltip.Content>
                   <Tooltip.Arrow />
-                  <p>Redo last change</p>
+                  <p>
+                    Redo last change{" "}
+                    <Kbd>
+                      <Kbd.Abbr keyValue="right" />
+                    </Kbd>
+                  </p>
                 </Tooltip.Content>
               </Tooltip.Trigger>
             </Tooltip>

--- a/apps/docs/src/app/themes/components/reset-button.tsx
+++ b/apps/docs/src/app/themes/components/reset-button.tsx
@@ -1,6 +1,8 @@
 import {ArrowRotateLeft} from "@gravity-ui/icons";
-import {AlertDialog, Button, Tooltip} from "@heroui/react";
+import {AlertDialog, Button, Kbd, Tooltip, useOverlayState} from "@heroui/react";
 import {useMemo} from "react";
+
+import useKeyPress from "@/hooks/use-key-press";
 
 import {defaultThemeVariables} from "../constants";
 import {useResetVariables} from "../hooks";
@@ -9,6 +11,7 @@ import {useVariablesState} from "../hooks/use-variables-state";
 export function ResetButton() {
   const reset = useResetVariables();
   const [variables] = useVariablesState();
+  const {isOpen, setOpen} = useOverlayState();
 
   const isDisabled = useMemo(() => {
     return (
@@ -22,10 +25,12 @@ export function ResetButton() {
     );
   }, [variables]);
 
+  useKeyPress("d", () => setOpen(true), {enabled: !isDisabled});
+
   return (
     <Tooltip closeDelay={0} delay={100}>
       <Tooltip.Trigger>
-        <AlertDialog>
+        <AlertDialog isOpen={isOpen} onOpenChange={setOpen}>
           <Button isIconOnly isDisabled={isDisabled} size="md" variant="tertiary">
             <ArrowRotateLeft />
           </Button>
@@ -67,7 +72,12 @@ export function ResetButton() {
       </Tooltip.Trigger>
       <Tooltip.Content>
         <Tooltip.Arrow />
-        <p>Reset to defaults</p>
+        <p>
+          Reset to defaults{" "}
+          <Kbd>
+            <Kbd.Content>D</Kbd.Content>
+          </Kbd>
+        </p>
       </Tooltip.Content>
     </Tooltip>
   );

--- a/apps/docs/src/app/themes/components/theme-popover.tsx
+++ b/apps/docs/src/app/themes/components/theme-popover.tsx
@@ -3,9 +3,10 @@
 import type {ThemeId} from "../constants";
 
 import {BucketPaint, ChevronsExpandVertical} from "@gravity-ui/icons";
-import {InputGroup, Label, ListBox, Popover} from "@heroui/react";
+import {InputGroup, Kbd, Label, ListBox, Popover} from "@heroui/react";
 import Image from "next/image";
 
+import useKeyPress from "@/hooks/use-key-press";
 import {cn} from "@/utils/cn";
 
 import {findMatchingTheme, themeValuesById, themes} from "../constants";
@@ -29,6 +30,16 @@ export function ThemePopover() {
       radius: themeValues.radius,
     });
   };
+
+  const randomizeTheme = () => {
+    const randomTheme = themes[Math.floor(Math.random() * themes.length)];
+
+    if (randomTheme) {
+      applyTheme(randomTheme.id);
+    }
+  };
+
+  useKeyPress("t", randomizeTheme);
 
   return (
     <Popover>
@@ -94,6 +105,13 @@ export function ThemePopover() {
               </ListBox.Item>
             )}
           </ListBox>
+          <p className="mt-5 text-xs text-muted">
+            Press{" "}
+            <Kbd>
+              <Kbd.Content>T</Kbd.Content>
+            </Kbd>{" "}
+            to pick random
+          </p>
         </Popover.Dialog>
       </Popover.Content>
     </Popover>


### PR DESCRIPTION
Closes #HHTA-334

## 📝 Description

Add keyboard shortcuts to the theme builder for improved productivity and accessibility, with visual hints using the `Kbd` component.

## ⛳️ Current behavior (updates)

Users can only interact with the theme builder through mouse clicks for undo/redo, reset, and theme selection.

## 🚀 New behavior

- **Arrow Left**: Undo last change
- **Arrow Right**: Redo last change
- **D**: Open reset dialog
- **T**: Pick random theme

All shortcuts display `Kbd` hints in tooltips and the theme popover to improve discoverability.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Files changed:
- `builder-header.tsx` - Added undo/redo keyboard shortcuts with Kbd hints
- `reset-button.tsx` - Added reset dialog shortcut with Kbd hint
- `theme-popover.tsx` - Added random theme shortcut with Kbd hint