### PR TITLE
fix(listbox): remove duplicated press event handlers

### DIFF
--- a/.changeset/ninety-buttons-think.md
+++ b/.changeset/ninety-buttons-think.md
@@ -1,0 +1,5 @@
+---
+"@heroui/listbox": patch
+---
+
+prevent duplicated press event in listbox

--- a/packages/components/listbox/__tests__/listbox.test.tsx
+++ b/packages/components/listbox/__tests__/listbox.test.tsx
@@ -317,7 +317,7 @@ describe("Listbox", () => {
     const onPressChange = jest.fn();
 
     const {getAllByRole} = render(
-      <Listbox aria-label="Actions">
+      <Listbox aria-label="Actions" selectionMode="single">
         <ListboxItem
           key="new"
           onPress={onPress}

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -11,7 +11,7 @@ import {useFocusRing} from "@react-aria/focus";
 import {filterDOMProps} from "@heroui/react-utils";
 import {dataAttr, objectToDeps, removeEvents, mergeProps} from "@heroui/shared-utils";
 import {useOption} from "@react-aria/listbox";
-import {useHover, usePress} from "@react-aria/interactions";
+import {useHover} from "@react-aria/interactions";
 import {useIsMobile} from "@heroui/use-is-mobile";
 
 interface Props<T extends object> extends ListboxItemBaseProps<T> {
@@ -40,12 +40,6 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     className,
     classNames,
     autoFocus,
-    onPress,
-    onPressUp,
-    onPressStart,
-    onPressEnd,
-    onPressChange,
-    onClick,
     shouldHighlightOnFocus,
     hideSelectedIcon = false,
     isReadOnly = false,
@@ -67,17 +61,6 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
 
   const isMobile = useIsMobile();
 
-  const {pressProps, isPressed} = usePress({
-    ref: domRef,
-    isDisabled,
-    onClick,
-    onPress,
-    onPressUp,
-    onPressStart,
-    onPressEnd,
-    onPressChange,
-  });
-
   const {isHovered, hoverProps} = useHover({
     isDisabled,
   });
@@ -86,7 +69,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     autoFocus,
   });
 
-  const {isFocused, isSelected, optionProps, labelProps, descriptionProps} = useOption(
+  const {optionProps, labelProps, descriptionProps, isFocused, isSelected, isPressed} = useOption(
     {
       key,
       isDisabled,
@@ -137,7 +120,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     onFocusCapture: handleFocusCapture,
     ...mergeProps(
       itemProps,
-      isReadOnly ? {} : mergeProps(focusProps, pressProps),
+      isReadOnly ? {} : focusProps,
       hoverProps,
       filterDOMProps(otherProps, {
         enabled: shouldFilterDOMProps,

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -96,10 +96,6 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
 
   const baseStyles = cn(classNames?.base, className);
 
-  if (isReadOnly) {
-    itemProps = removeEvents(itemProps);
-  }
-
   const isHighlighted =
     (shouldHighlightOnFocus && isFocused) ||
     (isMobile ? isHovered || isPressed : isHovered || (isFocused && !isFocusVisible));
@@ -115,17 +111,15 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     }
   };
 
-  const getItemProps: PropGetter = (props = {}) => ({
+  const getItemProps: PropGetter = (userProps = {}) => ({
     ref: domRef,
     onFocusCapture: handleFocusCapture,
     ...mergeProps(
-      itemProps,
+      filterDOMProps(otherProps, {enabled: shouldFilterDOMProps}),
+      isReadOnly ? removeEvents(itemProps) : itemProps,
       isReadOnly ? {} : focusProps,
       hoverProps,
-      filterDOMProps(otherProps, {
-        enabled: shouldFilterDOMProps,
-      }),
-      props,
+      userProps,
     ),
     "data-selectable": dataAttr(isSelectable),
     "data-focus": dataAttr(isFocused),
@@ -134,7 +128,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     "data-selected": dataAttr(isSelected),
     "data-pressed": dataAttr(isPressed),
     "data-focus-visible": dataAttr(isFocusVisible),
-    className: slots.base({class: cn(baseStyles, props.className)}),
+    className: slots.base({class: cn(baseStyles, userProps.className)}),
   });
 
   const getLabelProps: PropGetter = (props = {}) => ({


### PR DESCRIPTION
Closes #6120 

## 📝 Description

### 1. Approach
An issue was identified where events such as onPress and onPressStart were triggered multiple times in AutocompleteItem.
To resolve this issue, the internal implementation of useListboxItem, which is used by AutocompleteItem, was refactored.
The `usePress` hook was removed, and the interaction handling was simplified to rely solely on `useOption`.

<br/>

### 2. Root cause

After analyzing the implementation, it was confirmed that `useOption` already handles interaction events internally through `useSelectableItem`. (<a href="https://github.com/heroui-inc/heroui/issues/6120#issuecomment-3904664983">related comment</a>)

<br/>

Additionally, the `isPressed` state is also exposed directly by `useOption`.

<img width="1173" height="978" alt="스크린샷 2026-03-14 오후 10 28 43" src="https://github.com/user-attachments/assets/56e332d4-33c6-4ab3-adbf-b81d457d7376" />


However, the previous implementation used both `useOption` and `usePress `simultaneously.
Because their props were merged using mergeProps, handlers for the same DOM interaction events (pointerdown, pointerup, etc.) were registered twice.

As a result, a single user interaction could trigger the event chain multiple times.

<br/>

## ⛳️ Current behavior (updates)

he previous interaction structure looked like this:
```
useOption
 + usePress
 → mergeProps(optionProps, pressProps)
```

In this structure, both hooks attach handlers to the same DOM events.

For example:
- pointerdown
- pointerup

These events were processed by both useOption and `usePress`, 
which could cause a single interaction to be executed more than once.


<br/>

## 🚀 New behavior

The interaction structure has been simplified as follows:
```
useOption
 → interaction handling
 → pressed state (isPressed)
 → selection logic
```

**Key changes**
- Removed the usePress hook
- Used the isPressed state provided by useOption
- Eliminated duplicated DOM interaction handlers

`useOption` already handles the following internally:
- pointer interactions
- keyboard interactions
- selection logic
- pressed state (isPressed)

Therefore, an additional usePress hook was not necessary.

<br/>

## 💣 Is this a breaking change (Yes/No):

Some tests were updated to reflect the correct behavior of React Aria.

`onPress` is only triggered when `selectionMode !== "none"`.  
The tests were adjusted accordingly to ensure the interaction is tested under the correct selection mode.


<br />

## Test

<details>
  <summary>test sample code</summary>

  ```js
import {Autocomplete, AutocompleteItem} from "@heroui/react";

export const animals = [
  {label: "Cat", key: "cat", description: "The second most popular pet in the world"},
  {label: "Dog", key: "dog", description: "The most popular pet in the world"},
  {label: "Elephant", key: "elephant", description: "The largest land animal"},
  {label: "Lion", key: "lion", description: "The king of the jungle"},
  {label: "Tiger", key: "tiger", description: "The largest cat species"},
  {label: "Giraffe", key: "giraffe", description: "The tallest land animal"},
  {
    label: "Dolphin",
    key: "dolphin",
    description: "A widely distributed and diverse group of aquatic mammals",
  },
  {label: "Penguin", key: "penguin", description: "A group of aquatic flightless birds"},
  {label: "Zebra", key: "zebra", description: "A several species of African equids"},
  {
    label: "Shark",
    key: "shark",
    description: "A group of elasmobranch fish characterized by a cartilaginous skeleton",
  },
  {
    label: "Whale",
    key: "whale",
    description: "Diverse group of fully aquatic placental marine mammals",
  },
  {label: "Otter", key: "otter", description: "A carnivorous mammal in the subfamily Lutrinae"},
  {label: "Crocodile", key: "crocodile", description: "A large semiaquatic reptile"},
];

export default function App() {
  function handlePress(e) {
    console.log("press type:", e.type);
  }
  function handleEvent(name) {
    console.log("event name:", name);
  }

  return (
    <div className="flex w-full flex-wrap md:flex-nowrap gap-4">
      <Autocomplete className="max-w-xs" label="Select an animal">
        {animals.map((animal) => (
          <AutocompleteItem
            key={animal.key}
            onKeyDown={() => handleEvent("onKeyDown")}
            onKeyUp={() => handleEvent("onKeyUp")}
            onPress={handlePress}
            onPressChange={() => handleEvent("onPressChange")}
            onPressEnd={() => handleEvent("onPressEnd")}
            onPressStart={() => handleEvent("onPressStart")}
            onPressUp={() => handleEvent("onPressUp")}
          >
            {animal.label}
          </AutocompleteItem>
        ))}
      </Autocomplete>
      <Autocomplete
        className="max-w-xs"
        defaultItems={animals}
        label="Favorite Animal"
        placeholder="Search an animal"
      >
        {(item) => <AutocompleteItem key={item.key}>{item.label}</AutocompleteItem>}
      </Autocomplete>
    </div>
  );
}

  ```
</details>


> Before: press event fired twice on item selection


https://github.com/user-attachments/assets/553f0029-aec2-43b3-b2a0-232910131788



<br/>

> After: press event fires once on item selection


https://github.com/user-attachments/assets/c2b655f2-874d-43f3-95fd-e56fc1009d35

