### PR TITLE
docs(native): v1.0.0 stable release

### DIFF
--- a/apps/docs/content/docs/native/components/(buttons)/button.mdx
+++ b/apps/docs/content/docs/native/components/(buttons)/button.mdx
@@ -304,7 +304,7 @@ export default function ButtonExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/button.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/button.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(buttons)/close-button.mdx
+++ b/apps/docs/content/docs/native/components/(buttons)/close-button.mdx
@@ -96,7 +96,7 @@ export default function CloseButtonExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/close-button.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/close-button.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(buttons)/link-button.mdx
+++ b/apps/docs/content/docs/native/components/(buttons)/link-button.mdx
@@ -1,0 +1,165 @@
+---
+title: LinkButton
+description: A ghost-variant button with no highlight feedback, designed for inline link-style interactions.
+icon: new
+links:
+  source_native: link-button/link-button.tsx
+  styles_native: link-button/link-button.styles.ts
+  figma: true
+---
+
+<NativeVideoPlayerView
+  srcLight="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/components/videos/link-button-docs-light.mp4"
+  srcDark="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/components/videos/link-button-docs-dark.mp4"
+/>
+
+## Import
+
+```tsx
+import { LinkButton } from 'heroui-native';
+```
+
+## Anatomy
+
+```tsx
+<LinkButton>
+  <LinkButton.Label>...</LinkButton.Label>
+</LinkButton>
+```
+
+- **LinkButton**: Root pressable container. Renders a `Button` with the `ghost` variant and disabled highlight feedback enforced internally. These cannot be overridden by consumers.
+- **LinkButton.Label**: Text content of the link button. Inherits size and variant styling from the parent context.
+
+## Usage
+
+### Basic Usage
+
+The LinkButton component renders inline link-style text that responds to press events.
+
+```tsx
+<LinkButton onPress={handlePress}>Learn more</LinkButton>
+```
+
+### Sizes
+
+Control the text size with the `size` prop.
+
+```tsx
+<LinkButton size="sm">
+  Small
+</LinkButton>
+
+<LinkButton size="md">
+  Medium
+</LinkButton>
+
+<LinkButton size="lg">
+  Large
+</LinkButton>
+```
+
+### Disabled State
+
+Disable the link button to prevent interaction.
+
+```tsx
+<LinkButton isDisabled>Disabled link</LinkButton>
+```
+
+### Custom Styling
+
+Apply custom styles using the `className` prop on both root and label.
+
+```tsx
+<LinkButton className="px-2">
+  <LinkButton.Label className="text-accent underline">
+    Styled link
+  </LinkButton.Label>
+</LinkButton>
+```
+
+### Inline with Text
+
+Place link buttons inline alongside regular text for terms, policies, or contextual navigation.
+
+```tsx
+<View className="flex-row flex-wrap">
+  <Text className="text-sm text-muted">I agree to the </Text>
+  <LinkButton size="sm" onPress={handleTermsPress}>
+    <LinkButton.Label className="text-accent">
+      Terms of Service
+    </LinkButton.Label>
+  </LinkButton>
+  <Text className="text-sm text-muted"> and </Text>
+  <LinkButton size="sm" onPress={handlePrivacyPress}>
+    <LinkButton.Label className="text-accent">Privacy Policy</LinkButton.Label>
+  </LinkButton>
+</View>
+```
+
+## Example
+
+```tsx
+import { Button, Checkbox, ControlField, LinkButton } from 'heroui-native';
+import React from 'react';
+import { Alert, View } from 'react-native';
+
+export default function LinkButtonExample() {
+  const [isAgreed, setIsAgreed] = React.useState(false);
+
+  const handleTermsPress = () => Alert.alert('Terms', 'Navigate to Terms');
+  const handlePrivacyPress = () =>
+    Alert.alert('Privacy', 'Navigate to Privacy Policy');
+
+  return (
+    <View className="flex-1 px-5 items-center justify-center">
+      <View className="w-full max-w-xs gap-6">
+        <ControlField
+          isSelected={isAgreed}
+          onSelectedChange={setIsAgreed}
+          className="items-start"
+        >
+          <ControlField.Indicator>
+            <Checkbox className="mt-0.5" />
+          </ControlField.Indicator>
+          <View className="flex-row flex-wrap flex-1">
+            <Text className="text-sm text-muted">I agree to the </Text>
+            <LinkButton size="sm" onPress={handleTermsPress}>
+              <LinkButton.Label className="text-accent">
+                Terms of Service
+              </LinkButton.Label>
+            </LinkButton>
+            <Text className="text-sm text-muted"> and </Text>
+            <LinkButton size="sm" onPress={handlePrivacyPress}>
+              <LinkButton.Label className="text-accent">
+                Privacy Policy
+              </LinkButton.Label>
+            </LinkButton>
+          </View>
+        </ControlField>
+        <Button isDisabled={!isAgreed}>Sign up</Button>
+      </View>
+    </View>
+  );
+}
+```
+
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/link-button.tsx>).
+
+## API Reference
+
+### LinkButton
+
+Extends all [Button](./button#button) props except `variant` (enforced as `ghost` internally).
+
+**Behavioral overrides applied internally:**
+
+| override    | value        | description                                         |
+| ----------- | ------------ | --------------------------------------------------- |
+| `variant`   | `ghost`      | Always renders as a ghost button, cannot be changed |
+| `highlight` | `false`      | Highlight feedback is disabled, cannot be changed   |
+| `className` | `h-auto p-0` | Removes default button height and padding           |
+
+### LinkButton.Label
+
+Equivalent to [Button.Label](./button#buttonlabel). Accepts the same props.

--- a/apps/docs/content/docs/native/components/(buttons)/link-button.mdx
+++ b/apps/docs/content/docs/native/components/(buttons)/link-button.mdx
@@ -144,7 +144,7 @@ export default function LinkButtonExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/link-button.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/link-button.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(collections)/menu.mdx
+++ b/apps/docs/content/docs/native/components/(collections)/menu.mdx
@@ -403,7 +403,7 @@ export default function MenuExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/menu.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/menu.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(collections)/tag-group.mdx
+++ b/apps/docs/content/docs/native/components/(collections)/tag-group.mdx
@@ -1,7 +1,6 @@
 ---
 title: TagGroup
 description: A compound component for displaying and managing selectable tags with optional removal.
-icon: new
 links:
   source_native: tag-group/tag-group.tsx
   styles_native: tag-group/tag-group.styles.ts

--- a/apps/docs/content/docs/native/components/(collections)/tag-group.mdx
+++ b/apps/docs/content/docs/native/components/(collections)/tag-group.mdx
@@ -274,7 +274,7 @@ export default function TagGroupExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/tag-group.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/tag-group.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(controls)/slider.mdx
+++ b/apps/docs/content/docs/native/components/(controls)/slider.mdx
@@ -214,7 +214,7 @@ export default function SliderExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/slider.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/slider.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(controls)/switch.mdx
+++ b/apps/docs/content/docs/native/components/(controls)/switch.mdx
@@ -192,7 +192,7 @@ export default function SwitchExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/switch.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/switch.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(data-display)/chip.mdx
+++ b/apps/docs/content/docs/native/components/(data-display)/chip.mdx
@@ -153,7 +153,7 @@ export default function ChipExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/chip.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/chip.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(feedback)/alert.mdx
+++ b/apps/docs/content/docs/native/components/(feedback)/alert.mdx
@@ -198,7 +198,7 @@ export default function AlertExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/alert.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/alert.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(feedback)/skeleton-group.mdx
+++ b/apps/docs/content/docs/native/components/(feedback)/skeleton-group.mdx
@@ -193,7 +193,7 @@ export default function SkeletonGroupExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/skeleton-group.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/skeleton-group.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(feedback)/skeleton.mdx
+++ b/apps/docs/content/docs/native/components/(feedback)/skeleton.mdx
@@ -178,7 +178,7 @@ export default function SkeletonExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/skeleton.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/skeleton.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(feedback)/spinner.mdx
+++ b/apps/docs/content/docs/native/components/(feedback)/spinner.mdx
@@ -144,7 +144,7 @@ export default function SpinnerExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/spinner.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/spinner.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/checkbox.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/checkbox.mdx
@@ -209,7 +209,7 @@ export default function BasicUsage() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/checkbox.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/checkbox.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/control-field.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/control-field.mdx
@@ -189,7 +189,7 @@ export default function ControlFieldExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/control-field.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/control-field.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/description.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/description.mdx
@@ -121,7 +121,7 @@ export default function DescriptionExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/description.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/description.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/field-error.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/field-error.mdx
@@ -172,7 +172,7 @@ export default function FieldErrorExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/field-error.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/field-error.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/input-group.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input-group.mdx
@@ -163,7 +163,7 @@ export default function InputGroupExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/input-group.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/input-group.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/input-group.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input-group.mdx
@@ -1,7 +1,6 @@
 ---
 title: InputGroup
 description: A compound layout component that groups an input with optional prefix and suffix decorators.
-icon: new
 links:
   source_native: input-group/input-group.tsx
   styles_native: input-group/input-group.styles.ts

--- a/apps/docs/content/docs/native/components/(forms)/input-otp.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input-otp.mdx
@@ -269,7 +269,7 @@ export default function InputOTPExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/input-otp.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/input-otp.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/input-otp.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input-otp.mdx
@@ -197,6 +197,34 @@ Use render props in Group to create custom slot layouts.
 </InputOTP>
 ```
 
+### Inside a Bottom Sheet
+
+When rendering an InputOTP inside a `BottomSheet`, use the `useBottomSheetAwareHandlers` hook to wire keyboard avoidance handlers. Pass the returned `onFocus` and `onBlur` to InputOTP.
+
+```tsx
+import { InputOTP, useBottomSheetAwareHandlers } from 'heroui-native';
+
+const BottomSheetOTPInput = () => {
+  const { onFocus, onBlur } = useBottomSheetAwareHandlers();
+
+  return (
+    <InputOTP maxLength={6} onFocus={onFocus} onBlur={onBlur}>
+      <InputOTP.Group>
+        <InputOTP.Slot index={0} />
+        <InputOTP.Slot index={1} />
+        <InputOTP.Slot index={2} />
+      </InputOTP.Group>
+      <InputOTP.Separator />
+      <InputOTP.Group>
+        <InputOTP.Slot index={3} />
+        <InputOTP.Slot index={4} />
+        <InputOTP.Slot index={5} />
+      </InputOTP.Group>
+    </InputOTP>
+  );
+};
+```
+
 ## Example
 
 ```tsx

--- a/apps/docs/content/docs/native/components/(forms)/input-otp.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input-otp.mdx
@@ -1,6 +1,7 @@
 ---
 title: InputOTP
 description: Input component for entering one-time passwords (OTP) with individual character slots, animations, and validation support.
+icon: updated
 links:
   source_native: input-otp/input-otp.tsx
   styles_native: input-otp/input-otp.styles.ts

--- a/apps/docs/content/docs/native/components/(forms)/input.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input.mdx
@@ -207,7 +207,7 @@ export const TextInputContent = () => {
 };
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/input.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/input.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/input.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input.mdx
@@ -1,6 +1,7 @@
 ---
 title: Input
 description: A text input component with styled border and background for collecting user input.
+icon: updated
 links:
   source_native: input/input.tsx
   styles_native: input/input.styles.ts

--- a/apps/docs/content/docs/native/components/(forms)/input.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/input.mdx
@@ -118,6 +118,28 @@ import { Input, Label, TextField } from 'heroui-native';
 </TextField>;
 ```
 
+### Inside a Bottom Sheet
+
+When rendering an Input inside a `BottomSheet`, use the `useBottomSheetAwareHandlers` hook to wire keyboard avoidance handlers. Pass the returned `onFocus` and `onBlur` to the Input.
+
+```tsx
+import { Input, TextField, useBottomSheetAwareHandlers } from 'heroui-native';
+
+const BottomSheetTextInput = () => {
+  const { onFocus, onBlur } = useBottomSheetAwareHandlers();
+
+  return (
+    <TextField>
+      <Input
+        placeholder="Type here..."
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    </TextField>
+  );
+};
+```
+
 ## Example
 
 ```tsx

--- a/apps/docs/content/docs/native/components/(forms)/label.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/label.mdx
@@ -155,7 +155,7 @@ export default function LabelExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/label.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/label.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/radio-group.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/radio-group.mdx
@@ -203,7 +203,7 @@ export default function RadioGroupExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/radio-group.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/radio-group.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/search-field.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/search-field.mdx
@@ -147,7 +147,7 @@ export default function SearchFieldExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/search-field.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/search-field.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/select.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/select.mdx
@@ -418,7 +418,7 @@ export default function SelectExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/select.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/select.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/text-area.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/text-area.mdx
@@ -133,7 +133,7 @@ export default function TextAreaExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/text-area.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/text-area.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(forms)/text-field.mdx
+++ b/apps/docs/content/docs/native/components/(forms)/text-field.mdx
@@ -216,7 +216,7 @@ export const TextInputContent = () => {
 };
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/text-field.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/text-field.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(layout)/card.mdx
+++ b/apps/docs/content/docs/native/components/(layout)/card.mdx
@@ -141,7 +141,7 @@ export default function CardExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/card.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/card.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(layout)/separator.mdx
+++ b/apps/docs/content/docs/native/components/(layout)/separator.mdx
@@ -101,7 +101,7 @@ export default function SeparatorExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/separator.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/separator.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(layout)/surface.mdx
+++ b/apps/docs/content/docs/native/components/(layout)/surface.mdx
@@ -131,7 +131,7 @@ export default function SurfaceExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/surface.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/surface.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(media)/avatar.mdx
+++ b/apps/docs/content/docs/native/components/(media)/avatar.mdx
@@ -257,7 +257,7 @@ export default function AvatarExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/avatar.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/avatar.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(navigation)/accordion.mdx
+++ b/apps/docs/content/docs/native/components/(navigation)/accordion.mdx
@@ -253,7 +253,7 @@ export default function AccordionExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/accordion.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/accordion.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(navigation)/list-group.mdx
+++ b/apps/docs/content/docs/native/components/(navigation)/list-group.mdx
@@ -327,7 +327,7 @@ export default function ListGroupExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/list-group.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/list-group.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(navigation)/tabs.mdx
+++ b/apps/docs/content/docs/native/components/(navigation)/tabs.mdx
@@ -364,7 +364,7 @@ export default function TabsExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/tabs.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/tabs.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(overlays)/bottom-sheet.mdx
+++ b/apps/docs/content/docs/native/components/(overlays)/bottom-sheet.mdx
@@ -200,7 +200,7 @@ export default function BottomSheetExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/bottom-sheet.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/bottom-sheet.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(overlays)/dialog.mdx
+++ b/apps/docs/content/docs/native/components/(overlays)/dialog.mdx
@@ -145,7 +145,7 @@ export default function DialogExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/dialog.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/dialog.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(overlays)/popover.mdx
+++ b/apps/docs/content/docs/native/components/(overlays)/popover.mdx
@@ -300,7 +300,7 @@ export default function PopoverExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/popover.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/popover.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(overlays)/toast.mdx
+++ b/apps/docs/content/docs/native/components/(overlays)/toast.mdx
@@ -166,7 +166,7 @@ export default function ToastExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/toast.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/toast.tsx>).
 
 ## Global Configuration
 

--- a/apps/docs/content/docs/native/components/(utilities)/pressable-feedback.mdx
+++ b/apps/docs/content/docs/native/components/(utilities)/pressable-feedback.mdx
@@ -209,7 +209,7 @@ export default function PressableFeedbackExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/pressable-feedback.tsx>).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/pressable-feedback.tsx>).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/(utilities)/scroll-shadow.mdx
+++ b/apps/docs/content/docs/native/components/(utilities)/scroll-shadow.mdx
@@ -166,7 +166,7 @@ export default function ScrollShadowExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/scroll-shadow.tsx).
+You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/scroll-shadow.tsx).
 
 ## API Reference
 

