### PR TITLE
feat(switch): introduce Switch.Content

### DIFF
--- a/apps/docs/content/docs/react/components/(controls)/switch.mdx
+++ b/apps/docs/content/docs/react/components/(controls)/switch.mdx
@@ -1,6 +1,7 @@
 ---
 title: Switch
 description: A toggle switch component for boolean states
+icon: updated
 links:
   rac: Switch
   source: switch/switch.tsx
@@ -26,7 +27,7 @@ import { Switch, SwitchGroup, Label } from '@heroui/react';
 Import the Switch component and access all parts using dot notation.
 
 ```tsx
-import { Switch, Label } from '@heroui/react';
+import { Switch, Label, Description } from '@heroui/react';
 
 export default () => (
   <Switch>
@@ -35,7 +36,10 @@ export default () => (
         <Switch.Icon/> {/* Optional */}
       </Switch.Thumb>
     </Switch.Control>
-    <Label/> {/* Optional */}
+    <Switch.Content>
+      <Label />
+      <Description /> {/* Optional */}
+    </Switch.Content>
   </Switch>
 );
 ```
@@ -216,6 +220,10 @@ To customize the Switch component classes, you can use the `@layer components` d
     @apply bg-white shadow-sm;
   }
 
+  .switch__content {
+    @apply flex flex-col gap-1;
+  }
+
   .switch__icon {
     @apply h-3 w-3 text-current;
   }
