### PR TITLE
fix(breadcrumbs): remove unexpected underline from breadcrumb links

### DIFF
--- a/packages/styles/components/breadcrumbs.css
+++ b/packages/styles/components/breadcrumbs.css
@@ -4,7 +4,12 @@
 
   /* Breadcrumb link */
   .breadcrumbs__link {
-    @apply relative px-0.5 text-sm leading-5 font-medium text-muted opacity-100;
+    @apply relative px-0.5 text-sm leading-5 font-medium text-muted no-underline opacity-100;
+
+    &:hover,
+    &[data-hovered="true"] {
+      @apply underline;
+    }
 
     &[data-current="true"] {
       @apply text-link opacity-100;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Breadcrumb items shouldn't show underline unless they are being hovered.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

By default

<img width="332" height="44" alt="image" src="https://github.com/user-attachments/assets/deec8220-1dd7-4676-b9de-db0076fa87ef" />

On hover

<img width="337" height="54" alt="image" src="https://github.com/user-attachments/assets/b541f5a1-0861-40d3-9351-bdc6ce36a7e7" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

By default

<img width="272" height="55" alt="image" src="https://github.com/user-attachments/assets/8921b418-6107-4d56-802e-0965d9c63b6d" />

On hover

<img width="295" height="63" alt="image" src="https://github.com/user-attachments/assets/b54ab49c-74d0-4e91-afe0-86e1a852f0eb" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