--- a/apps/docs/content/docs/native/components/meta.json
+++ b/apps/docs/content/docs/native/components/meta.json
@@ -23,6 +23,7 @@
     "(forms)/input-group",
     "(forms)/input-otp",
     "(forms)/label",
+    "(buttons)/link-button",
     "(navigation)/list-group",
     "(collections)/menu",
     "(overlays)/popover",

--- a/apps/docs/content/docs/native/getting-started/(handbook)/colors.mdx
+++ b/apps/docs/content/docs/native/getting-started/(handbook)/colors.mdx
@@ -143,7 +143,7 @@ import { Button } from 'heroui-native';
 
 ## Default Theme
 
-The complete theme definition can be found in ([variables.css](https://github.com/heroui-inc/heroui-native/blob/rc/src/styles/variables.css)). This theme automatically switches between light and dark modes through [Uniwind's theming system](https://docs.uniwind.dev/theming/basics), which supports system preferences and programmatic theme switching.
+The complete theme definition can be found in ([variables.css](https://github.com/heroui-inc/heroui-native/blob/main/src/styles/variables.css)). This theme automatically switches between light and dark modes through [Uniwind's theming system](https://docs.uniwind.dev/theming/basics), which supports system preferences and programmatic theme switching.
 
 <CollapsibleCode lang="css" code={`  @theme {
     /* Primitive Colors (Do not change between light and dark) */

--- a/apps/docs/content/docs/native/getting-started/(handbook)/theming.mdx
+++ b/apps/docs/content/docs/native/getting-started/(handbook)/theming.mdx
@@ -339,11 +339,11 @@ HeroUI defines three types of variables:
 2. **Theme Variables** — Colors that change between light/dark themes
 3. **Calculated Variables** — Automatically generated hover (pressed) states and size variants
 
-For a complete reference, see: [Colors Documentation](/docs/native/getting-started/colors), [Default Theme Variables](https://github.com/heroui-inc/heroui-native/blob/rc/src/styles/variables.css), [Shared Theme Utilities](https://github.com/heroui-inc/heroui-native/blob/rc/src/styles/theme.css)
+For a complete reference, see: [Colors Documentation](/docs/native/getting-started/colors), [Default Theme Variables](https://github.com/heroui-inc/heroui-native/blob/main/src/styles/variables.css), [Shared Theme Utilities](https://github.com/heroui-inc/heroui-native/blob/main/src/styles/theme.css)
 
 **Calculated variables (Tailwind):**
 
-We use Tailwind's `@theme` directive to automatically create calculated variables for hover (pressed) states and radius variants. These are defined in [theme.css](https://github.com/heroui-inc/heroui-native/blob/rc/src/styles/theme.css):
+We use Tailwind's `@theme` directive to automatically create calculated variables for hover (pressed) states and radius variants. These are defined in [theme.css](https://github.com/heroui-inc/heroui-native/blob/main/src/styles/theme.css):
 <CollapsibleCode lang="css" code={`  @theme inline static {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/apps/docs/content/docs/native/getting-started/(overview)/quick-start.mdx
+++ b/apps/docs/content/docs/native/getting-started/(overview)/quick-start.mdx
@@ -36,22 +36,22 @@ icon: rocket
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tab value="npm">
     ```bash
-    npm install react-native-screens@^4.16.0 react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0 @gorhom/bottom-sheet@^5.2.8
+    npm install react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm add react-native-screens@^4.16.0 react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0 @gorhom/bottom-sheet@^5.2.8
+    pnpm add react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0
     ```
   </Tab>
   <Tab value="yarn">
     ```bash
-    yarn add react-native-screens@^4.16.0 react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0 @gorhom/bottom-sheet@^5.2.8
+    yarn add react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0
     ```
   </Tab>
   <Tab value="bun">
     ```bash
-    bun add react-native-screens@^4.16.0 react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0 @gorhom/bottom-sheet@^5.2.8
+    bun add react-native-reanimated@^4.1.1 react-native-gesture-handler@^2.28.0 react-native-worklets@^0.5.1 react-native-safe-area-context@^5.6.0 react-native-svg@^15.12.1 tailwind-variants@^3.2.2 tailwind-merge@^3.4.0
     ```
   </Tab>
 </Tabs>
@@ -60,13 +60,22 @@ icon: rocket
   It's recommended to use the exact versions specified above to avoid compatibility issues. Version mismatches may cause unexpected bugs.
 </Callout>
 
-### 3. Set Up Uniwind
+### 3. Optional Dependencies
+
+These packages are only needed if you use specific components or features:
+
+| Package | Version | Required for |
+| --- | --- | --- |
+| `react-native-screens` | `^4.16.0` | BottomSheet, Dialog, Menu, Popover, Select, Toast |
+| `@gorhom/bottom-sheet` | `^5.2.8` | BottomSheet, Menu / Popover / Select when `presentation="bottom-sheet"` |
+
+### 4. Set Up Uniwind
 
 Follow the [Uniwind installation guide](https://docs.uniwind.dev/quickstart) to set up Tailwind CSS for React Native.
 
 If you're migrating from NativeWind, see the [migration guide](https://docs.uniwind.dev/migration-from-nativewind).
 
-### 4. Configure global.css
+### 5. Configure global.css
 
 Inside your `global.css` file add the following imports:
 
@@ -85,7 +94,7 @@ Inside your `global.css` file add the following imports:
 @source './node_modules/heroui-native/lib';
 ```
 
-### 5. Wrap Your App with Provider
+### 6. Wrap Your App with Provider
 
 Wrap your application with `HeroUINativeProvider`. You must wrap it with `GestureHandlerRootView`:
 
@@ -104,7 +113,7 @@ export default function App() {
 
 > **Note**: For advanced configuration options including text props, animation settings, and toast configuration, see the [Provider documentation](/docs/native/getting-started/provider).
 
-### 6. Use Your First Component
+### 7. Use Your First Component
 
 ```tsx
 import { Button } from 'heroui-native';
@@ -119,7 +128,7 @@ export default function MyComponent() {
 }
 ```
 
-### 7. Reduce Bundle Size with Granular Exports
+### 8. Reduce Bundle Size with Granular Exports
 
 If you want to reduce bundle size and import only the components you need, our library provides granular exports for each component:
 
@@ -149,7 +158,7 @@ Granular imports are ideal when you only need a few components, as they help kee
   **Important**: To keep the bundle size under control, you must follow the pattern with granular imports consistently. Even one general import from `heroui-native` will break this optimization strategy.
 </Callout>
 
-> **Tip**: For even more control over your bundle, consider using [`HeroUINativeProviderRaw`](/docs/native/getting-started/provider#raw-provider) — a lightweight provider that excludes `ToastProvider` and `PortalHost`, making dependencies like `react-native-screens`, `@gorhom/bottom-sheet`, and `react-native-svg` fully optional.
+> **Tip**: For even more control over your bundle, consider using [`HeroUINativeProviderRaw`](/docs/native/getting-started/provider#raw-provider) — a lightweight provider that excludes `ToastProvider` and `PortalHost`.
 
 ## What's Next?
 

--- a/apps/docs/content/docs/native/getting-started/index.mdx
+++ b/apps/docs/content/docs/native/getting-started/index.mdx
@@ -5,7 +5,7 @@ icon: book-open
 image: https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light.jpg
 ---
 
-HeroUI Native is a component library built on [Tailwind v4](https://tailwindcss.com/blog/tailwindcss-v4) via [Uniwind](https://uniwind.dev/) and modern mobile development technologies. Every component comes with smooth animations, polished details, and built-in accessibility—ready to use, fully customizable.
+HeroUI Native is a React Native component library built on [Tailwind v4](https://tailwindcss.com/blog/tailwindcss-v4) via [Uniwind](https://uniwind.dev/) and modern mobile development technologies. Every component comes with smooth animations, polished details, and built-in accessibility—ready to use, fully customizable.
 
 <NativeImageHeroView />
 
@@ -51,7 +51,7 @@ HeroUI Native is not a snapshot—it's a garden that keeps growing. 🌱
 Yes, completely free and open source under the MIT license.
 
 **Is it production-ready?**
-Currently in **beta**. We're actively working towards a stable release with community feedback.
+Yes, HeroUI Native is production-ready and actively used in production apps.
 
 **Can I customize the components?**
 Yes! Update default styles, animations or compose component parts differently. Every slot is customizable.

--- a/apps/docs/content/docs/native/releases/index.mdx
+++ b/apps/docs/content/docs/native/releases/index.mdx
@@ -9,6 +9,16 @@ description: All updates and changes to HeroUI Native, including new features, f
 
 ## Latest Release
 
+### v1.0.0
+
+**March 2026**
+
+🎉 HeroUI Native reaches its first stable release, graduating from beta and release candidate stages. This milestone includes the new LinkButton component, sub-menu conflict resolution, an optional `@gorhom/bottom-sheet` peer dependency, and improved type safety for `useThemeColor`.
+
+[Read full release notes →](/docs/native/releases/v1-0-0)
+
+---
+
 ### RC 4
 
 **March 2026**
@@ -93,8 +103,8 @@ This release introduces the new [Bottom Sheet](/docs/native/components/bottom-sh
 
 HeroUI Native follows a regular release cycle:
 
-- **Release candidates**: Final stabilization before stable release - In progress
-- **Stable releases**: Quarterly major versions (Q1 2026 target)
+- **Stable releases**: v1.0.0 shipped Q1 2026
+- **Patch releases**: Bug fixes and minor improvements as needed
 
 ## Contributing
 

--- a/apps/docs/content/docs/native/releases/meta.json
+++ b/apps/docs/content/docs/native/releases/meta.json
@@ -7,6 +7,7 @@
     "---Overview---",
     "index",
     "---Releases---",
+    "v1-0-0",
     "rc-4",
     "rc-3",
     "rc-2",

--- a/apps/docs/content/docs/native/releases/v1-0-0.mdx
+++ b/apps/docs/content/docs/native/releases/v1-0-0.mdx
@@ -1,0 +1,224 @@
+---
+title: v1.0.0
+description: LinkButton component, sub-menu conflict resolution, optional @gorhom/bottom-sheet, ThemeColorValue branded type
+github:
+  pull: 347
+---
+
+<div className="flex items-center gap-3 mb-6">
+  <span className="text-sm text-muted">March 19, 2026</span>
+</div>
+
+🎉 HeroUI Native reaches v1.0.0 — the first stable release, marking the library's graduation from beta and release candidate stages into a production-ready foundation for React Native apps. Alongside this milestone, the release includes the new LinkButton component, sub-menu conflict resolution, an optional `@gorhom/bottom-sheet` peer dependency, and improved type safety for `useThemeColor`.
+
+## Installation
+
+Update to the latest version:
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+<Tab value="npm">
+  ```bash
+  npm i heroui-native
+  ```
+</Tab>
+<Tab value="pnpm">
+  ``` bash
+  pnpm add heroui-native
+  ```
+</Tab>
+<Tab value="yarn">
+  ```bash
+  yarn add heroui-native
+  ```
+</Tab>
+<Tab value="bun">
+  ```bash
+  bun add heroui-native
+  ```
+</Tab>
+</Tabs>
+
+<Callout type="info">
+  **Using AI assistants?** Simply prompt "Hey Cursor, update HeroUI Native to the latest version" and your AI assistant will automatically compare versions and apply the necessary changes. Learn more about the [HeroUI Native MCP Server](/docs/native/getting-started/mcp-server).
+</Callout>
+
+## Try It Out
+
+Experience all the v1.0.0 improvements in action with our preview app! You can explore the new LinkButton component, improved sub-menu behavior, and all the fixes directly on your device.
+
+### Prerequisites
+
+Make sure you have the latest version of [Expo Go](https://expo.dev/go) installed on your mobile device.
+
+### How to Access
+
+**Option 1: Scan the QR Code**
+
+Use your device's camera or Expo Go app to scan:
+
+<div className="flex justify-center my-6">
+  <img
+    width="200"
+    src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/images/qr-code-native.png"
+    alt="Expo Go QR Code"
+  />
+</div>
+
+> **Note for Android users:** If scanning the QR code with your device's camera or other scanner apps redirects to a browser and shows a 404 error, open Expo Go first and use its built-in QR scanner instead.
+
+**Option 2: Click the Link**
+
+**[📱 Open Demo App in Expo Go](https://link.heroui.com/native-demo)**
+
+This will automatically open the app in Expo Go if it's installed on your device.
+
+## What's New
+
+### LinkButton Component
+
+The new [LinkButton](/docs/native/components/button) compound component renders a ghost-variant button with no highlight feedback, designed for inline link-style interactions such as "Terms of Service" or "Privacy Policy" links. It delegates entirely to the existing Button infrastructure while enforcing ghost variant and disabled highlight internally.
+
+<NativeVideoPlayerView
+  srcLight="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/components/videos/link-button-docs-light.mp4"
+  srcDark="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/components/videos/link-button-docs-dark.mp4"
+/>
+
+**Features:**
+
+- Compound sub-component: `LinkButton.Label` for styled text content
+- Ghost variant enforced internally — no `variant` prop exposed
+- Highlight feedback disabled by default via `resolveAnimationObject`
+- `h-auto p-0` base class removes default button height and padding for inline use
+- Consumer animation config merged while preserving `highlight: false`
+
+**Usage:**
+
+```tsx
+import { LinkButton } from "heroui-native";
+
+export function TermsLink() {
+  return (
+    <LinkButton onPress={() => openURL("https://example.com/terms")}>
+      <LinkButton.Label>Terms of Service</LinkButton.Label>
+    </LinkButton>
+  );
+}
+```
+
+**Related PR:** [#341](https://github.com/heroui-inc/heroui-native/pull/341)
+
+## Component Improvements
+
+### Sub-Menu Single-Open Enforcement and Backdrop Close
+
+The [Menu](/docs/native/components/menu) sub-menu system has been refactored to track the active sub-menu by ID instead of a simple boolean, enforcing single-open behavior across sibling sub-menus. A backdrop pressable overlay now renders over the menu content area when a sub-menu is open, allowing users to dismiss it by tapping outside.
+
+**Improvements:**
+
+- `openSubMenuId` replaces the boolean flag — only one sub-menu can be active at a time; opening a new one automatically closes the previous
+- A `Pressable` overlay renders over the menu content when a sub-menu is open, allowing tap-to-dismiss
+- Non-active sub-menu triggers receive `opacity-40` and `pointer-events-none` via the new `isOtherSubMenuOpen` style variant
+- Open sub-menu content uses `z-50`; closed uses `z-40` to avoid stacking issues
+- New "Two Sub Menus" example added to the demo app showcasing multiple sub-menus in a single menu
+
+**Related PR:** [#343](https://github.com/heroui-inc/heroui-native/pull/343)
+
+### Button Label Ref Type Fix
+
+The `ButtonLabel` ref type has been corrected from `View` to `TextRef`, and an unused `View` import has been removed from `button.tsx`. This fix aligns the ref type with the actual rendered element.
+
+**Related PR:** [#341](https://github.com/heroui-inc/heroui-native/pull/341)
+
+## API Enhancements
+
+### `ThemeColorValue` Branded Type for `useThemeColor`
+
+The `useThemeColor` hook now returns a `ThemeColorValue` branded type for single-color calls, making misuse of array destructuring immediately visible as a `never` type in the IDE. The non-null assertion operator (`!`) has also been replaced with a safe nullish coalescing fallback.
+
+**New behavior:**
+
+```tsx
+import { useThemeColor } from "heroui-native";
+
+// Correct — direct assignment
+const mutedColor = useThemeColor("muted");
+
+// Incorrect — IDE immediately surfaces `never` type
+const [color] = useThemeColor("muted"); // color: never
+```
+
+`ThemeColorValue` extends `string`, so it is assignable everywhere a `string` is expected. Existing call sites are unaffected at runtime. The `_colorValueBrand` symbol is declared with `declare const` so it has zero runtime footprint.
+
+**Related PR:** [#337](https://github.com/heroui-inc/heroui-native/pull/337)
+
+### `useBottomSheetAwareHandlers` Public Hook
+
+The `useBottomSheetAwareHandlers` hook is now exported as a public API, giving consumers explicit control over keyboard avoidance wiring inside bottom sheets. This replaces the implicit `isBottomSheetAware` prop that was previously available on `Input` and `InputOTP`.
+
+**Usage:**
+
+```tsx
+import { useBottomSheetAwareHandlers, Input } from "heroui-native";
+
+export function BottomSheetInput() {
+  const { onFocus, onBlur } = useBottomSheetAwareHandlers();
+
+  return <Input onFocus={onFocus} onBlur={onBlur} placeholder="Type here..." />;
+}
+```
+
+**Related PR:** [#347](https://github.com/heroui-inc/heroui-native/pull/347)
+
+## ⚠️ Breaking Changes
+
+### `Input` and `InputOTP` Inside Bottom Sheet
+
+The `isBottomSheetAware` prop has been removed from `Input` and `InputOTP`. Previously, keyboard avoidance inside bottom sheets was handled automatically under the hood. Now you must explicitly use the `useBottomSheetAwareHandlers` hook and pass the handlers yourself. This change keeps the Input component lighter by removing the implicit `@gorhom/bottom-sheet` import, allowing the package to be an optional peer dependency for projects that don't use bottom sheet features.
+
+**Migration:**
+
+```tsx
+// Before
+<Input isBottomSheetAware placeholder="Type here..." />
+
+// After
+import { useBottomSheetAwareHandlers } from "heroui-native";
+
+const { onFocus, onBlur } = useBottomSheetAwareHandlers();
+<Input onFocus={onFocus} onBlur={onBlur} placeholder="Type here..." />
+```
+
+This applies to any `Input` or `InputOTP` rendered inside a `BottomSheet`. Components used outside of bottom sheets are unaffected.
+
+**Related PR:** [#347](https://github.com/heroui-inc/heroui-native/pull/347)
+
+## Bug Fixes
+
+This release includes fixes for the following issues:
+
+- **[Issue #330](https://github.com/heroui-inc/heroui-native/issues/330)**: Resolved `Input` unconditionally importing `@gorhom/bottom-sheet` at the module level even when `isBottomSheetAware` was `false`. The package is now loaded lazily via an optional `try/catch` wrapper, so projects that don't use bottom sheet features no longer need it installed.
+
+- **[Issue #340](https://github.com/heroui-inc/heroui-native/issues/340)**: Fixed sub-menu content appearing behind sibling sub-menu triggers. The sub-menu system now tracks the active sub-menu by ID, enforces single-open behavior, and applies correct z-index layering (`z-50` for open, `z-40` for closed).
+
+**Related PRs:**
+
+- [#347](https://github.com/heroui-inc/heroui-native/pull/347)
+- [#343](https://github.com/heroui-inc/heroui-native/pull/343)
+
+## Updated Documentation
+
+The following documentation pages have been updated to reflect the changes in this release:
+
+- [LinkButton](/docs/native/components/link-button) - LinkButton compound component documentation with anatomy, usage examples, and API reference
+- [Menu](/docs/native/components/menu) - Updated sub-menu documentation with single-open enforcement and backdrop close behavior
+- [Input](/docs/native/components/input) - Updated bottom sheet usage examples with `useBottomSheetAwareHandlers` hook pattern
+- [InputOTP](/docs/native/components/input-otp) - Updated bottom sheet usage examples with `useBottomSheetAwareHandlers` hook pattern
+
+## Links
+
+- [Component Documentation](../components)
+- [GitHub Repository](https://github.com/heroui-inc/heroui-native)
+
+## Contributors
+
+Thanks to everyone who contributed to this release!

--- a/apps/docs/src/components/native-components-category.tsx
+++ b/apps/docs/src/components/native-components-category.tsx
@@ -10,7 +10,7 @@ import {NativeComponentItem} from "./native-component-item";
 const COMPONENT_GROUPS = [
   {
     category: "Buttons",
-    components: ["(buttons)/button", "(buttons)/close-button"],
+    components: ["(buttons)/button", "(buttons)/close-button", "(buttons)/link-button"],
   },
   {
     category: "Collections",


### PR DESCRIPTION
## 📝 Description

Adds comprehensive v1.0.0 release documentation for HeroUI Native, including the new LinkButton component docs, updated quick-start guide with optional dependencies, and migration of all GitHub repository links from the `rc` branch to `main`. This batch of documentation changes reflects the library's graduation from beta/RC to a stable production-ready release.

## ⛳️ Current behavior (updates)

All component documentation links point to the `rc` branch on GitHub, the getting-started index describes the library as beta, and there is no documentation for the LinkButton component or the v1.0.0 release.

## 🚀 New behavior

- New `v1-0-0.mdx` release note covering LinkButton, sub-menu fixes, optional `@gorhom/bottom-sheet`, `ThemeColorValue` branded type, `useBottomSheetAwareHandlers` hook, and breaking changes
- New `link-button.mdx` component documentation with anatomy, usage examples, and API reference
- All 30+ component docs updated: GitHub links now reference `main` instead of `rc`
- Quick-start guide restructured: `react-native-screens` and `@gorhom/bottom-sheet` moved to a new "Optional Dependencies" table
- Input and InputOTP docs updated with "Inside a Bottom Sheet" sections using `useBottomSheetAwareHandlers`
- Getting-started index updated to mark the library as production-ready (no longer beta)
- Removed `icon: new` from TagGroup and InputGroup; added `icon: updated` to Input and InputOTP
- LinkButton added to `meta.json` and `native-components-category.tsx`
- Release schedule updated from "RC in progress" to "v1.0.0 shipped Q1 2026"

## 💣 Is this a breaking change (Yes/No):

**No** - These are documentation-only changes with no impact on library code or APIs.

## 📝 Additional Information

All changes are scoped to `apps/docs/content/docs/native/` and one component in `apps/docs/src/components/`. No library source code, tests, or build configuration is affected. The 47 modified files are predominantly single-line link updates from `rc` to `main`.