@@ -231,6 +239,7 @@ HeroUI follows the [BEM](https://getbem.com/) methodology to ensure component va
 The Switch component uses these CSS classes ([View source styles](https://github.com/heroui-inc/heroui/blob/v3/packages/styles/components/switch.css)):
 
 - `.switch` - Base switch container
+- `.switch__content` - Optional content container
 - `.switch__control` - Switch control track
 - `.switch__thumb` - Switch thumb that moves
 - `.switch__icon` - Optional icon inside the thumb

--- a/apps/docs/src/demos/switch/basic.tsx
+++ b/apps/docs/src/demos/switch/basic.tsx
@@ -6,7 +6,9 @@ export function Basic() {
       <Switch.Control>
         <Switch.Thumb />
       </Switch.Control>
-      <Label className="text-sm">Enable notifications</Label>
+      <Switch.Content>
+        <Label className="text-sm">Enable notifications</Label>
+      </Switch.Content>
     </Switch>
   );
 }

--- a/apps/docs/src/demos/switch/controlled.tsx
+++ b/apps/docs/src/demos/switch/controlled.tsx
@@ -12,7 +12,9 @@ export function Controlled() {
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Enable notifications</Label>
+        <Switch.Content>
+          <Label className="text-sm">Enable notifications</Label>
+        </Switch.Content>
       </Switch>
       <p className="text-sm text-muted">Switch is {isSelected ? "on" : "off"}</p>
     </div>

--- a/apps/docs/src/demos/switch/default-selected.tsx
+++ b/apps/docs/src/demos/switch/default-selected.tsx
@@ -6,7 +6,9 @@ export function DefaultSelected() {
       <Switch.Control>
         <Switch.Thumb />
       </Switch.Control>
-      <Label className="text-sm">Enable notifications</Label>
+      <Switch.Content>
+        <Label className="text-sm">Enable notifications</Label>
+      </Switch.Content>
     </Switch>
   );
 }

--- a/apps/docs/src/demos/switch/disabled.tsx
+++ b/apps/docs/src/demos/switch/disabled.tsx
@@ -6,7 +6,9 @@ export function Disabled() {
       <Switch.Control>
         <Switch.Thumb />
       </Switch.Control>
-      <Label className="text-sm">Enable notifications</Label>
+      <Switch.Content>
+        <Label className="text-sm">Enable notifications</Label>
+      </Switch.Content>
     </Switch>
   );
 }

--- a/apps/docs/src/demos/switch/form.tsx
+++ b/apps/docs/src/demos/switch/form.tsx
@@ -22,19 +22,25 @@ export function Form() {
           <Switch.Control>
             <Switch.Thumb />
           </Switch.Control>
-          <Label className="text-sm">Enable notifications</Label>
+          <Switch.Content>
+            <Label className="text-sm">Enable notifications</Label>
+          </Switch.Content>
         </Switch>
         <Switch defaultSelected name="newsletter" value="on">
           <Switch.Control>
             <Switch.Thumb />
           </Switch.Control>
-          <Label className="text-sm">Subscribe to newsletter</Label>
+          <Switch.Content>
+            <Label className="text-sm">Subscribe to newsletter</Label>
+          </Switch.Content>
         </Switch>
         <Switch name="marketing" value="on">
           <Switch.Control>
             <Switch.Thumb />
           </Switch.Control>
-          <Label className="text-sm">Receive marketing updates</Label>
+          <Switch.Content>
+            <Label className="text-sm">Receive marketing updates</Label>
+          </Switch.Content>
         </Switch>
       </SwitchGroup>
       <Button className="mt-4" size="sm" type="submit" variant="primary">

--- a/apps/docs/src/demos/switch/group-horizontal.tsx
+++ b/apps/docs/src/demos/switch/group-horizontal.tsx
@@ -7,19 +7,25 @@ export function GroupHorizontal() {
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Notifications</Label>
+        <Switch.Content>
+          <Label className="text-sm">Notifications</Label>
+        </Switch.Content>
       </Switch>
       <Switch name="marketing">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Marketing</Label>
+        <Switch.Content>
+          <Label className="text-sm">Marketing</Label>
+        </Switch.Content>
       </Switch>
       <Switch name="social">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Social</Label>
+        <Switch.Content>
+          <Label className="text-sm">Social</Label>
+        </Switch.Content>
       </Switch>
     </SwitchGroup>
   );

--- a/apps/docs/src/demos/switch/group.tsx
+++ b/apps/docs/src/demos/switch/group.tsx
@@ -7,19 +7,25 @@ export function Group() {
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Allow Notifications</Label>
+        <Switch.Content>
+          <Label className="text-sm">Allow Notifications</Label>
+        </Switch.Content>
       </Switch>
       <Switch name="marketing">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Marketing emails</Label>
+        <Switch.Content>
+          <Label className="text-sm">Marketing emails</Label>
+        </Switch.Content>
       </Switch>
       <Switch name="social">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Social media updates</Label>
+        <Switch.Content>
+          <Label className="text-sm">Social media updates</Label>
+        </Switch.Content>
       </Switch>
     </SwitchGroup>
   );

--- a/apps/docs/src/demos/switch/label-position.tsx
+++ b/apps/docs/src/demos/switch/label-position.tsx
@@ -7,10 +7,14 @@ export function LabelPosition() {
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Label after</Label>
+        <Switch.Content>
+          <Label className="text-sm">Label after</Label>
+        </Switch.Content>
       </Switch>
       <Switch>
-        <Label className="text-sm">Label before</Label>
+        <Switch.Content>
+          <Label className="text-sm">Label before</Label>
+        </Switch.Content>
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>

--- a/apps/docs/src/demos/switch/render-props.tsx
+++ b/apps/docs/src/demos/switch/render-props.tsx
@@ -10,7 +10,9 @@ export function RenderProps() {
           <Switch.Control>
             <Switch.Thumb />
           </Switch.Control>
-          <Label className="text-sm">{isSelected ? "Enabled" : "Disabled"}</Label>
+          <Switch.Content>
+            <Label className="text-sm">{isSelected ? "Enabled" : "Disabled"}</Label>
+          </Switch.Content>
         </>
       )}
     </Switch>

--- a/apps/docs/src/demos/switch/sizes.tsx
+++ b/apps/docs/src/demos/switch/sizes.tsx
@@ -7,19 +7,25 @@ export function Sizes() {
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-xs">Small</Label>
+        <Switch.Content>
+          <Label className="text-xs">Small</Label>
+        </Switch.Content>
       </Switch>
       <Switch size="md">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Medium</Label>
+        <Switch.Content>
+          <Label className="text-sm">Medium</Label>
+        </Switch.Content>
       </Switch>
       <Switch size="lg">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-base">Large</Label>
+        <Switch.Content>
+          <Label className="text-base">Large</Label>
+        </Switch.Content>
       </Switch>
     </div>
   );

--- a/apps/docs/src/demos/switch/with-description.tsx
+++ b/apps/docs/src/demos/switch/with-description.tsx
@@ -4,15 +4,13 @@ export function WithDescription() {
   return (
     <div className="max-w-sm">
       <Switch>
-        <div className="flex gap-3">
-          <Switch.Control>
-            <Switch.Thumb />
-          </Switch.Control>
-          <div className="-mt-0.5 flex flex-col gap-1">
-            <Label className="text-sm">Public profile</Label>
-            <Description>Allow others to see your profile information</Description>
-          </div>
-        </div>
+        <Switch.Control>
+          <Switch.Thumb />
+        </Switch.Control>
+        <Switch.Content>
+          <Label className="text-sm">Public profile</Label>
+          <Description>Allow others to see your profile information</Description>
+        </Switch.Content>
       </Switch>
     </div>
   );

--- a/packages/react/src/components/switch/index.ts
+++ b/packages/react/src/components/switch/index.ts
@@ -1,12 +1,13 @@
 import type {ComponentProps} from "react";
 
-import {SwitchControl, SwitchIcon, SwitchRoot, SwitchThumb} from "./switch";
+import {SwitchContent, SwitchControl, SwitchIcon, SwitchRoot, SwitchThumb} from "./switch";
 
 /* -------------------------------------------------------------------------------------------------
  * Compound Component
  * -----------------------------------------------------------------------------------------------*/
 export const Switch = Object.assign(SwitchRoot, {
   Root: SwitchRoot,
+  Content: SwitchContent,
   Control: SwitchControl,
   Thumb: SwitchThumb,
   Icon: SwitchIcon,
@@ -15,6 +16,7 @@ export const Switch = Object.assign(SwitchRoot, {
 export type Switch = {
   Props: ComponentProps<typeof SwitchRoot>;
   RootProps: ComponentProps<typeof SwitchRoot>;
+  ContentProps: ComponentProps<typeof SwitchContent>;
   ControlProps: ComponentProps<typeof SwitchControl>;
   ThumbProps: ComponentProps<typeof SwitchThumb>;
   IconProps: ComponentProps<typeof SwitchIcon>;
@@ -23,11 +25,12 @@ export type Switch = {
 /* -------------------------------------------------------------------------------------------------
  * Named Component
  * -----------------------------------------------------------------------------------------------*/
-export {SwitchRoot, SwitchControl, SwitchIcon, SwitchThumb};
+export {SwitchRoot, SwitchContent, SwitchControl, SwitchIcon, SwitchThumb};
 
 export type {
   SwitchRootProps,
   SwitchRootProps as SwitchProps,
+  SwitchContentProps,
   SwitchControlProps,
   SwitchThumbProps,
   SwitchIconProps,

--- a/packages/react/src/components/switch/switch.stories.tsx
+++ b/packages/react/src/components/switch/switch.stories.tsx
@@ -25,7 +25,9 @@ export const Default: Story = {
       <Switch.Control>
         <Switch.Thumb />
       </Switch.Control>
-      <Label className="text-sm">Enable notifications</Label>
+      <Switch.Content>
+        <Label className="text-sm">Enable notifications</Label>
+      </Switch.Content>
     </Switch>
   ),
 };
@@ -36,7 +38,9 @@ export const Disabled: Story = {
       <Switch.Control>
         <Switch.Thumb />
       </Switch.Control>
-      <Label className="text-sm">Enable notifications</Label>
+      <Switch.Content>
+        <Label className="text-sm">Enable notifications</Label>
+      </Switch.Content>
     </Switch>
   ),
 };
@@ -47,7 +51,9 @@ export const DefaultSelected: Story = {
       <Switch.Control>
         <Switch.Thumb />
       </Switch.Control>
-      <Label className="text-sm">Enable notifications</Label>
+      <Switch.Content>
+        <Label className="text-sm">Enable notifications</Label>
+      </Switch.Content>
     </Switch>
   ),
 };
@@ -72,7 +78,9 @@ export const Controlled: Story = {
           <Switch.Control>
             <Switch.Thumb />
           </Switch.Control>
-          <Label className="text-sm">Enable notifications</Label>
+          <Switch.Content>
+            <Label className="text-sm">Enable notifications</Label>
+          </Switch.Content>
         </Switch>
         <p className="text-sm text-muted">Switch is {isSelected ? "on" : "off"}</p>
       </div>
@@ -97,19 +105,25 @@ export const Sizes: Story = {
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-xs">Small</Label>
+        <Switch.Content>
+          <Label className="text-xs">Small</Label>
+        </Switch.Content>
       </Switch>
       <Switch size="md">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-sm">Medium</Label>
+        <Switch.Content>
+          <Label className="text-sm">Medium</Label>
+        </Switch.Content>
       </Switch>
       <Switch size="lg">
         <Switch.Control>
           <Switch.Thumb />
         </Switch.Control>
-        <Label className="text-base">Large</Label>
+        <Switch.Content>
+          <Label className="text-base">Large</Label>
+        </Switch.Content>
       </Switch>
     </div>
   ),
@@ -130,15 +144,13 @@ export const WithDescription: Story = {
   render: () => (
     <div className="max-w-sm">
       <Switch>
-        <div className="flex gap-3">
-          <Switch.Control>
-            <Switch.Thumb />
-          </Switch.Control>
-          <div className="-mt-0.5 flex flex-col gap-1">
-            <Label className="text-sm">Public profile</Label>
-            <Description>Allow others to see your profile information</Description>
-          </div>
-        </div>
+        <Switch.Control>
+          <Switch.Thumb />
+        </Switch.Control>
+        <Switch.Content>
+          <Label className="text-sm">Public profile</Label>
+          <Description>Allow others to see your profile information</Description>
+        </Switch.Content>
       </Switch>
     </div>
   ),

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -97,8 +97,33 @@ const SwitchIcon = ({children, className, ...props}: SwitchIconProps) => {
 };
 
 /* -------------------------------------------------------------------------------------------------
+ * Switch Content
+ * -----------------------------------------------------------------------------------------------*/
+interface SwitchContentProps extends ComponentPropsWithRef<"div"> {}
+
+const SwitchContent = ({children, className, ...props}: SwitchContentProps) => {
+  const {slots} = useContext(SwitchContext);
+
+  return (
+    <div
+      className={composeSlotClassName(slots?.content, className)}
+      data-slot="switch-content"
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
  * Exports
  * -----------------------------------------------------------------------------------------------*/
-export {SwitchRoot, SwitchControl, SwitchThumb, SwitchIcon};
+export {SwitchRoot, SwitchControl, SwitchThumb, SwitchIcon, SwitchContent};
 
-export type {SwitchRootProps, SwitchControlProps, SwitchThumbProps, SwitchIconProps};
+export type {
+  SwitchRootProps,
+  SwitchControlProps,
+  SwitchThumbProps,
+  SwitchIconProps,
+  SwitchContentProps,
+};

--- a/packages/styles/components/switch.css
+++ b/packages/styles/components/switch.css
@@ -187,3 +187,8 @@
 .switch__label {
   @apply text-base font-medium text-foreground;
 }
+
+/* Switch content */
+.switch__content {
+  @apply flex flex-col gap-0;
+}

--- a/packages/styles/src/components/switch/switch.styles.ts
+++ b/packages/styles/src/components/switch/switch.styles.ts
@@ -8,6 +8,7 @@ export const switchVariants = tv({
   },
   slots: {
     base: "switch",
+    content: "switch__content",
     control: "switch__control",
     icon: "switch__icon",
     thumb: "switch__thumb",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

requested from [discord](https://discord.com/channels/856545348885676062/1473431429588193452). This PR is to introduce Content to Switch, following the pattern like Radio.Content or Checkbox.Content.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Currently if we have label or description, we need to do the following

```tsx
<Switch>
  <Switch.Control>
    <Switch.Thumb />
  </Switch.Control>
  <div className="flex flex-col gap-1">
    <Label className="text-sm">Public profile</Label>
    <Description>Allow others to see your profile information</Description>
  </div>
</Switch>
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

With Switch.Content, we can just the following

```tsx
<Switch>
  <Switch.Control>
    <Switch.Thumb />
  </Switch.Control>
  <Switch.Content>
    <Label className="text-sm">Public profile</Label>
    <Description>Allow others to see your profile information</Description>
  </Switch.Content>
</Switch>
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No. If the content is just Label and not wrapped by `Switch.Content`. It still looks the same.

## 📝 Additional Information
