### PR TITLE
fix(use-draggable): persist transform position across renders

### DIFF
--- a/.changeset/cold-turtles-love.md
+++ b/.changeset/cold-turtles-love.md
@@ -1,0 +1,5 @@
+---
+"@heroui/use-draggable": patch
+---
+
+persist transform position across renders (#6283)

--- a/packages/hooks/use-draggable/src/index.ts
+++ b/packages/hooks/use-draggable/src/index.ts
@@ -29,11 +29,22 @@ export function useDraggable(props: UseDraggableProps): MoveResult {
   const {targetRef, isDisabled = false, canOverflow = false} = props;
   const boundary = useRef({minLeft: 0, minTop: 0, maxLeft: 0, maxTop: 0});
   const isDragging = useRef(false);
-  let transform = {offsetX: 0, offsetY: 0};
+  const transform = useRef({offsetX: 0, offsetY: 0});
+  const prevTargetRef = useRef<HTMLElement | null>(null);
+
+  // Reset transform when target element changes (e.g., modal closes and reopens)
+  useEffect(() => {
+    const currentTarget = targetRef?.current ?? null;
+
+    if (prevTargetRef.current !== currentTarget) {
+      transform.current = {offsetX: 0, offsetY: 0};
+      prevTargetRef.current = currentTarget;
+    }
+  }, [targetRef?.current]);
 
   const onMoveStart = useCallback(() => {
     isDragging.current = true;
-    const {offsetX, offsetY} = transform;
+    const {offsetX, offsetY} = transform.current;
 
     const targetRect = targetRef?.current?.getBoundingClientRect();
     const targetLeft = targetRect?.left ?? 0;
@@ -55,14 +66,14 @@ export function useDraggable(props: UseDraggableProps): MoveResult {
       maxLeft,
       maxTop,
     };
-  }, [transform, targetRef?.current]);
+  }, [targetRef]);
 
   const onMove = useCallback(
     (e: MoveMoveEvent) => {
       if (isDisabled) {
         return;
       }
-      const {offsetX, offsetY} = transform;
+      const {offsetX, offsetY} = transform.current;
       const {minLeft, minTop, maxLeft, maxTop} = boundary.current;
       let moveX = offsetX + e.deltaX;
       let moveY = offsetY + e.deltaY;
@@ -72,7 +83,7 @@ export function useDraggable(props: UseDraggableProps): MoveResult {
         moveY = Math.min(Math.max(moveY, minTop), maxTop);
       }
 
-      transform = {
+      transform.current = {
         offsetX: moveX,
         offsetY: moveY,
       };
@@ -81,7 +92,7 @@ export function useDraggable(props: UseDraggableProps): MoveResult {
         targetRef.current.style.transform = `translate(${moveX}px, ${moveY}px)`;
       }
     },
-    [isDisabled, transform, boundary.current, canOverflow, targetRef?.current],
+    [isDisabled, canOverflow, targetRef],
   );
 
   const onMoveEnd = useCallback(() => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6283

## 📝 Description

<!--- Add a brief description -->

- Fix draggable modal position resetting to center when starting a new drag after previous drag
- Change transform from a regular variable to useRef to persist position across renders
- Add effect to reset transform when target element changes (modal close/reopen)

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

- Open a draggable modal
- Drag it to the left, release
- Drag it to the right
- Jump to center

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

- Open a draggable modal
- Drag it to the left, release
- Drag it to the right - continue from current position, not jump to center
- Close and reopen modal - should start from center position again

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
