### PR TITLE
chore(docs): add secondary variant in SearchField

### DIFF
--- a/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
@@ -32,7 +32,7 @@ export function AsynchronousFiltering() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search">
+          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search characters..." />

--- a/apps/docs/src/demos/autocomplete/controlled-open-state.tsx
+++ b/apps/docs/src/demos/autocomplete/controlled-open-state.tsx
@@ -33,7 +33,7 @@ export function ControlledOpenState() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/autocomplete/controlled.tsx
+++ b/apps/docs/src/demos/autocomplete/controlled.tsx
@@ -37,7 +37,7 @@ export function Controlled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/autocomplete/custom-indicator.tsx
+++ b/apps/docs/src/demos/autocomplete/custom-indicator.tsx
@@ -37,7 +37,7 @@ export function CustomIndicator() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/autocomplete/default.tsx
+++ b/apps/docs/src/demos/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/autocomplete/disabled.tsx
+++ b/apps/docs/src/demos/autocomplete/disabled.tsx
@@ -40,7 +40,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -73,7 +73,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />

--- a/apps/docs/src/demos/autocomplete/email-recipients.tsx
+++ b/apps/docs/src/demos/autocomplete/email-recipients.tsx
@@ -73,7 +73,7 @@ export function EmailRecipients() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search emails..." />

--- a/apps/docs/src/demos/autocomplete/full-width.tsx
+++ b/apps/docs/src/demos/autocomplete/full-width.tsx
@@ -36,7 +36,7 @@ export function FullWidth() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/autocomplete/location-search.tsx
+++ b/apps/docs/src/demos/autocomplete/location-search.tsx
@@ -61,7 +61,7 @@ export function LocationSearch() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={customFilter}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search cities..." />

--- a/apps/docs/src/demos/autocomplete/multiple-select.tsx
+++ b/apps/docs/src/demos/autocomplete/multiple-select.tsx
@@ -73,7 +73,7 @@ export function MultipleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/autocomplete/required.tsx
+++ b/apps/docs/src/demos/autocomplete/required.tsx
@@ -62,7 +62,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -96,7 +96,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />

--- a/apps/docs/src/demos/autocomplete/single-select.tsx
+++ b/apps/docs/src/demos/autocomplete/single-select.tsx
@@ -35,7 +35,7 @@ export default function SingleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search animals..." />

--- a/apps/docs/src/demos/autocomplete/tag-group-selection.tsx
+++ b/apps/docs/src/demos/autocomplete/tag-group-selection.tsx
@@ -75,7 +75,7 @@ export function TagGroupSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search tags..." />

--- a/apps/docs/src/demos/autocomplete/user-selection-multiple.tsx
+++ b/apps/docs/src/demos/autocomplete/user-selection-multiple.tsx
@@ -112,7 +112,7 @@ export function UserSelectionMultiple() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/autocomplete/user-selection.tsx
+++ b/apps/docs/src/demos/autocomplete/user-selection.tsx
@@ -101,7 +101,7 @@ export function UserSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/autocomplete/variants.tsx
+++ b/apps/docs/src/demos/autocomplete/variants.tsx
@@ -57,7 +57,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search">
+                <SearchField autoFocus name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -91,7 +91,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search">
+                <SearchField autoFocus name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -156,7 +156,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search">
+                <SearchField autoFocus name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -216,7 +216,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search">
+                <SearchField autoFocus name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/autocomplete/with-description.tsx
+++ b/apps/docs/src/demos/autocomplete/with-description.tsx
@@ -34,7 +34,7 @@ export function WithDescription() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/autocomplete/with-disabled-options.tsx
+++ b/apps/docs/src/demos/autocomplete/with-disabled-options.tsx
@@ -26,7 +26,7 @@ export function WithDisabledOptions() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search animals..." />

--- a/apps/docs/src/demos/autocomplete/with-sections.tsx
+++ b/apps/docs/src/demos/autocomplete/with-sections.tsx
@@ -33,7 +33,7 @@ export function WithSections() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search">
+          <SearchField autoFocus name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search countries..." />

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -65,7 +65,7 @@ export const Default: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -117,7 +117,7 @@ export const WithClearButton: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -182,7 +182,7 @@ export const WithOnClearCallback: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search animals..." />
@@ -264,7 +264,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search">
+                  <SearchField autoFocus name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -298,7 +298,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search">
+                  <SearchField autoFocus name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -363,7 +363,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search">
+                  <SearchField autoFocus name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -423,7 +423,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search">
+                  <SearchField autoFocus name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -508,7 +508,7 @@ export const MultipleSelect: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search..." />
@@ -562,7 +562,7 @@ export const FullWidth: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -615,7 +615,7 @@ export const WithDescription: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -659,7 +659,7 @@ export const WithSections: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />
@@ -756,7 +756,7 @@ export const WithDisabledOptions: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -828,7 +828,7 @@ export const CustomIndicator: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -902,7 +902,7 @@ export const Required: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -936,7 +936,7 @@ export const Required: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search countries..." />
@@ -994,7 +994,7 @@ export const Controlled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1049,7 +1049,7 @@ export const ControlledOpenState: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1104,7 +1104,7 @@ export const AsynchronousFiltering: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-            <SearchField autoFocus className="sticky top-0 z-10" name="search">
+            <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search characters..." />
@@ -1173,7 +1173,7 @@ export const Disabled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1206,7 +1206,7 @@ export const Disabled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search">
+              <SearchField autoFocus name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search countries..." />
@@ -1316,7 +1316,7 @@ export const UserSelection: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1441,7 +1441,7 @@ export const UserSelectionMultiple: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1519,7 +1519,7 @@ export const LocationSearch: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={customFilter}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search cities..." />
@@ -1610,7 +1610,7 @@ export const TagGroupSelection: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search tags..." />
@@ -1691,7 +1691,7 @@ export const EmailRecipients: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search">
+            <SearchField autoFocus name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search emails..." />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Reported by Andres, input in surface should use secondary variant. This PR is to add `variant="secondary"` to all autocomplete examples (docs & storybook).

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="305" height="392" alt="image" src="https://github.com/user-attachments/assets/8a11c9ee-d11a-48d8-85da-b76ec7cbbb2b" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="333" height="397" alt="image" src="https://github.com/user-attachments/assets/ea052206-a555-41f7-b2bf-285a69dd5342" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
