### PR TITLE
fix(styles): add relative positioning to radio to prevent scroll jump

### DIFF
--- a/packages/styles/components/radio.css
+++ b/packages/styles/components/radio.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .radio {
-  @apply flex items-start gap-3 outline-none no-highlight;
+  @apply relative flex items-start gap-3 outline-none no-highlight;
 
   cursor: var(--cursor-interactive);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported from Discord [here](https://discord.com/channels/856545348885676062/1414957667243397182/1473900352460951779)

React Aria renders a visually hidden <input> inside an absolutely-positioned <span>. Without position: relative on the .radio element, the hidden input gets positioned relative to a distant ancestor, causing the browser to scroll when focusing it on click. Adding relative to the .radio base class contains the absolute positioning within the radio component's bounds.

Reproducible code in Electron:

```tsx
<div
    style={{
        overflowY: "scroll",
        display: "flex",
        flex: 1,
        flexDirection: "column",
    }}
>
    <div style={{ minHeight: 1000 }}></div>

    <RadioGroup orientation="horizontal">
    <Radio value="Value 1">
        <Radio.Control>
            <Radio.Indicator />
        </Radio.Control>
        <Radio.Content>
            <Label>The first value</Label>
            <Description>Click me for a bug</Description>
        </Radio.Content>
    </Radio>

    <Radio value="Value 2">
        <Radio.Control>
            <Radio.Indicator />
        </Radio.Control>
        <Radio.Content>
            <Label>The second value</Label>
            <Description>Click me for a bug</Description>
        </Radio.Content>
    </Radio>
    </RadioGroup>
</div>
```

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

[pr6317-before.webm](https://github.com/user-attachments/assets/c8935ac5-3147-445c-a7fb-6696b42fb7df)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr6317-after.webm](https://github.com/user-attachments/assets/856c6c8b-f8ae-4dfc-970d-2b8e0acf9ca9)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
