### PR TITLE
fix(styles): input-group secondary variant focus bg not overriding base

### DIFF
--- a/packages/styles/components/input-group.css
+++ b/packages/styles/components/input-group.css
@@ -149,8 +149,8 @@
     }
   }
 
-  &:focus-within,
-  &[data-focus-within="true"] {
+  &:has([data-slot="input-group-input"]:focus),
+  &:has([data-slot="input-group-textarea"]:focus) {
     background-color: var(--input-group-bg-focus);
   }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported by Discord user [here](https://discord.com/channels/856545348885676062/1469698114561769605/1486893926693736649)

- Fixed a CSS specificity issue where the `.input-group--secondary` focus background color could not override the base `.input-group` focus background color
- The base focus rule uses `:has([data-slot="input-group-input"]:focus)` (specificity 0,3,0), while the secondary variant used `:focus-within` (specificity 0,2,0), causing the base to always win
- Updated the secondary variant to use the same `:has()` selector pattern, matching the base specificity and allowing source order to correctly resolve the override

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="230" height="146" alt="image" src="https://github.com/user-attachments/assets/46dcdd57-0fa4-48d3-83f8-8e2cb10045bd" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="238" height="153" alt="image" src="https://github.com/user-attachments/assets/3c8cdb06-a132-4d1b-addd-edb3a947a719" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
