### PR TITLE
fix(autocomplete): hide clearbutton when spinner is shown

### DIFF
--- a/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
@@ -36,9 +36,10 @@ export function AsynchronousFiltering() {
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search characters..." />
-              <SearchField.ClearButton />
-              {!!list.isLoading && (
+              {list.isLoading ? (
                 <Spinner className="absolute top-1/2 right-2 -translate-y-1/2" size="sm" />
+              ) : (
+                <SearchField.ClearButton />
               )}
             </SearchField.Group>
           </SearchField>

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -1108,9 +1108,10 @@ export const AsynchronousFiltering: Story = {
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search characters..." />
-                <SearchField.ClearButton />
-                {!!list.isLoading && (
+                {list.isLoading ? (
                   <Spinner className="absolute top-1/2 right-2 -translate-y-1/2" size="sm" />
+                ) : (
+                  <SearchField.ClearButton />
                 )}
               </SearchField.Group>
             </SearchField>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6165

## 📝 Description

<!--- Add a brief description -->

When isLoading is true, spinner will show up and overlap with close button. This PR is to hide close button when isLoading is true.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
