### PR TITLE
feat(tabs): add Tabs.Separator component and update documentation

### DIFF
--- a/apps/docs/content/docs/react/components/(navigation)/tabs.mdx
+++ b/apps/docs/content/docs/react/components/(navigation)/tabs.mdx
@@ -35,6 +35,7 @@ export default () => (
     <Tabs.ListContainer>
       <Tabs.List aria-label="Options">
         <Tabs.Tab>
+          <Tabs.Separator /> {/* Optional */}
           <Tabs.Indicator />
         </Tabs.Tab>
       </Tabs.List>
@@ -56,6 +57,15 @@ export default () => (
 <ComponentPreview
   isBgSolid
   name="tabs-disabled"
+/>
+
+### With Separator
+
+Add `<Tabs.Separator />` inside each `<Tabs.Tab>` (except the first) to display separator lines between tabs.
+
+<ComponentPreview
+  isBgSolid
+  name="tabs-with-separator"
 />
 
 ### Custom Styles
@@ -134,6 +144,7 @@ The Tabs component uses these CSS classes:
 - `.tabs__list-container` - Tab list container wrapper
 - `.tabs__list` - Tab list container
 - `.tabs__tab` - Individual tab button
+- `.tabs__separator` - Separator between tabs
 - `.tabs__panel` - Tab panel content
 - `.tabs__indicator` - Tab indicator
 
@@ -163,7 +174,6 @@ The component supports both CSS pseudo-classes and data attributes:
 |------|------|---------|-------------|
 | `variant` | `"primary" \| "secondary"` | `"primary"` | Visual style variant. Primary uses a filled indicator, secondary uses an underline indicator |
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Tab layout orientation |
-| `hideSeparator` | `boolean` | `false` | Hide separator lines between tabs |
 | `selectedKey` | `string` | - | Controlled selected tab key |
 | `defaultSelectedKey` | `string` | - | Default selected tab key |
 | `onSelectionChange` | `(key: Key) => void` | - | Selection change handler |
@@ -182,6 +192,12 @@ The component supports both CSS pseudo-classes and data attributes:
 |------|------|---------|-------------|
 | `id` | `string` | - | Unique tab identifier |
 | `isDisabled` | `boolean` | `false` | Whether tab is disabled |
+| `className` | `string` | - | Additional CSS classes |
+
+### Tabs.Separator Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
 | `className` | `string` | - | Additional CSS classes |
 
 ### Tabs.Panel Props

--- a/apps/docs/src/demos/index.ts
+++ b/apps/docs/src/demos/index.ts
@@ -1462,9 +1462,9 @@ export const demos: Record<string, DemoItem> = {
     component: TabsDemos.CustomStyles,
     file: "tabs/custom-styles.tsx",
   },
-  "tabs-without-separator": {
-    component: TabsDemos.WithoutSeparator,
-    file: "tabs/without-separator.tsx",
+  "tabs-with-separator": {
+    component: TabsDemos.WithSeparator,
+    file: "tabs/with-separator.tsx",
   },
   "tabs-secondary": {
     component: TabsDemos.Secondary,

--- a/apps/docs/src/demos/tabs/index.ts
+++ b/apps/docs/src/demos/tabs/index.ts
@@ -2,6 +2,6 @@ export {Basic} from "./basic";
 export {Vertical} from "./vertical";
 export {Disabled} from "./disabled";
 export {CustomStyles} from "./custom-styles";
-export {WithoutSeparator} from "./without-separator";
+export {WithSeparator} from "./with-separator";
 export {Secondary} from "./secondary";
 export {SecondaryVertical} from "./secondary-vertical";

--- a/apps/docs/src/demos/tabs/with-separator.tsx
+++ b/apps/docs/src/demos/tabs/with-separator.tsx
@@ -1,8 +1,8 @@
 import {Tabs} from "@heroui/react";
 
-export function WithoutSeparator() {
+export function WithSeparator() {
   return (
-    <Tabs hideSeparator className="w-full max-w-md">
+    <Tabs className="w-full max-w-md">
       <Tabs.ListContainer>
         <Tabs.List aria-label="Options">
           <Tabs.Tab id="overview">
@@ -10,10 +10,12 @@ export function WithoutSeparator() {
             <Tabs.Indicator />
           </Tabs.Tab>
           <Tabs.Tab id="analytics">
+            <Tabs.Separator />
             Analytics
             <Tabs.Indicator />
           </Tabs.Tab>
           <Tabs.Tab id="reports">
+            <Tabs.Separator />
             Reports
             <Tabs.Indicator />
           </Tabs.Tab>

--- a/packages/react/src/components/tabs/index.ts
+++ b/packages/react/src/components/tabs/index.ts
@@ -1,6 +1,14 @@
 import type {ComponentProps} from "react";
 
-import {Tab, TabIndicator, TabList, TabListContainer, TabPanel, TabsRoot} from "./tabs";
+import {
+  Tab,
+  TabIndicator,
+  TabList,
+  TabListContainer,
+  TabPanel,
+  TabSeparator,
+  TabsRoot,
+} from "./tabs";
 
 /* -------------------------------------------------------------------------------------------------
  * Compound Component
@@ -11,6 +19,7 @@ export const Tabs = Object.assign(TabsRoot, {
   List: TabList,
   Tab,
   Indicator: TabIndicator,
+  Separator: TabSeparator,
   Panel: TabPanel,
 });
 
@@ -21,13 +30,14 @@ export type Tabs = {
   ListProps: ComponentProps<typeof TabList>;
   TabProps: ComponentProps<typeof Tab>;
   IndicatorProps: ComponentProps<typeof TabIndicator>;
+  SeparatorProps: ComponentProps<typeof TabSeparator>;
   PanelProps: ComponentProps<typeof TabPanel>;
 };
 
 /* -------------------------------------------------------------------------------------------------
  * Named Component
  * -----------------------------------------------------------------------------------------------*/
-export {TabsRoot, TabListContainer, TabList, Tab, TabIndicator, TabPanel};
+export {TabsRoot, TabListContainer, TabList, Tab, TabIndicator, TabSeparator, TabPanel};
 
 export type {
   TabsRootProps,
@@ -36,6 +46,7 @@ export type {
   TabListProps,
   TabProps,
   TabIndicatorProps,
+  TabSeparatorProps,
   TabPanelProps,
 } from "./tabs";
 

--- a/packages/react/src/components/tabs/tabs.stories.tsx
+++ b/packages/react/src/components/tabs/tabs.stories.tsx
@@ -237,10 +237,10 @@ const CustomStyleTemplate = (args: Story["args"]) => {
   );
 };
 
-const WithoutSeparatorTemplate = (args: Story["args"]) => {
+const WithSeparatorTemplate = (args: Story["args"]) => {
   return (
     <div className="w-[600px]">
-      <Tabs {...args} hideSeparator>
+      <Tabs {...args}>
         <Tabs.ListContainer>
           <Tabs.List aria-label="Options">
             <Tabs.Tab id="overview">
@@ -248,10 +248,12 @@ const WithoutSeparatorTemplate = (args: Story["args"]) => {
               <Tabs.Indicator />
             </Tabs.Tab>
             <Tabs.Tab id="analytics">
+              <Tabs.Separator />
               Analytics
               <Tabs.Indicator />
             </Tabs.Tab>
             <Tabs.Tab id="reports">
+              <Tabs.Separator />
               Reports
               <Tabs.Indicator />
             </Tabs.Tab>
@@ -490,11 +492,11 @@ export const WithCustomStyle: Story = {
   render: CustomStyleTemplate,
 };
 
-export const WithoutSeparator: Story = {
+export const WithSeparator: Story = {
   args: {
     children: null,
   },
-  render: WithoutSeparatorTemplate,
+  render: WithSeparatorTemplate,
 };
 
 export const Showcase1: Story = {

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -19,7 +19,6 @@ import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
  * Tabs Context
  * -----------------------------------------------------------------------------------------------*/
 type TabsContext = {
-  hideSeparator?: boolean;
   orientation?: "horizontal" | "vertical";
   slots?: ReturnType<typeof tabsVariants>;
 };
@@ -32,13 +31,11 @@ const TabsContext = createContext<TabsContext>({});
 interface TabsRootProps extends ComponentPropsWithRef<typeof TabsPrimitive>, TabsVariants {
   children: React.ReactNode;
   className?: string;
-  hideSeparator?: boolean;
 }
 
 const TabsRoot = ({
   children,
   className,
-  hideSeparator = false,
   orientation = "horizontal",
   variant,
   ...props
@@ -46,7 +43,7 @@ const TabsRoot = ({
   const slots = React.useMemo(() => tabsVariants({variant}), [variant]);
 
   return (
-    <TabsContext value={{hideSeparator, orientation, slots}}>
+    <TabsContext value={{orientation, slots}}>
       <TabsPrimitive
         {...props}
         className={composeTwRenderProps(className, slots.base())}
@@ -89,13 +86,12 @@ interface TabListProps extends ComponentPropsWithRef<typeof TabListPrimitive<obj
 }
 
 const TabList = ({children, className, ...props}: TabListProps) => {
-  const {hideSeparator, slots} = useContext(TabsContext);
+  const {slots} = useContext(TabsContext);
 
   return (
     <TabListPrimitive
       {...props}
       className={composeTwRenderProps(className, slots?.tabList())}
-      data-hide-separator={hideSeparator ? "true" : undefined}
       data-slot="tabs-list"
     >
       {children}
@@ -166,9 +162,29 @@ const TabPanel = ({children, className, ...props}: TabPanelProps) => {
 };
 
 /* -------------------------------------------------------------------------------------------------
+ * Tab Separator
+ * -----------------------------------------------------------------------------------------------*/
+interface TabSeparatorProps extends ComponentPropsWithRef<"span"> {
+  className?: string;
+}
+
+const TabSeparator = ({className, ...props}: TabSeparatorProps) => {
+  const {slots} = useContext(TabsContext);
+
+  return (
+    <span
+      aria-hidden="true"
+      className={composeSlotClassName(slots?.separator, className)}
+      data-slot="tabs-separator"
+      {...props}
+    />
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
  * Exports
  * -----------------------------------------------------------------------------------------------*/
-export {TabsRoot, TabListContainer, TabList, Tab, TabIndicator, TabPanel};
+export {TabsRoot, TabListContainer, TabList, Tab, TabIndicator, TabPanel, TabSeparator};
 
 export type {
   TabsRootProps,
@@ -177,4 +193,5 @@ export type {
   TabProps,
   TabIndicatorProps,
   TabPanelProps,
+  TabSeparatorProps,
 };

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -57,56 +57,19 @@
     opacity 150ms var(--ease-smooth);
   @apply motion-reduce:transition-none;
 
-  /* Separator between tabs */
-  &:not(:first-child):before {
-    @apply bg-muted/25;
-
-    content: "";
-    border-radius: 4px;
-    position: absolute;
-
-    /**
-     * Transitions
-     * CRITICAL: motion-reduce must be AFTER transition for correct override specificity
-     */
-    transition: opacity 150ms var(--ease-smooth);
-    @apply motion-reduce:transition-none;
-  }
-
-  /* Horizontal tabs - vertical separator */
-  .tabs__list[data-orientation="horizontal"] &:not(:first-child):before {
-    left: 0;
-    top: 25%;
-    width: 1px;
-    height: 50%;
-  }
-
-  /* Vertical tabs - horizontal separator */
-  .tabs__list[data-orientation="vertical"] &:not(:first-child):before {
-    top: 0;
-    left: 5%;
-    width: 90%;
-    height: 1px;
-  }
-
   /* Selected state */
   &[data-selected="true"] {
     @apply text-segment-foreground;
   }
 
   /* Hide separator when this tab is selected */
-  &[data-selected="true"]:before {
+  &[data-selected="true"] .tabs__separator {
     opacity: 0;
   }
 
   /* Hide separator when previous sibling is selected */
-  &[data-selected="true"] + .tabs__tab:before {
+  &[data-selected="true"] + .tabs__tab .tabs__separator {
     opacity: 0;
-  }
-
-  /* Hide separator when hideSeparator prop is set */
-  [data-hide-separator="true"] &:not(:first-child):before {
-    display: none;
   }
 
   /* Disabled state */
@@ -128,6 +91,38 @@
   &:focus-visible:not(:focus),
   &[data-focus-visible="true"] {
     @apply status-focused;
+  }
+}
+
+/* Tab separator */
+.tabs__separator {
+  @apply bg-muted/25;
+
+  border-radius: 4px;
+  position: absolute;
+  pointer-events: none;
+
+  /**
+   * Transitions
+   * CRITICAL: motion-reduce must be AFTER transition for correct override specificity
+   */
+  transition: opacity 150ms var(--ease-smooth);
+  @apply motion-reduce:transition-none;
+
+  /* Horizontal tabs - vertical separator */
+  .tabs__list[data-orientation="horizontal"] & {
+    left: 0;
+    top: 25%;
+    width: 1px;
+    height: 50%;
+  }
+
+  /* Vertical tabs - horizontal separator */
+  .tabs__list[data-orientation="vertical"] & {
+    top: 0;
+    left: 5%;
+    width: 90%;
+    height: 1px;
   }
 }
 
@@ -212,15 +207,15 @@
   .tabs__tab {
     @apply rounded-none;
 
-    /* Hide separators in secondary variant */
-    &:not(:first-child):before {
-      display: none;
-    }
-
     /* Selected state - use text-foreground */
     &[data-selected="true"] {
       @apply text-foreground;
     }
+  }
+
+  /* Hide separators in secondary variant */
+  .tabs__separator {
+    display: none;
   }
 
   /* Tab indicator - line style */

--- a/packages/styles/src/components/tabs/tabs.styles.ts
+++ b/packages/styles/src/components/tabs/tabs.styles.ts
@@ -8,6 +8,7 @@ export const tabsVariants = tv({
   },
   slots: {
     base: "tabs",
+    separator: "tabs__separator",
     tab: "tabs__tab",
     tabIndicator: "tabs__indicator",
     tabList: "tabs__list",


### PR DESCRIPTION
Closes #HHTA-404

## 📝 Description

Replaces the CSS pseudo-element (`::before`) separator implementation with an explicit `Tabs.Separator` compound component, giving users full control over separator placement and visibility.

## ⛳️ Current behavior (updates)

- Separators between tabs are rendered automatically via CSS `::before` pseudo-elements on every tab except the first
- A `hideSeparator` boolean prop on `<Tabs>` controls visibility globally
- Users have no granular control over which tabs show separators

## 🚀 New behavior

- New `<Tabs.Separator />` compound component that users place explicitly inside `<Tabs.Tab>` where needed
- Removes the `hideSeparator` prop — separators are opt-in by composition instead of opt-out by prop
- Separators automatically hide when the adjacent tab is selected (preserved behavior)
- Separators are hidden by default in the `secondary` variant (preserved behavior)
- Supports custom `className` for styling overrides
- Updated documentation, demos, and stories to reflect the new API

## 💣 Is this a breaking change (Yes/No):

Yes — the `hideSeparator` prop has been removed from `<Tabs>`. Users who previously used `<Tabs hideSeparator>` should simply omit `<Tabs.Separator />` from their tab markup. Users who relied on automatic separators need to add `<Tabs.Separator />` inside each `<Tabs.Tab>` (except the first).