### PR TITLE
fix(avatar): inherit border-radius on fallback to respect className overrides

### DIFF
--- a/packages/styles/components/avatar.css
+++ b/packages/styles/components/avatar.css
@@ -5,7 +5,7 @@
 
 /* Avatar fallback element */
 .avatar__fallback {
-  @apply flex size-full items-center justify-center rounded-full bg-default text-sm font-medium;
+  @apply flex size-full items-center justify-center bg-default text-sm font-medium;
 }
 
 /* Avatar image element */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6193

## 📝 Description

<!--- Add a brief description -->

Fallback element should inherit the parent's border-radius so that custom `className` border-radius can override it even `color` and `variant` are set.

Reproducible Example:

- the 1st avatar is rounded-full and the 3rd one is rounded-lg. These two are correct
- the middle one is with rounded-lg + soft variant but rendered like rounded-full, which is not expected.

```tsx
<div className="flex items-start gap-4">
  <Avatar className="rounded-full" color="warning" variant="default">
    <Avatar.Fallback>1</Avatar.Fallback>
  </Avatar>

  <Avatar className="rounded-lg" color="warning" variant="soft">
    <Avatar.Fallback>2</Avatar.Fallback>
  </Avatar>

  <Avatar className="rounded-lg">
    <Avatar.Fallback>3</Avatar.Fallback>
  </Avatar>
</div>
```

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="183" height="64" alt="image" src="https://github.com/user-attachments/assets/f6e1e70d-9d12-4690-8f08-c0df146016a2" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="205" height="78" alt="image" src="https://github.com/user-attachments/assets/16791b48-794b-4ce9-84be-bae78031fb0d" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
