### PR TITLE
fix(react): add missing external deps

### DIFF
--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -48,6 +48,9 @@ const external = [
   /^react-dom($|\/)/,
   /^@react-aria/,
   /^@react-stately/,
+  /^@react-types\//,
+  /^@internationalized\//,
+  /^react-aria-components($|\/)/,
   /^tailwind-merge/,
   /^tailwind-variants/,
 ];


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6302

## 📝 Description

<!--- Add a brief description -->

When Rollup builds `@heroui/react`, it checks each import against the external list. `@internationalized/date` is only a devDependency, so it wasn't in the list. Rollup handed it to `@rollup/plugin-node-resolve`, which resolved it to the physical file in pnpm's store (`node_modules/.pnpm/@internationalized_date@3.11.0/...`). With `preserveModules: true`, that resolved path was written directly into the dist output.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

`node_modules/.pnpm` found in `dist`.

<img width="361" height="396" alt="image" src="https://github.com/user-attachments/assets/21de7101-38c7-4b97-bd4d-d23dfb783a33" />

Using the repo provided by user with production beta version (after deploying to Netlify)

<img width="964" height="825" alt="image" src="https://github.com/user-attachments/assets/c346703b-f580-41c7-b85a-c8455a6bfac2" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

`node_modules/.pnpm` not found in `dist`.

<img width="351" height="296" alt="image" src="https://github.com/user-attachments/assets/3b4d80ea-590e-4bb4-ab9a-6f43a0ac708c" />

Using the repo provided by user with PR build version (after deploying to Netlify)

<img width="246" height="193" alt="image" src="https://github.com/user-attachments/assets/75984e87-7ca9-44b6-9090-b699c451e575" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
