### PR TITLE
feat(meter): add Meter component with documentation, demos, and styles

### DIFF
--- a/apps/docs/content/docs/react/components/(feedback)/meter.mdx
+++ b/apps/docs/content/docs/react/components/(feedback)/meter.mdx
@@ -1,0 +1,161 @@
+---
+title: Meter
+description: A meter represents a quantity within a known range, or a fractional value.
+icon: new
+links:
+  rac: Meter
+  source: meter/meter.tsx
+  styles: meter.css
+  storybook: Components/Feedback/Meter
+---
+
+## Import
+
+```tsx
+import { Meter, Label } from '@heroui/react';
+```
+
+### Usage
+
+<ComponentPreview
+  name="meter-basic"
+/>
+
+### Anatomy
+
+```tsx
+import { Meter, Label } from '@heroui/react';
+
+export default () => (
+  <Meter value={60}>
+    <Label>Storage</Label>
+    <Meter.Output />
+    <Meter.Track>
+      <Meter.Fill />
+    </Meter.Track>
+  </Meter>
+);
+```
+
+### Sizes
+
+<ComponentPreview
+  name="meter-sizes"
+/>
+
+### Colors
+
+<ComponentPreview
+  name="meter-colors"
+/>
+
+### Custom Value Scale
+
+Use `minValue`, `maxValue`, and `formatOptions` to customize the value range and display format.
+
+<ComponentPreview
+  name="meter-custom-value"
+/>
+
+### Without Label
+
+When no visible label is needed, use `aria-label` for accessibility.
+
+<ComponentPreview
+  name="meter-without-label"
+/>
+
+<RelatedComponents component="meter" />
+
+## Styling
+
+### Passing Tailwind CSS classes
+
+You can customize individual Meter parts:
+
+```tsx
+import { Meter, Label } from '@heroui/react';
+
+function CustomMeter() {
+  return (
+    <Meter value={60}>
+      <Label>Storage</Label>
+      <Meter.Output />
+      <Meter.Track className="bg-purple-100 dark:bg-purple-900">
+        <Meter.Fill className="bg-purple-500" />
+      </Meter.Track>
+    </Meter>
+  );
+}
+```
+
+### Customizing the component classes
+
+To customize the Meter component classes, you can use the `@layer components` directive.
+<br/>[Learn more](https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes).
+
+```css
+@layer components {
+  .meter {
+    @apply w-full gap-2;
+  }
+
+  .meter__track {
+    @apply h-3 rounded-full;
+  }
+
+  .meter__fill {
+    @apply rounded-full;
+  }
+}
+```
+
+HeroUI follows the [BEM](https://getbem.com/) methodology to ensure component variants and states are reusable and easy to customize.
+
+### CSS Classes
+
+The Meter component uses these CSS classes ([View source styles](https://github.com/heroui-inc/heroui/blob/v3/packages/styles/components/meter.css)):
+
+#### Base & Element Classes
+- `.meter` - Base container (grid layout)
+- `.meter__output` - Value text display
+- `.meter__track` - Track background
+- `.meter__fill` - Filled portion of the track
+
+#### Size Classes
+- `.meter--sm` - Small size variant (thinner track)
+- `.meter--md` - Medium size variant (default)
+- `.meter--lg` - Large size variant (thicker track)
+
+#### Color Classes
+- `.meter--default` - Default color variant
+- `.meter--accent` - Accent color variant
+- `.meter--success` - Success color variant
+- `.meter--warning` - Warning color variant
+- `.meter--danger` - Danger color variant
+
+## API Reference
+
+### Meter Props
+
+Inherits from [React Aria Meter](https://react-spectrum.adobe.com/react-aria/Meter.html).
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `number` | `0` | The current value |
+| `minValue` | `number` | `0` | The minimum value |
+| `maxValue` | `number` | `100` | The maximum value |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Size of the meter track |
+| `color` | `"default" \| "accent" \| "success" \| "warning" \| "danger"` | `"accent"` | Color of the fill bar |
+| `formatOptions` | `Intl.NumberFormatOptions` | `{style: 'percent'}` | Number format for the value display |
+| `valueLabel` | `ReactNode` | - | Custom value label content |
+| `children` | `ReactNode \| (values: MeterRenderProps) => ReactNode` | - | Content or render prop |
+
+### MeterRenderProps
+
+When using the render prop pattern, these values are provided:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `percentage` | `number` | The percentage of the meter (0-100) |
+| `valueText` | `string` | The formatted value text |

--- a/apps/docs/content/docs/react/components/meta.json
+++ b/apps/docs/content/docs/react/components/meta.json
@@ -47,6 +47,7 @@
     "(forms)/label",
     "(navigation)/link",
     "(collections)/list-box",
+    "(feedback)/meter",
     "(overlays)/modal",
     "(forms)/number-field",
     "(navigation)/pagination",

--- a/apps/docs/src/components-registry.ts
+++ b/apps/docs/src/components-registry.ts
@@ -287,6 +287,13 @@ const componentsMap: Record<string, ComponentInfo> = {
     name: "list-box",
     title: "Listbox",
   },
+  meter: {
+    category: "feedback",
+    description: "A quantity indicator within a known range",
+    href: "/docs/components/meter",
+    name: "meter",
+    title: "Meter",
+  },
   modal: {
     category: "layout",
     description: "Displays content in a modal overlay",

--- a/apps/docs/src/components/components-category.tsx
+++ b/apps/docs/src/components/components-category.tsx
@@ -71,7 +71,7 @@ const COMPONENT_GROUPS = [
   },
   {
     category: "Feedback",
-    components: ["alert", "skeleton", "spinner"],
+    components: ["alert", "meter", "skeleton", "spinner"],
   },
   {
     category: "Layout",

--- a/apps/docs/src/demos/index.ts
+++ b/apps/docs/src/demos/index.ts
@@ -41,6 +41,7 @@ import * as KbdDemos from "./kbd";
 import * as LabelDemos from "./label";
 import * as LinkDemos from "./link";
 import * as ListBoxDemos from "./list-box";
+import * as MeterDemos from "./meter";
 import * as ModalDemos from "./modal";
 import * as NumberFieldDemos from "./number-field";
 import * as PaginationDemos from "./pagination";
@@ -1983,6 +1984,27 @@ export const demos: Record<string, DemoItem> = {
   "list-box-custom-render-function": {
     component: ListBoxDemos.CustomRenderFunction,
     file: "list-box/custom-render-function.tsx",
+  },
+  // Meter demos
+  "meter-basic": {
+    component: MeterDemos.Basic,
+    file: "meter/basic.tsx",
+  },
+  "meter-sizes": {
+    component: MeterDemos.Sizes,
+    file: "meter/sizes.tsx",
+  },
+  "meter-colors": {
+    component: MeterDemos.Colors,
+    file: "meter/colors.tsx",
+  },
+  "meter-custom-value": {
+    component: MeterDemos.CustomValue,
+    file: "meter/custom-value.tsx",
+  },
+  "meter-without-label": {
+    component: MeterDemos.WithoutLabel,
+    file: "meter/without-label.tsx",
   },
   // Modal demos
   "modal-default": {

--- a/apps/docs/src/demos/meter/basic.tsx
+++ b/apps/docs/src/demos/meter/basic.tsx
@@ -1,0 +1,13 @@
+import {Label, Meter} from "@heroui/react";
+
+export function Basic() {
+  return (
+    <Meter aria-label="Storage" className="w-64" value={60}>
+      <Label>Storage</Label>
+      <Meter.Output />
+      <Meter.Track>
+        <Meter.Fill />
+      </Meter.Track>
+    </Meter>
+  );
+}

--- a/apps/docs/src/demos/meter/colors.tsx
+++ b/apps/docs/src/demos/meter/colors.tsx
@@ -1,0 +1,43 @@
+import {Label, Meter} from "@heroui/react";
+
+export function Colors() {
+  return (
+    <div className="flex w-64 flex-col gap-6">
+      <Meter color="default" value={50}>
+        <Label>Default</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+      <Meter color="accent" value={50}>
+        <Label>Accent</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+      <Meter color="success" value={50}>
+        <Label>Success</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+      <Meter color="warning" value={50}>
+        <Label>Warning</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+      <Meter color="danger" value={50}>
+        <Label>Danger</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+    </div>
+  );
+}

--- a/apps/docs/src/demos/meter/custom-value.tsx
+++ b/apps/docs/src/demos/meter/custom-value.tsx
@@ -1,0 +1,19 @@
+import {Label, Meter} from "@heroui/react";
+
+export function CustomValue() {
+  return (
+    <Meter
+      className="w-64"
+      formatOptions={{currency: "USD", style: "currency"}}
+      maxValue={1000}
+      minValue={0}
+      value={750}
+    >
+      <Label>Revenue</Label>
+      <Meter.Output />
+      <Meter.Track>
+        <Meter.Fill />
+      </Meter.Track>
+    </Meter>
+  );
+}

--- a/apps/docs/src/demos/meter/index.ts
+++ b/apps/docs/src/demos/meter/index.ts
@@ -1,0 +1,5 @@
+export {Basic} from "./basic";
+export {Colors} from "./colors";
+export {CustomValue} from "./custom-value";
+export {Sizes} from "./sizes";
+export {WithoutLabel} from "./without-label";

--- a/apps/docs/src/demos/meter/sizes.tsx
+++ b/apps/docs/src/demos/meter/sizes.tsx
@@ -1,0 +1,29 @@
+import {Label, Meter} from "@heroui/react";
+
+export function Sizes() {
+  return (
+    <div className="flex w-64 flex-col gap-6">
+      <Meter color="success" size="sm" value={40}>
+        <Label>Small</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+      <Meter color="accent" size="md" value={60}>
+        <Label>Medium</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+      <Meter color="warning" size="lg" value={80}>
+        <Label>Large</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+    </div>
+  );
+}

--- a/apps/docs/src/demos/meter/without-label.tsx
+++ b/apps/docs/src/demos/meter/without-label.tsx
@@ -1,0 +1,11 @@
+import {Meter} from "@heroui/react";
+
+export function WithoutLabel() {
+  return (
+    <Meter aria-label="Storage usage" className="w-64" value={45}>
+      <Meter.Track>
+        <Meter.Fill />
+      </Meter.Track>
+    </Meter>
+  );
+}

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -74,6 +74,7 @@ export * from "./modal";
 export * from "./number-field";
 export * from "./pagination";
 export * from "./select";
+export * from "./meter";
 export * from "./slider";
 export * from "./table";
 

--- a/packages/react/src/components/meter/index.ts
+++ b/packages/react/src/components/meter/index.ts
@@ -1,0 +1,41 @@
+import type {ComponentProps} from "react";
+
+import {MeterFill, MeterOutput, MeterRoot, MeterTrack} from "./meter";
+
+/* -------------------------------------------------------------------------------------------------
+ * Compound Component
+ * -----------------------------------------------------------------------------------------------*/
+export const Meter = Object.assign(MeterRoot, {
+  Root: MeterRoot,
+  Output: MeterOutput,
+  Track: MeterTrack,
+  Fill: MeterFill,
+});
+
+export type Meter = {
+  Props: ComponentProps<typeof MeterRoot>;
+  RootProps: ComponentProps<typeof MeterRoot>;
+  OutputProps: ComponentProps<typeof MeterOutput>;
+  TrackProps: ComponentProps<typeof MeterTrack>;
+  FillProps: ComponentProps<typeof MeterFill>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * Named Component
+ * -----------------------------------------------------------------------------------------------*/
+export {MeterRoot, MeterOutput, MeterTrack, MeterFill};
+
+export type {
+  MeterRootProps,
+  MeterRootProps as MeterProps,
+  MeterOutputProps,
+  MeterTrackProps,
+  MeterFillProps,
+} from "./meter";
+
+/* -------------------------------------------------------------------------------------------------
+ * Variants
+ * -----------------------------------------------------------------------------------------------*/
+export {meterVariants} from "@heroui/styles";
+
+export type {MeterVariants} from "@heroui/styles";

--- a/packages/react/src/components/meter/meter.stories.tsx
+++ b/packages/react/src/components/meter/meter.stories.tsx
@@ -1,0 +1,156 @@
+import type {Meta, StoryObj} from "@storybook/react";
+
+import React from "react";
+
+import {Label} from "../label";
+
+import {Meter} from "./index";
+
+const meta: Meta<typeof Meter> = {
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["default", "accent", "success", "warning", "danger"],
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+  },
+  component: Meter,
+  decorators: [
+    (Story) => (
+      <div className="w-96 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  title: "Components/Feedback/Meter",
+};
+
+export default meta;
+type Story = StoryObj<typeof Meter>;
+
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <Meter value={60} {...args}>
+        <Label>Storage</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => {
+    return (
+      <div className="flex w-full flex-col gap-6">
+        <Meter size="sm" value={40} {...args}>
+          <Label>Small</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+        <Meter size="md" value={60} {...args}>
+          <Label>Medium</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+        <Meter size="lg" value={80} {...args}>
+          <Label>Large</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+      </div>
+    );
+  },
+};
+
+export const Colors: Story = {
+  render: (args) => {
+    return (
+      <div className="flex w-full flex-col gap-6">
+        <Meter color="default" value={50} {...args}>
+          <Label>Default</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+        <Meter color="accent" value={50} {...args}>
+          <Label>Accent</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+        <Meter color="success" value={50} {...args}>
+          <Label>Success</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+        <Meter color="warning" value={50} {...args}>
+          <Label>Warning</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+        <Meter color="danger" value={50} {...args}>
+          <Label>Danger</Label>
+          <Meter.Output />
+          <Meter.Track>
+            <Meter.Fill />
+          </Meter.Track>
+        </Meter>
+      </div>
+    );
+  },
+};
+
+export const CustomValue: Story = {
+  render: (args) => {
+    return (
+      <Meter
+        formatOptions={{style: "currency", currency: "USD"}}
+        maxValue={1000}
+        minValue={0}
+        value={750}
+        {...args}
+      >
+        <Label>Revenue</Label>
+        <Meter.Output />
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+    );
+  },
+};
+
+export const WithoutLabel: Story = {
+  render: (args) => {
+    return (
+      <Meter aria-label="Storage usage" value={45} {...args}>
+        <Meter.Track>
+          <Meter.Fill />
+        </Meter.Track>
+      </Meter>
+    );
+  },
+};

--- a/packages/react/src/components/meter/meter.tsx
+++ b/packages/react/src/components/meter/meter.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type {MeterVariants} from "@heroui/styles";
+import type {ComponentPropsWithRef} from "react";
+import type {MeterRenderProps} from "react-aria-components";
+
+import {meterVariants} from "@heroui/styles";
+import React, {createContext, useContext} from "react";
+import {Meter as MeterPrimitive} from "react-aria-components";
+
+import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
+
+/* -------------------------------------------------------------------------------------------------
+ * Meter Context
+ * -----------------------------------------------------------------------------------------------*/
+interface MeterContext {
+  slots?: ReturnType<typeof meterVariants>;
+  state?: MeterRenderProps;
+}
+
+const MeterContext = createContext<MeterContext>({});
+
+/* -------------------------------------------------------------------------------------------------
+ * Meter Root
+ * -----------------------------------------------------------------------------------------------*/
+interface MeterRootProps extends ComponentPropsWithRef<typeof MeterPrimitive>, MeterVariants {}
+
+const MeterRoot = ({children, className, color, size, ...props}: MeterRootProps) => {
+  const slots = React.useMemo(() => meterVariants({color, size}), [color, size]);
+
+  return (
+    <MeterPrimitive
+      data-slot="meter"
+      {...props}
+      className={composeTwRenderProps(className, slots.base())}
+    >
+      {(values) => (
+        <MeterContext value={{slots, state: values}}>
+          {typeof children === "function" ? children(values) : children}
+        </MeterContext>
+      )}
+    </MeterPrimitive>
+  );
+};
+
+MeterRoot.displayName = "HeroUI.Meter";
+
+/* -------------------------------------------------------------------------------------------------
+ * Meter Output
+ * -----------------------------------------------------------------------------------------------*/
+interface MeterOutputProps extends ComponentPropsWithRef<"span"> {}
+
+const MeterOutput = ({children, className, ...props}: MeterOutputProps) => {
+  const {slots, state} = useContext(MeterContext);
+
+  return (
+    <span
+      className={composeSlotClassName(slots?.output, className)}
+      data-slot="meter-output"
+      {...props}
+    >
+      {children ?? state?.valueText}
+    </span>
+  );
+};
+
+MeterOutput.displayName = "HeroUI.Meter.Output";
+
+/* -------------------------------------------------------------------------------------------------
+ * Meter Track
+ * -----------------------------------------------------------------------------------------------*/
+interface MeterTrackProps extends ComponentPropsWithRef<"div"> {}
+
+const MeterTrack = ({children, className, ...props}: MeterTrackProps) => {
+  const {slots} = useContext(MeterContext);
+
+  return (
+    <div
+      className={composeSlotClassName(slots?.track, className)}
+      data-slot="meter-track"
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+MeterTrack.displayName = "HeroUI.Meter.Track";
+
+/* -------------------------------------------------------------------------------------------------
+ * Meter Fill
+ * -----------------------------------------------------------------------------------------------*/
+interface MeterFillProps extends ComponentPropsWithRef<"div"> {}
+
+const MeterFill = ({className, style, ...props}: MeterFillProps) => {
+  const {slots, state} = useContext(MeterContext);
+
+  return (
+    <div
+      className={composeSlotClassName(slots?.fill, className)}
+      data-slot="meter-fill"
+      style={{
+        ...style,
+        width: `${state?.percentage ?? 0}%`,
+      }}
+      {...props}
+    />
+  );
+};
+
+MeterFill.displayName = "HeroUI.Meter.Fill";
+
+/* -------------------------------------------------------------------------------------------------
+ * Exports
+ * -----------------------------------------------------------------------------------------------*/
+export {MeterRoot, MeterOutput, MeterTrack, MeterFill};
+
+export type {MeterRootProps, MeterOutputProps, MeterTrackProps, MeterFillProps};

--- a/packages/styles/components/index.css
+++ b/packages/styles/components/index.css
@@ -83,6 +83,7 @@
 @import "./alert.css";
 @import "./empty-state.css";
 @import "./skeleton.css";
+@import "./meter.css";
 @import "./spinner.css";
 @import "./toast.css";
 

--- a/packages/styles/components/meter.css
+++ b/packages/styles/components/meter.css
@@ -1,0 +1,106 @@
+/* ==========================================================================
+   Meter - A quantity indicator within a known range
+   ========================================================================== */
+
+/* Base styles */
+.meter {
+  display: grid;
+  grid-template-areas:
+    "label output"
+    "track track";
+  grid-template-columns: 1fr auto;
+
+  @apply w-full gap-2;
+
+  /* Default color tokens (accent) */
+  --meter-fill: var(--color-accent);
+
+  [data-slot="label"] {
+    @apply w-fit text-sm font-medium;
+
+    grid-area: label;
+  }
+
+  .meter__output {
+    @apply text-sm font-medium tabular-nums;
+
+    grid-area: output;
+  }
+
+  .meter__track {
+    @apply relative overflow-hidden rounded-full bg-default;
+
+    grid-area: track;
+
+    /* Default height (matches --md) */
+    @apply h-2;
+  }
+
+  .meter__fill {
+    @apply absolute top-0 left-0 h-full rounded-full;
+
+    background-color: var(--meter-fill);
+
+    /**
+     * Transitions
+     * CRITICAL: motion-reduce must be AFTER transition for correct override specificity
+     */
+    transition: width 300ms var(--ease-out);
+    @apply motion-reduce:transition-none;
+  }
+
+  /* Disabled state */
+  &:disabled,
+  &[data-disabled="true"],
+  &[aria-disabled="true"] {
+    @apply status-disabled;
+
+    [data-slot="label"] {
+      @apply opacity-100;
+    }
+  }
+}
+
+/* ==========================================================================
+   Size variants
+   ========================================================================== */
+
+.meter--sm {
+  .meter__track {
+    @apply h-1;
+  }
+}
+
+.meter--md {
+  /* No styles as this is the default size */
+}
+
+.meter--lg {
+  .meter__track {
+    @apply h-3;
+  }
+}
+
+/* ==========================================================================
+   Color variants
+   ========================================================================== */
+
+.meter--default {
+  --meter-fill: var(--color-default-foreground);
+}
+
+.meter--accent {
+  --meter-fill: var(--color-accent);
+}
+
+.meter--success {
+  --meter-fill: var(--color-success);
+}
+
+.meter--warning {
+  --meter-fill: var(--color-warning);
+}
+
+.meter--danger {
+  --meter-fill: var(--color-danger);
+}

--- a/packages/styles/src/components/index.ts
+++ b/packages/styles/src/components/index.ts
@@ -47,6 +47,7 @@ export * from "./list-box";
 export * from "./list-box-item";
 export * from "./list-box-section";
 export * from "./menu";
+export * from "./meter";
 export * from "./menu-item";
 export * from "./menu-section";
 export * from "./modal";

--- a/packages/styles/src/components/meter/index.ts
+++ b/packages/styles/src/components/meter/index.ts
@@ -1,0 +1,1 @@
+export * from "./meter.styles";

--- a/packages/styles/src/components/meter/meter.styles.ts
+++ b/packages/styles/src/components/meter/meter.styles.ts
@@ -1,0 +1,48 @@
+import type {VariantProps} from "tailwind-variants";
+
+import {tv} from "tailwind-variants";
+
+export const meterVariants = tv({
+  defaultVariants: {
+    color: "accent",
+    size: "md",
+  },
+  slots: {
+    base: "meter",
+    fill: "meter__fill",
+    output: "meter__output",
+    track: "meter__track",
+  },
+  variants: {
+    color: {
+      accent: {
+        base: "meter--accent",
+      },
+      danger: {
+        base: "meter--danger",
+      },
+      default: {
+        base: "meter--default",
+      },
+      success: {
+        base: "meter--success",
+      },
+      warning: {
+        base: "meter--warning",
+      },
+    },
+    size: {
+      lg: {
+        base: "meter--lg",
+      },
+      md: {
+        base: "meter--md",
+      },
+      sm: {
+        base: "meter--sm",
+      },
+    },
+  },
+});
+
+export type MeterVariants = VariantProps<typeof meterVariants>;


### PR DESCRIPTION
Closes #N/A

## 📝 Description

Adds a new `Meter` component to HeroUI v3, including React implementation, styles package integration, Storybook stories, and docs content with multiple demos.

## ⛳️ Current behavior (updates)

## 🚀 New behavior

A complete `Meter` component is now available with:
- Component exports wired into `@heroui/react`
- CSS and style mappings added in `@heroui/styles`
- Storybook coverage for usage/variants
- Documentation page and demo examples registered in docs app

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The changes include component registration and category/docs metadata updates so the new component appears in documentation navigation and demo indexes.