### PR TITLE
fix(styles): convert ring to outline for invalid-field

### DIFF
--- a/packages/styles/utilities/index.css
+++ b/packages/styles/utilities/index.css
@@ -11,9 +11,21 @@
   --tw-ring-offset-width: 0px;
 }
 
-@utility invalid-field-outline {
+@utility invalid-field-ring {
+  /* Unfocused: show 1px outline */
   @apply outline-1 outline-danger outline-solid;
   --tw-ring-offset-width: 3px;
+
+  /* Focused: show 2px ring in danger color, remove outline */
+  &:focus,
+  &:focus-visible,
+  &[data-focused="true"],
+  &[data-focus-visible="true"],
+  &:focus-within,
+  &[data-focus-within="true"] {
+    @apply ring-2 ring-danger ring-offset-0;
+    --tw-ring-offset-width: 0px;
+  }
 }
 
 @utility no-highlight {
@@ -30,7 +42,7 @@
 }
 
 @utility status-invalid-field {
-  @apply invalid-field-outline;
+  @apply invalid-field-ring;
 }
 
 @utility status-disabled {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Currently for input type components with `status-invalid-field`, focusing via keyboard (tab) will not show the focus ring since `status-invalid-field` is using `invalid-field-ring` to indicate the invalid state. This PR is to use outline to indicate the invalid state while allowing the focus ring shown when it is focused.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

The component is focused but it won't be noticed

<img width="312" height="208" alt="image" src="https://github.com/user-attachments/assets/61afea3e-29af-4151-9b26-85e2f073dee7" />

<img width="315" height="66" alt="image" src="https://github.com/user-attachments/assets/04dbabfe-dc18-4d53-8948-7c7776f87cae" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="307" height="188" alt="image" src="https://github.com/user-attachments/assets/568e2e3d-da04-40e8-b969-4407cc3a8d6e" />

<img width="299" height="77" alt="image" src="https://github.com/user-attachments/assets/89f08fe2-c25f-418f-b134-aae14e88208d" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
