### PR TITLE
fix(search-dialog): align docs search modal surface and selected-item contrast

### DIFF
--- a/apps/docs/src/components/search-dialog.tsx
+++ b/apps/docs/src/components/search-dialog.tsx
@@ -198,7 +198,7 @@ export default function CustomSearchDialog(props: SharedProps) {
       {...restProps}
     >
       <SearchDialogOverlay />
-      <SearchDialogContent className="border-none">
+      <SearchDialogContent className="border-none bg-surface">
         <div className="border-none px-2 pt-2">
           <TagGroup
             disallowEmptySelection
@@ -223,6 +223,7 @@ export default function CustomSearchDialog(props: SharedProps) {
           <SearchDialogClose />
         </SearchDialogHeader>
         <SearchDialogList
+          className="**:aria-selected:bg-default **:aria-selected:text-foreground"
           items={
             search.length === 0
               ? defaultSuggestions.length > 0


### PR DESCRIPTION
Closes #N/A

## 📝 Description

Updates the docs search dialog styling to better match the app surface and improve result selection visibility.

## ⛳️ Current behavior (updates)

The search dialog content used the default background, and selected list items could have lower visual contrast depending on theme.

## 🚀 New behavior

The dialog content now uses the `bg-surface` background, and selected search results explicitly apply `bg-default` and `text-foreground` styles for clearer active-state feedback.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Single-file visual adjustment in `apps/docs/src/components/search-dialog.tsx` (2 insertions, 1 deletion).