### PR TITLE
fix(docs): update VSCode MCP server configuration in getting started guides

### DIFF
--- a/apps/docs/content/docs/native/getting-started/(ui-for-agents)/mcp-server.mdx
+++ b/apps/docs/content/docs/native/getting-started/(ui-for-agents)/mcp-server.mdx
@@ -93,8 +93,9 @@ See the [Windsurf MCP documentation](https://docs.windsurf.com/windsurf/cascade/
 
 ```json title=".vscode/mcp.json"
 {
-  "mcpServers": {
+  "servers": {
     "heroui-native": {
+      "type": "stdio",
       "command": "npx",
       "args": ["-y", "@heroui/native-mcp@latest"]
     }

--- a/apps/docs/content/docs/react/getting-started/(ui-for-agents)/mcp-server.mdx
+++ b/apps/docs/content/docs/react/getting-started/(ui-for-agents)/mcp-server.mdx
@@ -119,8 +119,9 @@ To configure MCP in VS Code with GitHub Copilot, add the HeroUI server to your p
 
 ```json title=".vscode/mcp.json"
 {
-  "mcpServers": {
+  "servers": {
     "heroui-react": {
+      "type": "stdio",
       "command": "npx",
       "args": ["-y", "@heroui/react-mcp@latest"]
     }


### PR DESCRIPTION
## 📝 Description

During the manually setup following the current instructions of the HeroUI v3 documentation for setup MCP server for VSCode I noticed that they may not be updated because it raises an error `Property mcServers is not allowed` so I ask Copilot to setup properly and I would like to contribute with my solution as an small update for the documentation.
<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<img width="581" height="256" alt="Captura de pantalla 2026-02-03 a la(s) 1 12 35 a m" src="https://github.com/user-attachments/assets/e45bf91a-7fb4-4312-99c6-c1bde8258e48" />

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<img width="529" height="303" alt="Captura de pantalla 2026-02-03 a la(s) 1 14 15 a m" src="https://github.com/user-attachments/assets/f48e07c0-05dd-4503-8dbe-da1d14de1743" />


<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

No
<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
