### PR TITLE
fix: remove duplicate DOM props from base wrapper element

### DIFF
--- a/.changeset/gorgeous-zebras-hope.md
+++ b/.changeset/gorgeous-zebras-hope.md
@@ -1,0 +1,6 @@
+---
+"@heroui/listbox": patch
+"@heroui/menu": patch
+---
+
+fix: remove duplicate DOM props from base wrapper element (#6306)

--- a/packages/components/listbox/src/use-listbox.ts
+++ b/packages/components/listbox/src/use-listbox.ts
@@ -11,7 +11,7 @@ import {useListBox as useAriaListbox} from "@react-aria/listbox";
 import {useProviderContext} from "@heroui/system";
 import {listbox} from "@heroui/theme";
 import {useListState} from "@react-stately/list";
-import {filterDOMProps, useDOMRef} from "@heroui/react-utils";
+import {useDOMRef} from "@heroui/react-utils";
 import {useMemo} from "react";
 import {cn} from "@heroui/theme";
 
@@ -119,11 +119,9 @@ export function useListbox<T extends object>(props: UseListboxProps<T>) {
     hideEmptyContent = false,
     shouldHighlightOnFocus = false,
     classNames,
-    ...otherProps
   } = props;
 
   const Component = as || "ul";
-  const shouldFilterDOMProps = typeof Component === "string";
 
   const domRef = useDOMRef(ref);
 
@@ -141,9 +139,6 @@ export function useListbox<T extends object>(props: UseListboxProps<T>) {
       ref: domRef,
       "data-slot": "base",
       className: slots.base({class: baseStyles}),
-      ...filterDOMProps(otherProps, {
-        enabled: shouldFilterDOMProps,
-      }),
       ...props,
     };
   };

--- a/packages/components/menu/src/use-menu.ts
+++ b/packages/components/menu/src/use-menu.ts
@@ -11,7 +11,7 @@ import {useProviderContext} from "@heroui/system";
 import {useMenu as useAriaMenu} from "@react-aria/menu";
 import {menu} from "@heroui/theme";
 import {useTreeState} from "@react-stately/tree";
-import {filterDOMProps, useDOMRef} from "@heroui/react-utils";
+import {useDOMRef} from "@heroui/react-utils";
 import {useMemo} from "react";
 import {cn} from "@heroui/theme";
 
@@ -126,7 +126,6 @@ export function useMenu<T extends object>(props: UseMenuProps<T>) {
   const Component = as || "ul";
 
   const domRef = useDOMRef(ref);
-  const shouldFilterDOMProps = typeof Component === "string";
 
   const innerState = useTreeState({...otherProps, ...userMenuProps, children});
 
@@ -142,9 +141,6 @@ export function useMenu<T extends object>(props: UseMenuProps<T>) {
       ref: domRef,
       "data-slot": "base",
       className: slots.base({class: baseStyles}),
-      ...filterDOMProps(otherProps, {
-        enabled: shouldFilterDOMProps,
-      }),
       ...props,
     };
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6306

## 📝 Description

<!--- Add a brief description -->

`filterDOMProps(otherProps)` in `getBaseProps` caused user-provided DOM attributes (e.g. data-testid) to appear on both the wrapper div and the inner list element. The list element already receives these props via React Aria's returned menuProps/listBoxProps, so the spread on the base wrapper was redundant.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
