### PR TITLE
feat(pagination): add custom navigation icons slots

### DIFF
--- a/.changeset/pagination-custom-icons.md
+++ b/.changeset/pagination-custom-icons.md
@@ -1,0 +1,5 @@
+---
+"@heroui/pagination": minor
+---
+
+feat(pagination): add `prevIcon` and `nextIcon` props to customize the previous/next page control icons, falling back to the default `ChevronIcon` when not provided.

--- a/packages/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/components/pagination/__tests__/pagination.test.tsx
@@ -141,4 +141,46 @@ describe("Pagination", () => {
 
     window.IntersectionObserver = originalIntersectionObserver;
   });
+
+  describe("custom icons", () => {
+    const originalIntersectionObserver = window.IntersectionObserver;
+
+    beforeAll(() => {
+      window.IntersectionObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      }));
+    });
+
+    afterAll(() => {
+      window.IntersectionObserver = originalIntersectionObserver;
+    });
+
+    it("should render custom prevIcon when provided", () => {
+      const wrapper = render(
+        <Pagination showControls prevIcon={<span data-testid="custom-prev">←</span>} total={10} />,
+      );
+
+      expect(wrapper.getByTestId("custom-prev")).not.toBeNull();
+    });
+
+    it("should render custom nextIcon when provided", () => {
+      const wrapper = render(
+        <Pagination showControls nextIcon={<span data-testid="custom-next">→</span>} total={10} />,
+      );
+
+      expect(wrapper.getByTestId("custom-next")).not.toBeNull();
+    });
+
+    it("should render default chevron icons when prevIcon and nextIcon are not provided", () => {
+      const wrapper = render(<Pagination showControls total={10} />);
+
+      const prevButton = wrapper.getByLabelText("previous page button");
+      const nextButton = wrapper.getByLabelText("next page button");
+
+      expect(prevButton.querySelector("svg")).not.toBeNull();
+      expect(nextButton.querySelector("svg")).not.toBeNull();
+    });
+  });
 });

--- a/packages/components/pagination/src/pagination.tsx
+++ b/packages/components/pagination/src/pagination.tsx
@@ -27,6 +27,8 @@ const Pagination = forwardRef<"nav", PaginationProps>((props, ref) => {
     activePage,
     disableCursorAnimation,
     disableAnimation,
+    prevIcon,
+    nextIcon,
     renderItem: renderItemProp,
     onNext,
     onPrevious,
@@ -45,22 +47,24 @@ const Pagination = forwardRef<"nav", PaginationProps>((props, ref) => {
 
   const renderChevronIcon = useCallback(
     (key: PaginationItemType) => {
-      if (
-        (key === PaginationItemType.PREV && !isRTL) ||
-        (key === PaginationItemType.NEXT && isRTL)
-      ) {
-        return <ChevronIcon />;
+      const isPrev =
+        (key === PaginationItemType.PREV && !isRTL) || (key === PaginationItemType.NEXT && isRTL);
+
+      if (isPrev) {
+        return prevIcon ?? <ChevronIcon />;
       }
 
       return (
-        <ChevronIcon
-          className={slots.chevronNext({
-            class: classNames?.chevronNext,
-          })}
-        />
+        nextIcon ?? (
+          <ChevronIcon
+            className={slots.chevronNext({
+              class: classNames?.chevronNext,
+            })}
+          />
+        )
       );
     },
-    [slots, isRTL],
+    [slots, isRTL, prevIcon, nextIcon],
   );
 
   const renderPrevItem = useCallback(

--- a/packages/components/pagination/src/use-pagination.ts
+++ b/packages/components/pagination/src/use-pagination.ts
@@ -129,6 +129,14 @@ interface Props extends Omit<HTMLHeroUIProps<"nav">, "onChange"> {
    */
   showControls?: boolean;
   /**
+   * Custom icon for the previous page control.
+   */
+  prevIcon?: ReactNode;
+  /**
+   * Custom icon for the next page control.
+   */
+  nextIcon?: ReactNode;
+  /**
    * Render a custom pagination item.
    * @param props Pagination item props
    * @returns ReactNode
@@ -182,6 +190,8 @@ export function usePagination(originalProps: UsePaginationProps) {
     boundaries,
     onChange,
     className,
+    prevIcon,
+    nextIcon,
     renderItem,
     getItemAriaLabel: getItemAriaLabelProp,
     ...otherProps
@@ -418,6 +428,8 @@ export function usePagination(originalProps: UsePaginationProps) {
     getItemRef,
     disableAnimation,
     disableCursorAnimation,
+    prevIcon,
+    nextIcon,
     setPage,
     onPrevious,
     onNext,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Add optional `prevIcon` and `nextIcon` props to customize the previous/next page control icons. Fallbacks to `<ChevronIcon />` if not provided.

## ⛳️ Current behavior (updates)

Always the default Chevron is used.

## 🚀 New behavior

If provided, custom icons can be used.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
