### PR TITLE
fix(docs): inconsistent width in async filtering example

### DIFF
--- a/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
@@ -2,6 +2,7 @@
 
 import {Autocomplete, EmptyState, Label, ListBox, SearchField, Spinner} from "@heroui/react";
 import {useAsyncList} from "@react-stately/data";
+import {cn} from "tailwind-variants";
 
 interface Character {
   name: string;
@@ -36,11 +37,15 @@ export function AsynchronousFiltering() {
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search characters..." />
-              {list.isLoading ? (
-                <Spinner className="absolute top-1/2 right-2 -translate-y-1/2" size="sm" />
-              ) : (
-                <SearchField.ClearButton />
-              )}
+              <Spinner
+                size="sm"
+                className={cn("absolute top-1/2 right-2 -translate-y-1/2", {
+                  "pointer-events-none opacity-0": !list.isLoading,
+                })}
+              />
+              <SearchField.ClearButton
+                className={cn({"pointer-events-none opacity-0": !!list.isLoading})}
+              />
             </SearchField.Group>
           </SearchField>
           <ListBox

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -5,6 +5,7 @@ import {Icon} from "@iconify/react";
 import {useAsyncList} from "@react-stately/data";
 import React, {useState} from "react";
 import {useFilter} from "react-aria-components";
+import {cn} from "tailwind-variants";
 
 import {Avatar, AvatarFallback, AvatarImage} from "../avatar";
 import {Button} from "../button";
@@ -1108,11 +1109,15 @@ export const AsynchronousFiltering: Story = {
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search characters..." />
-                {list.isLoading ? (
-                  <Spinner className="absolute top-1/2 right-2 -translate-y-1/2" size="sm" />
-                ) : (
-                  <SearchField.ClearButton />
-                )}
+                <Spinner
+                  size="sm"
+                  className={cn("absolute top-1/2 right-2 -translate-y-1/2", {
+                    "pointer-events-none opacity-0": !list.isLoading,
+                  })}
+                />
+                <SearchField.ClearButton
+                  className={cn({"pointer-events-none opacity-0": !!list.isLoading})}
+                />
               </SearchField.Group>
             </SearchField>
             <ListBox


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

In asynchronous-filtering example (doc & storybook), when isLoading is true, the autocomplete width shrink a bit as the close button is removed from DOM. 

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

The autocomplete shrinks a bit when isLoading is true

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

The autocomplete width shouldn't change no matter isLoading is true or false

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
