### PR TITLE
feat(toolbar): introduce Toolbar component with documentation and demos

### DIFF
--- a/apps/docs/content/docs/react/components/(buttons)/button-group.mdx
+++ b/apps/docs/content/docs/react/components/(buttons)/button-group.mdx
@@ -58,6 +58,14 @@ export default () => (
   name="button-group-sizes"
 />
 
+### Orientation
+
+Use the `orientation` prop to arrange buttons horizontally or vertically.
+
+<ComponentPreview
+  name="button-group-orientation"
+/>
+
 ### With Icons
 
 <ComponentPreview
@@ -154,6 +162,7 @@ Add `<ButtonGroup.Separator />` inside each Button (except the first) to show di
 |------|------|---------|-------------|
 | `variant` | `'primary' \| 'secondary' \| 'tertiary' \| 'ghost' \| 'danger'` | - | Visual style variant applied to all buttons in the group |
 | `size` | `'sm' \| 'md' \| 'lg'` | - | Size applied to all buttons in the group |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | The orientation of the button group |
 | `fullWidth` | `boolean` | `false` | Whether the button group should take full width of its container |
 | `isDisabled` | `boolean` | `false` | Whether all buttons in the group are disabled (can be overridden on individual buttons) |
 | `className` | `string` | - | Additional CSS classes |

--- a/apps/docs/content/docs/react/components/(layout)/toolbar.mdx
+++ b/apps/docs/content/docs/react/components/(layout)/toolbar.mdx
@@ -1,0 +1,108 @@
+---
+title: Toolbar
+description: A container for interactive controls with arrow key navigation.
+icon: new
+links:
+  rac: Toolbar
+  source: toolbar/toolbar.tsx
+  styles: toolbar.css
+  storybook: Components/Layout/Toolbar
+---
+
+## Import
+
+```tsx
+import { Toolbar } from '@heroui/react';
+```
+
+### Usage
+
+<ComponentPreview
+  name="toolbar-basic"
+/>
+
+### Vertical
+
+<ComponentPreview
+  name="toolbar-vertical"
+/>
+
+### With ButtonGroup
+
+<ComponentPreview
+  name="toolbar-with-button-group"
+/>
+
+### Attached
+
+<ComponentPreview
+  name="toolbar-attached"
+/>
+
+<RelatedComponents component="toolbar" />
+
+## Styling
+
+### Passing Tailwind CSS classes
+
+```tsx
+import { Toolbar } from '@heroui/react';
+
+function CustomToolbar() {
+  return (
+    <Toolbar
+      aria-label="Actions"
+      className="rounded-xl border border-default bg-surface p-2"
+    >
+      {/* toolbar content */}
+    </Toolbar>
+  );
+}
+```
+
+### Customizing the component classes
+
+To customize the Toolbar component classes, you can use the `@layer components` directive.
+<br/>[Learn more](https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes).
+
+```css
+@layer components {
+  .toolbar {
+    @apply gap-4 rounded-lg bg-surface p-3;
+  }
+}
+```
+
+HeroUI follows the [BEM](https://getbem.com/) methodology to ensure component variants and states are reusable and easy to customize.
+
+### CSS Classes
+
+The Toolbar component uses these CSS classes ([View source styles](https://github.com/heroui-inc/heroui/blob/v3/packages/styles/components/toolbar.css)):
+
+- `.toolbar` - Base container
+- `.toolbar--horizontal` - Horizontal orientation (default)
+- `.toolbar--vertical` - Vertical orientation
+- `.toolbar--attached` - Attached variant with surface background and full rounding
+
+## API Reference
+
+### Toolbar Props
+
+Inherits from [React Aria Toolbar](https://react-spectrum.adobe.com/react-aria/Toolbar.html).
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isAttached` | `boolean` | `false` | Whether the toolbar has a surface background with full rounding |
+| `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | The orientation of the toolbar |
+| `aria-label` | `string` | - | An accessible label for the toolbar |
+| `aria-labelledby` | `string` | - | The id of an element that labels the toolbar |
+| `children` | `React.ReactNode \| (values: ToolbarRenderProps) => React.ReactNode` | - | Content or render prop |
+| `className` | `string \| (values: ToolbarRenderProps) => string` | - | Additional CSS classes |
+
+### ToolbarRenderProps
+
+When using the render prop pattern, these values are provided:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `orientation` | `"horizontal" \| "vertical"` | The current orientation of the toolbar |

--- a/apps/docs/content/docs/react/components/meta.json
+++ b/apps/docs/content/docs/react/components/meta.json
@@ -72,6 +72,7 @@
     "(forms)/text-area",
     "(date-and-time)/time-field",
     "(overlays)/toast",
+    "(layout)/toolbar",
     "(buttons)/toggle-button",
     "(buttons)/toggle-button-group",
     "(overlays)/tooltip"

--- a/apps/docs/src/components-registry.ts
+++ b/apps/docs/src/components-registry.ts
@@ -477,6 +477,13 @@ const componentsMap: Record<string, ComponentInfo> = {
     name: "togglebuttongroup",
     title: "ToggleButtonGroup",
   },
+  toolbar: {
+    category: "layout",
+    description: "Container for interactive controls with arrow key navigation",
+    href: "/docs/components/toolbar",
+    name: "toolbar",
+    title: "Toolbar",
+  },
   tooltip: {
     category: "display",
     description: "Contextual information on hover or focus",
@@ -763,6 +770,7 @@ const componentRelationships: Record<string, string[]> = {
   toast: ["button", "alert", "closebutton", "spinner"],
   togglebutton: ["button", "switch", "checkbox", "togglebuttongroup"],
   togglebuttongroup: ["togglebutton", "buttongroup", "button"],
+  toolbar: ["buttongroup", "togglebuttongroup", "separator", "button"],
   tooltip: ["button", "popover"],
 };
 

--- a/apps/docs/src/components/components-category.tsx
+++ b/apps/docs/src/components/components-category.tsx
@@ -75,7 +75,7 @@ const COMPONENT_GROUPS = [
   },
   {
     category: "Layout",
-    components: ["card", "separator", "surface"],
+    components: ["card", "separator", "surface", "toolbar"],
   },
   {
     category: "Media",

--- a/apps/docs/src/demos/button-group/index.ts
+++ b/apps/docs/src/demos/button-group/index.ts
@@ -1,6 +1,7 @@
 export {Basic} from "./basic";
 export {Disabled} from "./disabled";
 export {FullWidth} from "./full-width";
+export {Orientation} from "./orientation";
 export {Sizes} from "./sizes";
 export {Variants} from "./variants";
 export {WithIcons} from "./with-icons";

--- a/apps/docs/src/demos/button-group/orientation.tsx
+++ b/apps/docs/src/demos/button-group/orientation.tsx
@@ -1,0 +1,49 @@
+import {TextAlignCenter, TextAlignJustify, TextAlignLeft, TextAlignRight} from "@gravity-ui/icons";
+import {Button, ButtonGroup} from "@heroui/react";
+
+export function Orientation() {
+  return (
+    <div className="flex items-start gap-8">
+      <div className="flex flex-col gap-2">
+        <span className="text-sm text-muted">Horizontal</span>
+        <ButtonGroup orientation="horizontal" variant="tertiary">
+          <Button isIconOnly>
+            <TextAlignLeft />
+          </Button>
+          <Button isIconOnly>
+            <ButtonGroup.Separator />
+            <TextAlignCenter />
+          </Button>
+          <Button isIconOnly>
+            <ButtonGroup.Separator />
+            <TextAlignRight />
+          </Button>
+          <Button isIconOnly>
+            <ButtonGroup.Separator />
+            <TextAlignJustify />
+          </Button>
+        </ButtonGroup>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-sm text-muted">Vertical</span>
+        <ButtonGroup orientation="vertical" variant="tertiary">
+          <Button isIconOnly>
+            <TextAlignLeft />
+          </Button>
+          <Button isIconOnly>
+            <ButtonGroup.Separator />
+            <TextAlignCenter />
+          </Button>
+          <Button isIconOnly>
+            <ButtonGroup.Separator />
+            <TextAlignRight />
+          </Button>
+          <Button isIconOnly>
+            <ButtonGroup.Separator />
+            <TextAlignJustify />
+          </Button>
+        </ButtonGroup>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/demos/index.ts
+++ b/apps/docs/src/demos/index.ts
@@ -68,6 +68,7 @@ import * as TimeFieldDemos from "./time-field";
 import * as ToastDemos from "./toast";
 import * as ToggleButtonDemos from "./toggle-button";
 import * as ToggleButtonGroupDemos from "./toggle-button-group";
+import * as ToolbarDemos from "./toolbar";
 import * as TooltipDemos from "./tooltip";
 
 export interface DemoItem {
@@ -340,6 +341,10 @@ export const demos: Record<string, DemoItem> = {
   "button-group-with-icons": {
     component: ButtonGroupDemos.WithIcons,
     file: "button-group/with-icons.tsx",
+  },
+  "button-group-orientation": {
+    component: ButtonGroupDemos.Orientation,
+    file: "button-group/orientation.tsx",
   },
   "button-group-without-separator": {
     component: ButtonGroupDemos.WithoutSeparator,
@@ -1948,6 +1953,23 @@ export const demos: Record<string, DemoItem> = {
   "toggle-button-group-without-separator": {
     component: ToggleButtonGroupDemos.WithoutSeparator,
     file: "toggle-button-group/without-separator.tsx",
+  },
+  // Toolbar demos
+  "toolbar-basic": {
+    component: ToolbarDemos.Basic,
+    file: "toolbar/basic.tsx",
+  },
+  "toolbar-vertical": {
+    component: ToolbarDemos.Vertical,
+    file: "toolbar/vertical.tsx",
+  },
+  "toolbar-with-button-group": {
+    component: ToolbarDemos.WithButtonGroup,
+    file: "toolbar/with-button-group.tsx",
+  },
+  "toolbar-attached": {
+    component: ToolbarDemos.Attached,
+    file: "toolbar/custom-styles.tsx",
   },
   // Tooltip demos
   "tooltip-basic": {

--- a/apps/docs/src/demos/progress-bar/custom-value.tsx
+++ b/apps/docs/src/demos/progress-bar/custom-value.tsx
@@ -43,7 +43,7 @@ export function CustomValue() {
       </div>
 
       <Separator className="md:hidden" />
-      <Separator className="hidden self-stretch md:block" orientation="vertical" />
+      <Separator className="hidden md:block" orientation="vertical" />
 
       <div className="flex max-w-52 flex-col gap-3">
         <Label className="text-xs font-medium text-muted">Options</Label>

--- a/apps/docs/src/demos/toolbar/basic.tsx
+++ b/apps/docs/src/demos/toolbar/basic.tsx
@@ -1,0 +1,39 @@
+import {Bold, Copy, Italic, Scissors, Underline} from "@gravity-ui/icons";
+import {
+  Button,
+  ButtonGroup,
+  Separator,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+} from "@heroui/react";
+
+export function Basic() {
+  return (
+    <Toolbar aria-label="Text formatting">
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Bold />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Italic />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Underline />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup variant="tertiary">
+        <Button isIconOnly aria-label="Copy">
+          <Copy />
+        </Button>
+        <Button isIconOnly aria-label="Cut">
+          <ButtonGroup.Separator />
+          <Scissors />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  );
+}

--- a/apps/docs/src/demos/toolbar/custom-styles.tsx
+++ b/apps/docs/src/demos/toolbar/custom-styles.tsx
@@ -1,0 +1,39 @@
+import {Bold, Copy, Italic, Scissors, Underline} from "@gravity-ui/icons";
+import {
+  Button,
+  ButtonGroup,
+  Separator,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+} from "@heroui/react";
+
+export function Attached() {
+  return (
+    <Toolbar isAttached aria-label="Text formatting">
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Bold />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Italic />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Underline />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup variant="tertiary">
+        <Button isIconOnly aria-label="Copy">
+          <Copy />
+        </Button>
+        <Button isIconOnly aria-label="Cut">
+          <ButtonGroup.Separator />
+          <Scissors />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  );
+}

--- a/apps/docs/src/demos/toolbar/index.ts
+++ b/apps/docs/src/demos/toolbar/index.ts
@@ -1,0 +1,4 @@
+export {Basic} from "./basic";
+export {Vertical} from "./vertical";
+export {WithButtonGroup} from "./with-button-group";
+export {Attached} from "./custom-styles";

--- a/apps/docs/src/demos/toolbar/vertical.tsx
+++ b/apps/docs/src/demos/toolbar/vertical.tsx
@@ -1,0 +1,39 @@
+import {ArrowUturnCcwLeft, ArrowUturnCwRight, Bold, Italic, Underline} from "@gravity-ui/icons";
+import {
+  Button,
+  ButtonGroup,
+  Separator,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+} from "@heroui/react";
+
+export function Vertical() {
+  return (
+    <Toolbar aria-label="Tools" orientation="vertical">
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Bold />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Italic />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Underline />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup variant="tertiary">
+        <Button isIconOnly aria-label="Undo">
+          <ArrowUturnCcwLeft />
+        </Button>
+        <Button isIconOnly aria-label="Redo">
+          <ButtonGroup.Separator />
+          <ArrowUturnCwRight />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  );
+}

--- a/apps/docs/src/demos/toolbar/with-button-group.tsx
+++ b/apps/docs/src/demos/toolbar/with-button-group.tsx
@@ -1,0 +1,64 @@
+import {
+  ArrowUturnCcwLeft,
+  ArrowUturnCwRight,
+  Bold,
+  Italic,
+  TextAlignCenter,
+  TextAlignLeft,
+  TextAlignRight,
+  Underline,
+} from "@gravity-ui/icons";
+import {
+  Button,
+  ButtonGroup,
+  Separator,
+  ToggleButton,
+  ToggleButtonGroup,
+  Toolbar,
+} from "@heroui/react";
+
+export function WithButtonGroup() {
+  return (
+    <Toolbar aria-label="Editor toolbar">
+      <ButtonGroup variant="tertiary">
+        <Button>
+          <ArrowUturnCcwLeft />
+          Undo
+        </Button>
+        <Button>
+          <ButtonGroup.Separator />
+          <ArrowUturnCwRight />
+          Redo
+        </Button>
+      </ButtonGroup>
+      <Separator />
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Bold />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Italic />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Underline />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup variant="tertiary">
+        <Button isIconOnly aria-label="Align left">
+          <TextAlignLeft />
+        </Button>
+        <Button isIconOnly aria-label="Align center">
+          <ButtonGroup.Separator />
+          <TextAlignCenter />
+        </Button>
+        <Button isIconOnly aria-label="Align right">
+          <ButtonGroup.Separator />
+          <TextAlignRight />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  );
+}

--- a/packages/react/src/components/button-group/button-group.tsx
+++ b/packages/react/src/components/button-group/button-group.tsx
@@ -6,8 +6,13 @@ import type {ComponentPropsWithRef} from "react";
 
 import {buttonGroupVariants} from "@heroui/styles";
 import React, {Children, createContext, isValidElement, useContext} from "react";
+import {
+  Group,
+  ToggleButtonGroupContext as RACToggleButtonGroupContext,
+  useSlottedContext,
+} from "react-aria-components";
 
-import {composeSlotClassName} from "../../utils";
+import {composeSlotClassName, composeTwRenderProps} from "../../utils";
 
 /* -------------------------------------------------------------------------------------------------
  * ButtonGroup Context
@@ -30,23 +35,33 @@ export const BUTTON_GROUP_CHILD = "__button_group_child";
  * -----------------------------------------------------------------------------------------------*/
 interface ButtonGroupRootProps
   extends
-    ComponentPropsWithRef<"div">,
-    Pick<ButtonProps, "size" | "variant" | "isDisabled">,
-    ButtonGroupVariants {}
+    ComponentPropsWithRef<typeof Group>,
+    Pick<ButtonProps, "size" | "variant">,
+    ButtonGroupVariants {
+  /** The orientation of the button group */
+  orientation?: "horizontal" | "vertical";
+}
 
 const ButtonGroupRoot = ({
   children,
   className,
   fullWidth,
   isDisabled,
+  orientation: orientationProp,
   size,
   variant,
   ...rest
 }: ButtonGroupRootProps) => {
-  const slots = React.useMemo(() => buttonGroupVariants({fullWidth}), [fullWidth]);
+  const racContext = useSlottedContext(RACToggleButtonGroupContext);
+  const orientation = orientationProp ?? racContext?.orientation ?? "horizontal";
+
+  const slots = React.useMemo(
+    () => buttonGroupVariants({fullWidth, orientation}),
+    [fullWidth, orientation],
+  );
 
   // Wrap only direct children with context provider
-  const wrappedChildren = Children.map(children, (child) => {
+  const wrappedChildren = Children.map(children as React.ReactNode, (child) => {
     if (!isValidElement(child)) {
       return child;
     }
@@ -59,9 +74,14 @@ const ButtonGroupRoot = ({
 
   return (
     <ButtonGroupContext value={{slots, size, variant, isDisabled, fullWidth}}>
-      <div className={slots.base({className})} data-slot="button-group" {...rest}>
+      <Group
+        className={composeTwRenderProps(className, slots.base())}
+        data-slot="button-group"
+        isDisabled={isDisabled}
+        {...rest}
+      >
         {wrappedChildren}
-      </div>
+      </Group>
     </ButtonGroupContext>
   );
 };

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -48,6 +48,7 @@ export * from "./tabs";
 export * from "./tag";
 export * from "./tag-group";
 export * from "./toggle-button-group";
+export * from "./toolbar";
 export * from "./tooltip";
 export * from "./input";
 export * from "./input-group";

--- a/packages/react/src/components/separator/separator.tsx
+++ b/packages/react/src/components/separator/separator.tsx
@@ -5,7 +5,11 @@ import type {ComponentPropsWithRef} from "react";
 
 import {separatorVariants} from "@heroui/styles";
 import React from "react";
-import {Separator as SeparatorPrimitive} from "react-aria-components";
+import {
+  SeparatorContext,
+  Separator as SeparatorPrimitive,
+  useSlottedContext,
+} from "react-aria-components";
 
 /* -------------------------------------------------------------------------------------------------
  * Separator Root
@@ -13,19 +17,17 @@ import {Separator as SeparatorPrimitive} from "react-aria-components";
 interface SeparatorRootProps
   extends ComponentPropsWithRef<typeof SeparatorPrimitive>, SeparatorVariants {}
 
-const SeparatorRoot = ({
-  className,
-  orientation = "horizontal",
-  variant,
-  ...props
-}: SeparatorRootProps) => {
+const SeparatorRoot = ({className, orientation, variant, ...props}: SeparatorRootProps) => {
+  const context = useSlottedContext(SeparatorContext);
+  const resolvedOrientation = orientation ?? context?.orientation ?? "horizontal";
+
   return (
     <SeparatorPrimitive
-      data-orientation={orientation}
+      data-orientation={resolvedOrientation}
       data-slot="separator"
-      orientation={orientation}
+      orientation={resolvedOrientation}
       className={separatorVariants({
-        orientation,
+        orientation: resolvedOrientation,
         variant,
         className,
       })}

--- a/packages/react/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/packages/react/src/components/toggle-button-group/toggle-button-group.tsx
@@ -5,7 +5,11 @@ import type {ComponentPropsWithRef} from "react";
 
 import {toggleButtonGroupVariants} from "@heroui/styles";
 import React, {createContext, useContext} from "react";
-import {ToggleButtonGroup as ToggleButtonGroupPrimitive} from "react-aria-components";
+import {
+  ToggleButtonGroupContext as RACToggleButtonGroupContext,
+  ToggleButtonGroup as ToggleButtonGroupPrimitive,
+  useSlottedContext,
+} from "react-aria-components";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils";
 
@@ -40,10 +44,13 @@ const ToggleButtonGroupRoot = ({
   fullWidth,
   isDetached = false,
   isDisabled,
-  orientation = "horizontal",
+  orientation: orientationProp,
   size,
   ...rest
 }: ToggleButtonGroupRootProps) => {
+  const racContext = useSlottedContext(RACToggleButtonGroupContext);
+  const orientation = orientationProp ?? racContext?.orientation ?? "horizontal";
+
   const slots = React.useMemo(
     () => toggleButtonGroupVariants({fullWidth, isDetached, orientation}),
     [fullWidth, isDetached, orientation],

--- a/packages/react/src/components/toolbar/index.ts
+++ b/packages/react/src/components/toolbar/index.ts
@@ -1,0 +1,29 @@
+import type {ComponentProps} from "react";
+
+import {ToolbarRoot} from "./toolbar";
+
+/* -------------------------------------------------------------------------------------------------
+ * Compound Component
+ * -----------------------------------------------------------------------------------------------*/
+export const Toolbar = Object.assign(ToolbarRoot, {
+  Root: ToolbarRoot,
+});
+
+export type Toolbar = {
+  Props: ComponentProps<typeof ToolbarRoot>;
+  RootProps: ComponentProps<typeof ToolbarRoot>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * Named Component
+ * -----------------------------------------------------------------------------------------------*/
+export {ToolbarRoot} from "./toolbar";
+
+export type {ToolbarRootProps, ToolbarRootProps as ToolbarProps} from "./toolbar";
+
+/* -------------------------------------------------------------------------------------------------
+ * Variants
+ * -----------------------------------------------------------------------------------------------*/
+export {toolbarVariants} from "@heroui/styles";
+
+export type {ToolbarVariants} from "@heroui/styles";

--- a/packages/react/src/components/toolbar/toolbar.stories.tsx
+++ b/packages/react/src/components/toolbar/toolbar.stories.tsx
@@ -1,0 +1,166 @@
+import type {Meta, StoryObj} from "@storybook/react";
+
+import {Icon} from "@iconify/react";
+import React from "react";
+
+import {Button} from "../button";
+import {ButtonGroup} from "../button-group";
+import {Separator} from "../separator";
+import {ToggleButton} from "../toggle-button";
+import {ToggleButtonGroup} from "../toggle-button-group";
+
+import {Toolbar} from "./index";
+
+const meta: Meta<typeof Toolbar> = {
+  argTypes: {
+    orientation: {
+      control: "select",
+      options: ["horizontal", "vertical"],
+    },
+  },
+  component: Toolbar,
+  parameters: {
+    layout: "centered",
+  },
+  title: "Components/Layout/Toolbar",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Toolbar>;
+
+export const Default: Story = {
+  render: () => (
+    <Toolbar aria-label="Text formatting">
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Icon icon="gravity-ui:bold" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:italic" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:underline" />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup>
+        <Button isIconOnly aria-label="Copy" variant="secondary">
+          <Icon icon="gravity-ui:copy" />
+        </Button>
+        <ButtonGroup.Separator />
+        <Button isIconOnly aria-label="Cut" variant="secondary">
+          <Icon icon="gravity-ui:scissors" />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  ),
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <Toolbar aria-label="Tools" orientation="vertical">
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Icon icon="gravity-ui:bold" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:italic" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:underline" />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup>
+        <Button isIconOnly aria-label="Undo" variant="secondary">
+          <Icon icon="gravity-ui:arrow-uturn-ccw-left" />
+        </Button>
+        <ButtonGroup.Separator />
+        <Button isIconOnly aria-label="Redo" variant="secondary">
+          <Icon icon="gravity-ui:arrow-uturn-cw-right" />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  ),
+};
+
+export const WithButtonGroup: Story = {
+  render: () => (
+    <Toolbar aria-label="Editor toolbar">
+      <ButtonGroup>
+        <Button variant="secondary">
+          <Icon icon="gravity-ui:arrow-uturn-ccw-left" />
+          Undo
+        </Button>
+        <ButtonGroup.Separator />
+        <Button variant="secondary">
+          <Icon icon="gravity-ui:arrow-uturn-cw-right" />
+          Redo
+        </Button>
+      </ButtonGroup>
+      <Separator />
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Icon icon="gravity-ui:bold" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:italic" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:underline" />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup>
+        <Button isIconOnly aria-label="Align left" variant="secondary">
+          <Icon icon="gravity-ui:text-align-left" />
+        </Button>
+        <ButtonGroup.Separator />
+        <Button isIconOnly aria-label="Align center" variant="secondary">
+          <Icon icon="gravity-ui:text-align-center" />
+        </Button>
+        <ButtonGroup.Separator />
+        <Button isIconOnly aria-label="Align right" variant="secondary">
+          <Icon icon="gravity-ui:text-align-right" />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  ),
+};
+
+export const Attached: Story = {
+  render: () => (
+    <Toolbar isAttached aria-label="Attached toolbar">
+      <ToggleButtonGroup aria-label="Text style" selectionMode="multiple">
+        <ToggleButton isIconOnly aria-label="Bold" id="bold">
+          <Icon icon="gravity-ui:bold" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Italic" id="italic">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:italic" />
+        </ToggleButton>
+        <ToggleButton isIconOnly aria-label="Underline" id="underline">
+          <ToggleButtonGroup.Separator />
+          <Icon icon="gravity-ui:underline" />
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Separator />
+      <ButtonGroup>
+        <Button isIconOnly aria-label="Copy" variant="secondary">
+          <Icon icon="gravity-ui:copy" />
+        </Button>
+        <ButtonGroup.Separator />
+        <Button isIconOnly aria-label="Cut" variant="secondary">
+          <Icon icon="gravity-ui:scissors" />
+        </Button>
+      </ButtonGroup>
+    </Toolbar>
+  ),
+};

--- a/packages/react/src/components/toolbar/toolbar.tsx
+++ b/packages/react/src/components/toolbar/toolbar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type {ToolbarVariants} from "@heroui/styles";
+import type {ComponentPropsWithRef} from "react";
+
+import {toolbarVariants} from "@heroui/styles";
+import React from "react";
+import {
+  SeparatorContext,
+  ToggleButtonGroupContext,
+  Toolbar as ToolbarPrimitive,
+} from "react-aria-components";
+
+import {composeTwRenderProps} from "../../utils";
+
+/* -------------------------------------------------------------------------------------------------
+ * Toolbar Root
+ * -----------------------------------------------------------------------------------------------*/
+interface ToolbarRootProps
+  extends ComponentPropsWithRef<typeof ToolbarPrimitive>, ToolbarVariants {}
+
+const ToolbarRoot = ({
+  children,
+  className,
+  isAttached,
+  orientation = "horizontal",
+  ...props
+}: ToolbarRootProps) => {
+  const styles = React.useMemo(
+    () => toolbarVariants({isAttached, orientation}),
+    [isAttached, orientation],
+  );
+
+  return (
+    <ToggleButtonGroupContext.Provider value={{orientation}}>
+      <SeparatorContext.Provider
+        value={{orientation: orientation === "horizontal" ? "vertical" : "horizontal"}}
+      >
+        <ToolbarPrimitive
+          className={composeTwRenderProps(className, styles)}
+          data-slot="toolbar"
+          orientation={orientation}
+          {...props}
+        >
+          {children}
+        </ToolbarPrimitive>
+      </SeparatorContext.Provider>
+    </ToggleButtonGroupContext.Provider>
+  );
+};
+
+ToolbarRoot.displayName = "HeroUI.Toolbar";
+
+/* -------------------------------------------------------------------------------------------------
+ * Exports
+ * -----------------------------------------------------------------------------------------------*/
+export {ToolbarRoot};
+export type {ToolbarRootProps};

--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -7,23 +7,50 @@
   @apply inline-flex h-auto items-center justify-center gap-0;
 }
 
+/* ==========================================================================
+   Orientation variants
+   ========================================================================== */
+
+.button-group--horizontal {
+  @apply flex-row;
+}
+
+.button-group--vertical {
+  @apply flex-col;
+}
+
 /* Remove border radius from all buttons in group */
 .button-group .button {
   @apply rounded-none;
 }
 
-/* Apply border radius to first button (left/start edge) */
-.button-group .button:first-child {
+/* Apply border radius to first button (start edge) */
+.button-group--horizontal .button:first-child {
   @apply rounded-s-3xl;
 }
 
-/* Apply border radius to last button (right/end edge) */
-.button-group .button:last-child {
+/* Apply border radius to last button (end edge) */
+.button-group--horizontal .button:last-child {
   @apply rounded-e-3xl;
 }
 
 /* If only one button, apply both rounded edges */
-.button-group .button:first-child:last-child {
+.button-group--horizontal .button:first-child:last-child {
+  @apply rounded-3xl;
+}
+
+/* Apply border radius to first button (top edge) in vertical */
+.button-group--vertical .button:first-child {
+  @apply rounded-t-3xl;
+}
+
+/* Apply border radius to last button (bottom edge) in vertical */
+.button-group--vertical .button:last-child {
+  @apply rounded-b-3xl;
+}
+
+/* If only one button in vertical, apply all rounded edges */
+.button-group--vertical .button:first-child:last-child {
   @apply rounded-3xl;
 }
 
@@ -31,6 +58,13 @@
 .button-group .button:active,
 .button-group .button[data-pressed="true"] {
   transform: none;
+}
+
+/* Override focus ring to use inset style so it stays within button bounds */
+.button-group .button:focus-visible:not(:focus),
+.button-group .button[data-focus-visible="true"] {
+  --tw-ring-offset-width: 0px;
+  @apply ring-inset;
 }
 
 /* ==========================================================================
@@ -43,10 +77,6 @@
   border-radius: 4px;
   position: absolute;
   pointer-events: none;
-  left: -1px;
-  top: 25%;
-  width: 1px;
-  height: 50%;
 
   /**
    * Transitions
@@ -54,26 +84,58 @@
    */
   transition: opacity 150ms var(--ease-smooth);
   @apply motion-reduce:transition-none;
+
+  /* Horizontal orientation - vertical divider */
+  .button-group--horizontal & {
+    left: -1px;
+    top: 25%;
+    width: 1px;
+    height: 50%;
+  }
+
+  /* Vertical orientation - horizontal divider */
+  .button-group--vertical & {
+    left: 25%;
+    top: -1px;
+    width: 50%;
+    height: 1px;
+  }
 }
 
 /* ==========================================================================
    Outline button border handling
    ========================================================================== */
 
-/* Remove adjacent borders from outline buttons in group since we have separators */
+/* Remove adjacent borders from outline buttons in horizontal group */
 /* First button: remove end border (right in LTR, left in RTL) */
-.button-group .button--outline:first-child {
+.button-group--horizontal .button--outline:first-child {
   @apply border-e-0;
 }
 
 /* Last button: remove start border (left in LTR, right in RTL) */
-.button-group .button--outline:last-child {
+.button-group--horizontal .button--outline:last-child {
   @apply border-s-0;
 }
 
 /* Middle buttons: remove both inline borders */
-.button-group .button--outline:not(:first-child):not(:last-child) {
+.button-group--horizontal .button--outline:not(:first-child):not(:last-child) {
   @apply border-x-0;
+}
+
+/* Remove adjacent borders from outline buttons in vertical group */
+/* First button: remove bottom border */
+.button-group--vertical .button--outline:first-child {
+  @apply border-b-0;
+}
+
+/* Last button: remove top border */
+.button-group--vertical .button--outline:last-child {
+  @apply border-t-0;
+}
+
+/* Middle buttons: remove both block borders */
+.button-group--vertical .button--outline:not(:first-child):not(:last-child) {
+  @apply border-y-0;
 }
 
 /* ==========================================================================

--- a/packages/styles/components/index.css
+++ b/packages/styles/components/index.css
@@ -39,6 +39,7 @@
 @import "./button-group.css";
 @import "./toggle-button.css";
 @import "./toggle-button-group.css";
+@import "./toolbar.css";
 
 /* ------------------------------------------------------------------------------------------------
  * Collections

--- a/packages/styles/components/separator.css
+++ b/packages/styles/components/separator.css
@@ -14,7 +14,7 @@
 }
 
 .separator--vertical {
-  @apply h-auto min-h-2 w-px;
+  @apply h-auto min-h-2 w-px self-stretch;
 }
 
 /* Color variants */

--- a/packages/styles/components/toolbar.css
+++ b/packages/styles/components/toolbar.css
@@ -1,0 +1,32 @@
+/* ==========================================================================
+   Toolbar - Container for interactive controls with arrow key navigation
+   ========================================================================== */
+
+/* Base styles */
+.toolbar {
+  @apply grid w-fit grid-flow-col items-center gap-2;
+
+  .separator--vertical {
+    @apply h-1/2 self-center;
+  }
+
+  .separator--horizontal {
+    @apply w-1/2 justify-center justify-self-center;
+  }
+}
+
+/* Orientation variants */
+.toolbar--horizontal {
+}
+
+.toolbar--vertical {
+  @apply grid-flow-row items-start justify-start;
+  .button-group {
+    @apply justify-start;
+  }
+}
+
+/* Attached variant */
+.toolbar--attached {
+  @apply rounded-full bg-surface p-1 shadow-overlay;
+}

--- a/packages/styles/src/components/button-group/button-group.styles.ts
+++ b/packages/styles/src/components/button-group/button-group.styles.ts
@@ -5,6 +5,7 @@ import {tv} from "tailwind-variants";
 export const buttonGroupVariants = tv({
   defaultVariants: {
     fullWidth: false,
+    orientation: "horizontal",
   },
   slots: {
     base: "button-group",
@@ -15,6 +16,14 @@ export const buttonGroupVariants = tv({
       false: {},
       true: {
         base: "button-group--full-width",
+      },
+    },
+    orientation: {
+      horizontal: {
+        base: "button-group--horizontal",
+      },
+      vertical: {
+        base: "button-group--vertical",
       },
     },
   },

--- a/packages/styles/src/components/index.ts
+++ b/packages/styles/src/components/index.ts
@@ -79,4 +79,5 @@ export * from "./time-field";
 export * from "./toast";
 export * from "./toggle-button";
 export * from "./toggle-button-group";
+export * from "./toolbar";
 export * from "./tooltip";

--- a/packages/styles/src/components/toolbar/index.ts
+++ b/packages/styles/src/components/toolbar/index.ts
@@ -1,0 +1,1 @@
+export * from "./toolbar.styles";

--- a/packages/styles/src/components/toolbar/toolbar.styles.ts
+++ b/packages/styles/src/components/toolbar/toolbar.styles.ts
@@ -1,0 +1,23 @@
+import type {VariantProps} from "tailwind-variants";
+
+import {tv} from "tailwind-variants";
+
+const toolbarVariants = tv({
+  base: "toolbar",
+  defaultVariants: {
+    isAttached: false,
+    orientation: "horizontal",
+  },
+  variants: {
+    isAttached: {
+      true: "toolbar--attached",
+    },
+    orientation: {
+      horizontal: "toolbar--horizontal",
+      vertical: "toolbar--vertical",
+    },
+  },
+});
+
+export {toolbarVariants};
+export type ToolbarVariants = VariantProps<typeof toolbarVariants>;


### PR DESCRIPTION
Closes #N/A

## 📝 Description

Introduces a new `Toolbar` component to the React package and adds full docs, stories, styles, and demos.  
Also updates related components to improve interoperability and orientation behavior.

## ⛳️ Current behavior (updates)

## 🚀 New behavior

This PR adds and updates:

- **New component**
  - `Toolbar` (React implementation, styles, exports, Storybook stories)

- **Updated related components**
  - `ButtonGroup` (layout/orientation integration updates + docs/demo additions)
  - `Separator` (adjustments for compatibility with toolbar/group usage)
  - `ToggleButtonGroup` (alignment updates for grouping behavior)

- **Docs and demos**
  - New Toolbar docs page and examples (`basic`, `vertical`, `custom-styles`, `with-button-group`)
  - Docs registry/category/index wiring updates so Toolbar appears correctly in docs navigation
  - Additional button-group docs/demo updates tied to orientation/use with toolbar patterns

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Includes style-layer updates for `toolbar.css` and supporting style exports, plus small supporting tweaks in existing component/style files to ensure consistent behavior across grouped controls.