### PR TITLE
fix(docs): incorrect link to text area page

### DIFF
--- a/apps/docs/src/components-registry.ts
+++ b/apps/docs/src/components-registry.ts
@@ -325,7 +325,7 @@ const componentsMap: Record<string, ComponentInfo> = {
   textarea: {
     category: "forms",
     description: "Multiline text input with focus management",
-    href: "/docs/components/textarea",
+    href: "/docs/components/text-area",
     name: "textarea",
     title: "TextArea",
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->
#

## 📝 Description

Fixed broken link from `docs/react/components/textarea` to `docs/react/components/text-area`


## ⛳️ Current behavior (updates)

Link redirects to 404 page

## 🚀 New behavior

Link redirects to text area component

## 💣 Is this a breaking change (Yes/No):

no

## 📝 Additional Information
