### PR TITLE
fix(docs): copy full code content when code block is collapsed

### DIFF
--- a/apps/docs/src/components/codeblock-client.tsx
+++ b/apps/docs/src/components/codeblock-client.tsx
@@ -11,6 +11,7 @@ import {cn} from "@/utils/cn";
 export function CodeBlock({
   children,
   className,
+  code,
   collapsible,
   isIsolated = false,
   preview,
@@ -20,6 +21,7 @@ export function CodeBlock({
 }: {
   isIsolated?: boolean;
   lang?: string;
+  code?: string;
   collapsible?: boolean;
   showLineNumbers?: boolean;
   title: string | undefined;
@@ -31,6 +33,7 @@ export function CodeBlock({
   if (!collapsible) {
     return (
       <BaseCodeBlock
+        code={code}
         title={title}
         className={cn(
           "code-block-wrapper docs-code-block",
@@ -56,6 +59,7 @@ export function CodeBlock({
         )}
       >
         <BaseCodeBlock
+          code={code}
           title={title}
           className={cn(
             "docs-code-block shadow-none",

--- a/apps/docs/src/components/codeblock.tsx
+++ b/apps/docs/src/components/codeblock.tsx
@@ -73,6 +73,7 @@ export async function CodeBlock({
   return (
     <CodeBlockClient
       className={className}
+      code={code?.trim() || ""}
       collapsible={collapsible}
       isIsolated={isIsolated}
       lang={lang}

--- a/apps/docs/src/mdx-components/fumadocs-custom-codeblock.tsx
+++ b/apps/docs/src/mdx-components/fumadocs-custom-codeblock.tsx
@@ -14,8 +14,9 @@ import {cn} from "@/utils/cn";
 export function FumadocsCustomCodeblock({
   allowCopy = true,
   children,
+  code,
   ...props
-}: {children: React.ReactNode} & CodeBlockProps) {
+}: {children: React.ReactNode; code?: string} & CodeBlockProps) {
   const areaRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -26,7 +27,7 @@ export function FumadocsCustomCodeblock({
       viewportProps={{ref: areaRef}}
       Actions={(actionsProps) => (
         <div {...actionsProps} className={cn("z-1! empty:hidden", actionsProps.className)}>
-          {!!allowCopy && <CopyButton containerRef={areaRef} />}
+          {!!allowCopy && <CopyButton code={code} containerRef={areaRef} />}
         </div>
       )}
     >
@@ -37,12 +38,20 @@ export function FumadocsCustomCodeblock({
 
 function CopyButton({
   className,
+  code,
   containerRef,
   ...props
 }: ComponentProps<"button"> & {
+  code?: string;
   containerRef: RefObject<HTMLElement | null>;
 }) {
   const [checked, onClick] = useCopyButton(() => {
+    if (code) {
+      void navigator.clipboard.writeText(code);
+
+      return;
+    }
+
     const pre = containerRef.current?.getElementsByTagName("pre").item(0);
 
     if (!pre) return;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

- Fixed an issue where clicking the copy button on a collapsible code block only copied the first 5 lines (preview) instead of the full code when the block was collapsed.
- Passed the raw `code` string through the component chain to the `CopyButton`, which uses it directly for clipboard writes when available, bypassing the DOM read.
- The collapsed preview rendering optimization is preserved — only the first 5 highlighted lines are rendered in the DOM when collapsed.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
