### PR TITLE
chore: trigger mcp extract on docs deploy

### DIFF
--- a/.github/workflows/trigger-mcp-extraction.yml
+++ b/.github/workflows/trigger-mcp-extraction.yml
@@ -1,0 +1,52 @@
+name: Trigger MCP Extraction on Vercel Deployment
+
+on:
+  repository_dispatch:
+    types:
+      - vercel.deployment.success
+      - vercel.deployment.promoted
+
+jobs:
+  trigger-extraction:
+    name: Trigger MCP Extraction
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Native MCP Extraction
+        if: |
+          github.event.client_payload.environment == 'production' ||
+          (github.event.client_payload.environment == 'preview' && 
+           (github.event.client_payload.git.ref == 'v3' || github.event.client_payload.git.ref == 'refs/heads/v3'))
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MCP_DISPATCH_TOKEN }}
+          repository: heroui-inc/heroui-mcp
+          event-type: native-docs-deployed
+          client-payload: |
+            {
+              "environment": "${{ github.event.client_payload.environment }}",
+              "deployment_url": "${{ github.event.client_payload.url }}",
+              "deployment_id": "${{ github.event.client_payload.id }}",
+              "git_ref": "${{ github.event.client_payload.git.ref }}",
+              "git_sha": "${{ github.event.client_payload.git.sha }}",
+              "triggered_by": "vercel_deployment"
+            }
+
+      - name: Trigger React MCP Extraction
+        if: |
+          github.event.client_payload.environment == 'production' ||
+          (github.event.client_payload.environment == 'preview' && 
+           (github.event.client_payload.git.ref == 'v3' || github.event.client_payload.git.ref == 'refs/heads/v3'))
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MCP_DISPATCH_TOKEN }}
+          repository: heroui-inc/heroui-mcp
+          event-type: react-docs-deployed
+          client-payload: |
+            {
+              "environment": "${{ github.event.client_payload.environment }}",
+              "deployment_url": "${{ github.event.client_payload.url }}",
+              "deployment_id": "${{ github.event.client_payload.id }}",
+              "git_ref": "${{ github.event.client_payload.git.ref }}",
+              "git_sha": "${{ github.event.client_payload.git.sha }}",
+              "triggered_by": "vercel_deployment"
+            }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Add a trigger for Vercel deployments of HeroUI docs to dispatch events to HeroUI MCP in order to trigger data extraction. HeroUI MCP relies on docs that this repo deploys to Vercel.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

MCP extraction triggers on HeroUI React or Native release

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

HeroUI docs deployment triggers MCP extraction

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->
No
## 📝 Additional Information
