### PR TITLE
fix(button): correct disableRipple prop precedence

### DIFF
--- a/.changeset/fix-button-disable-ripple.md
+++ b/.changeset/fix-button-disable-ripple.md
@@ -1,0 +1,5 @@
+---
+"@heroui/button": patch
+---
+
+fix(button): correct `disableRipple` prop precedence to respect explicit `false` value when `disableAnimation` is enabled

--- a/packages/components/button/__tests__/use-button.test.tsx
+++ b/packages/components/button/__tests__/use-button.test.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import {renderHook} from "@testing-library/react";
+import {HeroUIProvider} from "@heroui/system";
+
+import {useButton} from "../src/use-button";
+
+describe("useButton", () => {
+  it("should respect disableRipple={false} when disableAnimation is true", () => {
+    const {result} = renderHook(() => useButton({disableAnimation: true, disableRipple: false}));
+
+    expect(result.current.disableRipple).toBe(false);
+  });
+
+  it("should use global disableRipple when prop is not specified", () => {
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <HeroUIProvider disableRipple>{children}</HeroUIProvider>
+    );
+
+    const {result} = renderHook(() => useButton({}), {wrapper});
+
+    expect(result.current.disableRipple).toBe(true);
+  });
+
+  it("should override global disableRipple with explicit prop", () => {
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <HeroUIProvider disableRipple>{children}</HeroUIProvider>
+    );
+
+    const {result} = renderHook(() => useButton({disableRipple: false}), {wrapper});
+
+    expect(result.current.disableRipple).toBe(false);
+  });
+});

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -81,7 +81,7 @@ export function useButton(props: UseButtonProps) {
     className,
     spinner,
     isLoading = false,
-    disableRipple: disableRippleProp = false,
+    disableRipple: disableRippleProp,
     fullWidth = groupContext?.fullWidth ?? false,
     radius = groupContext?.radius,
     size = groupContext?.size ?? "md",
@@ -101,7 +101,7 @@ export function useButton(props: UseButtonProps) {
 
   const domRef = useDOMRef(ref);
 
-  const disableRipple = (disableRippleProp || globalContext?.disableRipple) ?? disableAnimation;
+  const disableRipple = disableRippleProp ?? globalContext?.disableRipple ?? disableAnimation;
 
   const {isFocusVisible, isFocused, focusProps} = useFocusRing({
     autoFocus,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes the `disableRipple` property precedence.

## ⛳️ Current behavior (updates)

The `(disableRippleProp || globalContext?.disableRipple)` returns `undefined` when `globalContext?.disableRipple` is `undefined` despite `disableRippleProp = false` explicitly.

## 🚀 New behavior

If explicit `disableRipple = false` is provided, respect it.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
