### PR TITLE
fix: mcp extraction not triggered on right branch/environment

### DIFF
--- a/.github/workflows/trigger-mcp-extraction.yml
+++ b/.github/workflows/trigger-mcp-extraction.yml
@@ -13,9 +13,8 @@ jobs:
     steps:
       - name: Trigger Native MCP Extraction
         if: |
-          github.event.client_payload.environment == 'production' ||
-          (github.event.client_payload.environment == 'preview' && 
-           (github.event.client_payload.git.ref == 'v3' || github.event.client_payload.git.ref == 'refs/heads/v3'))
+          github.event.client_payload.git.ref == 'v3' || 
+          github.event.client_payload.git.ref == 'refs/heads/v3'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.MCP_DISPATCH_TOKEN }}
@@ -23,7 +22,7 @@ jobs:
           event-type: native-docs-deployed
           client-payload: |
             {
-              "environment": "${{ github.event.client_payload.environment }}",
+              "environment": "production",
               "deployment_url": "${{ github.event.client_payload.url }}",
               "deployment_id": "${{ github.event.client_payload.id }}",
               "git_ref": "${{ github.event.client_payload.git.ref }}",
@@ -33,9 +32,8 @@ jobs:
 
       - name: Trigger React MCP Extraction
         if: |
-          github.event.client_payload.environment == 'production' ||
-          (github.event.client_payload.environment == 'preview' && 
-           (github.event.client_payload.git.ref == 'v3' || github.event.client_payload.git.ref == 'refs/heads/v3'))
+          github.event.client_payload.git.ref == 'v3' || 
+          github.event.client_payload.git.ref == 'refs/heads/v3'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.MCP_DISPATCH_TOKEN }}
@@ -43,7 +41,7 @@ jobs:
           event-type: react-docs-deployed
           client-payload: |
             {
-              "environment": "${{ github.event.client_payload.environment }}",
+              "environment": "production",
               "deployment_url": "${{ github.event.client_payload.url }}",
               "deployment_id": "${{ github.event.client_payload.id }}",
               "git_ref": "${{ github.event.client_payload.git.ref }}",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

MCP data extraction trigger isn't working when the `v3` branch is deployed
This is due to `v3` deploying to `preview` environment and not `production`
Update extraction trigger to always run in `production` mode on `v3` deployments

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->
`v3` deployments not triggering `production` MCP data extraction

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->
`v3` deployments triggers `production` MCP data extraction
## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
