### PR TITLE
fix(breadcrumbs): add missing props to Link

### DIFF
--- a/packages/react/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/react/src/components/breadcrumbs/breadcrumbs.tsx
@@ -94,7 +94,9 @@ const BreadcrumbsItem = ({
 
         return (
           <>
-            <Link className={slots?.link()}>{children}</Link>
+            <Link className={slots?.link()} {...props}>
+              {children}
+            </Link>
             {!isCurrent && renderSeparator()}
           </>
         );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6188

## 📝 Description

<!--- Add a brief description -->

When `href` is defined in `BreadcrumbsItem`, it should render as `<a`>. Currently it is not navigable.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

example: `<BreadcrumbsItem href="/a/b/c">Home</BreadcrumbsItem>`

<img width="851" height="123" alt="image" src="https://github.com/user-attachments/assets/14db1536-5116-4227-8ea2-475cab9750ed" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

example: `<BreadcrumbsItem href="/a/b/c">Home</BreadcrumbsItem>`

<img width="851" height="112" alt="image" src="https://github.com/user-attachments/assets/836dd715-05e5-4b09-ae45-78a7446692c9" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
