### PR TITLE
fix(button-group): correct radius selectors for extended buttons

### DIFF
--- a/.changeset/kind-bees-flow.md
+++ b/.changeset/kind-bees-flow.md
@@ -1,0 +1,5 @@
+---
+"@heroui/styles": patch
+---
+
+Fix ButtonGroup radius selectors to support custom buttons created with extendVariants.

--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -19,50 +19,50 @@
   @apply flex-col;
 }
 
-/* Remove border radius from all buttons in group */
-.button-group .button {
+/* Remove border radius from direct button children in group */
+.button-group > [data-slot="button"] {
   @apply rounded-none;
 }
 
 /* Apply border radius to first button (start edge) */
-.button-group--horizontal .button:first-child {
+.button-group--horizontal > [data-slot="button"]:first-child {
   @apply rounded-s-3xl;
 }
 
 /* Apply border radius to last button (end edge) */
-.button-group--horizontal .button:last-child {
+.button-group--horizontal > [data-slot="button"]:last-child {
   @apply rounded-e-3xl;
 }
 
 /* If only one button, apply both rounded edges */
-.button-group--horizontal .button:first-child:last-child {
+.button-group--horizontal > [data-slot="button"]:first-child:last-child {
   @apply rounded-3xl;
 }
 
 /* Apply border radius to first button (top edge) in vertical */
-.button-group--vertical .button:first-child {
+.button-group--vertical > [data-slot="button"]:first-child {
   @apply rounded-t-3xl;
 }
 
 /* Apply border radius to last button (bottom edge) in vertical */
-.button-group--vertical .button:last-child {
+.button-group--vertical > [data-slot="button"]:last-child {
   @apply rounded-b-3xl;
 }
 
 /* If only one button in vertical, apply all rounded edges */
-.button-group--vertical .button:first-child:last-child {
+.button-group--vertical > [data-slot="button"]:first-child:last-child {
   @apply rounded-3xl;
 }
 
 /* Remove scale transform on active/pressed state for buttons in group */
-.button-group .button:active,
-.button-group .button[data-pressed="true"] {
+.button-group > [data-slot="button"]:active,
+.button-group > [data-slot="button"][data-pressed="true"] {
   transform: none;
 }
 
 /* Override focus ring to use inset style so it stays within button bounds */
-.button-group .button:focus-visible:not(:focus),
-.button-group .button[data-focus-visible="true"] {
+.button-group > [data-slot="button"]:focus-visible:not(:focus),
+.button-group > [data-slot="button"][data-focus-visible="true"] {
   --tw-ring-offset-width: 0px;
   @apply ring-inset;
 }
@@ -108,33 +108,34 @@
 
 /* Remove adjacent borders from outline buttons in horizontal group */
 /* First button: remove end border (right in LTR, left in RTL) */
-.button-group--horizontal .button--outline:first-child {
+.button-group--horizontal > [data-slot="button"].button--outline:first-child {
   @apply border-e-0;
 }
 
 /* Last button: remove start border (left in LTR, right in RTL) */
-.button-group--horizontal .button--outline:last-child {
+.button-group--horizontal > [data-slot="button"].button--outline:last-child {
   @apply border-s-0;
 }
 
 /* Middle buttons: remove both inline borders */
-.button-group--horizontal .button--outline:not(:first-child):not(:last-child) {
+.button-group--horizontal
+  > [data-slot="button"].button--outline:not(:first-child):not(:last-child) {
   @apply border-x-0;
 }
 
 /* Remove adjacent borders from outline buttons in vertical group */
 /* First button: remove bottom border */
-.button-group--vertical .button--outline:first-child {
+.button-group--vertical > [data-slot="button"].button--outline:first-child {
   @apply border-b-0;
 }
 
 /* Last button: remove top border */
-.button-group--vertical .button--outline:last-child {
+.button-group--vertical > [data-slot="button"].button--outline:last-child {
   @apply border-t-0;
 }
 
 /* Middle buttons: remove both block borders */
-.button-group--vertical .button--outline:not(:first-child):not(:last-child) {
+.button-group--vertical > [data-slot="button"].button--outline:not(:first-child):not(:last-child) {
   @apply border-y-0;
 }
 


### PR DESCRIPTION
## Summary
- update `ButtonGroup` CSS to target direct child buttons via `[data-slot=button]` instead of relying on the `.button` class
- preserve first/last/only radius behavior for horizontal and vertical groups when using custom buttons (e.g. `extendVariants(Button, ...)`)
- align outline border-merging selectors with the same direct-child targeting to keep group visuals consistent

## Test plan
- [x] Run `pnpm build --filter=@heroui/styles`
- [x] Run `pnpm test packages/styles`
- [x] Verify branch diff only changes `packages/styles/components/button-group.css`
- [ ] Manually verify in docs/storybook that `ButtonGroup` + custom extended button rounds outer corners and squares inner corners

Closes #6260.