### PR TITLE
fix(styles): input group focusing styles

### DIFF
--- a/packages/styles/components/input-group.css
+++ b/packages/styles/components/input-group.css
@@ -1,6 +1,6 @@
 /* Input group styles */
 .input-group {
-  @apply inline-flex min-h-9 items-center overflow-hidden rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
+  @apply inline-flex min-h-9 items-center rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
   border-color: var(--color-field-border);
 
@@ -29,9 +29,9 @@
     }
   }
 
-  /* Focus within state */
-  &[data-focus-within="true"],
-  &:focus-within {
+  /* Focus within state - only when input/textarea is focused */
+  &:has([data-slot="input-group-input"]:focus),
+  &:has([data-slot="input-group-textarea"]:focus) {
     @apply status-focused-field;
     border-color: var(--color-field-border-focus);
     background-color: var(--color-field-focus);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

originally reported from discord.

A reproducible example can be found in https://v3.heroui.com/docs/react/components/input-group#password-toggle. Tabbing twice will see the input group and button are with focus-ring at the same time. This PR is to fix this behaviour. The group focus ring should only apply when the input is focused, not other inner components.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

first tabbing

<img width="356" height="100" alt="image" src="https://github.com/user-attachments/assets/0a19921f-164d-4546-8b7e-5250eaa12ca1" />

second tabbing

<img width="351" height="100" alt="image" src="https://github.com/user-attachments/assets/a0d27e7b-d2d6-4b69-892a-397b315bed32" />


## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

first tabbing

<img width="325" height="87" alt="image" src="https://github.com/user-attachments/assets/4ffb22b9-1960-4bc8-a1a9-e3be6bb4ae54" />

second tabbing

<img width="384" height="99" alt="image" src="https://github.com/user-attachments/assets/350168e5-39db-4a60-8e07-078cb5c03fe7" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
