### PR TITLE
fix(tag): override CloseButton aria-label in Tag with better value

### DIFF
--- a/packages/react/src/components/tag/tag.tsx
+++ b/packages/react/src/components/tag/tag.tsx
@@ -95,6 +95,7 @@ const TagRemoveButton = ({children, className, ...restProps}: TagRemoveButtonPro
 
   return (
     <CloseButton
+      aria-label="Remove tag"
       className={composeTwRenderProps(className, slots?.removeButton())}
       data-slot="tag-remove-button"
       slot="remove"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Reported from Discord [here](https://discord.com/channels/856545348885676062/1485129634604650546). `Tag` component is using `CloseButton` component for removing tags. In `CloseButton`, the default `aria-label` is `Close` which is not accurate in Tag scenario. `data-slot` and `slot` have been overrode already. This PR is to update `aria-label` with better value.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

```
aria-label="Close"
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

```
aria-label="Remove tag"
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
