### PR TITLE
fix(button): use correct bg color token for ghost and outline variants

### DIFF
--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -115,8 +115,8 @@
 .button--ghost,
 .button--outline {
   --button-bg: transparent;
-  --button-bg-hover: var(--color-default-hover);
-  --button-bg-pressed: var(--color-default-hover);
+  --button-bg-hover: var(--color-default);
+  --button-bg-pressed: var(--color-default);
   --button-fg: var(--color-default-foreground);
 }
 


### PR DESCRIPTION
## Summary
- Updates the ghost and outline button variants to use `--color-default` instead of `--color-default-hover` for their `--button-bg-hover` and `--button-bg-pressed` CSS custom properties.

## Test plan
- [ ] Verify ghost button hover/pressed background matches the intended design token
- [ ] Verify outline button hover/pressed background matches the intended design token

Made with [Cursor](https://cursor.com)