### PR TITLE
refactor(styles): apply inline-block to trigger

### DIFF
--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -7,6 +7,7 @@
  * Element: trigger - the element that opens the modal
  */
 .alert-dialog__trigger {
+  @apply inline-block;
   @apply cursor-(--cursor-interactive);
 
   /**

--- a/packages/styles/components/disclosure.css
+++ b/packages/styles/components/disclosure.css
@@ -9,7 +9,7 @@
 
 .disclosure__trigger {
   cursor: var(--cursor-interactive);
-  @apply no-highlight;
+  @apply inline-block no-highlight;
 
   /* Focus state */
   &:focus-visible:not(:focus),

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -7,7 +7,7 @@
  * Element: trigger - the element that opens the drawer
  */
 .drawer__trigger {
-  @apply cursor-(--cursor-interactive);
+  @apply inline-block cursor-(--cursor-interactive);
 
   /**
    * Transitions

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -7,6 +7,7 @@
 }
 
 .dropdown__trigger {
+  @apply inline-block;
   /* Only visible when using a custom trigger  - not passing "Button" as a child - hence we use some button styles (custom trigger) */
   @apply outline-none;
   /**

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -7,7 +7,7 @@
  * Element: trigger - the element that opens the modal
  */
 .modal__trigger {
-  @apply cursor-(--cursor-interactive);
+  @apply inline-block cursor-(--cursor-interactive);
 
   /**
    * Transitions

--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -68,6 +68,8 @@
 
 /* Popover trigger */
 .popover__trigger {
+  @apply inline-block;
+
   /**
    * Transitions
    * CRITICAL: motion-reduce must be AFTER transition for correct override specificity

--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -59,6 +59,8 @@
 
 /* Tooltip trigger */
 .tooltip__trigger {
+  @apply inline-block;
+
   /**
    * Transitions
    * CRITICAL: motion-reduce must be AFTER transition for correct override specificity


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported from [Discord](https://discord.com/channels/856545348885676062/1486057699090239604)

```tsx
<div>
  Hello{" "}
  <Popover>
    <Popover.Trigger>
      <span className="text-red-500 line-through">world</span>
    </Popover.Trigger>
    <Popover.Content {...props}>
      <Popover.Dialog>
        <Popover.Heading>Popover heading</Popover.Heading>
        <p>This is the popover content</p>
      </Popover.Dialog>
    </Popover.Content>
  </Popover>{" "}
  goodbye
</div>
```

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="179" height="115" alt="image" src="https://github.com/user-attachments/assets/8f071d69-7760-435e-9cfe-4aed2b621bc9" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="235" height="62" alt="image" src="https://github.com/user-attachments/assets/aa3e52fc-4d4e-4dd7-b736-6746f3e9ee9c" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
