### PR TITLE
fix(autocomplete): set correct --trigger-width CSS variable on popover

### DIFF
--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -6,8 +6,8 @@ import type {AutocompleteVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, RefObject} from "react";
 
 import {autocompleteVariants} from "@heroui/styles";
-import {mergeRefs} from "@react-aria/utils";
-import React, {createContext, useContext, useRef} from "react";
+import {mergeRefs, useResizeObserver} from "@react-aria/utils";
+import React, {createContext, useCallback, useContext, useRef, useState} from "react";
 import {
   Autocomplete as AutocompletePrimitive,
   Button as ButtonPrimitive,
@@ -194,9 +194,19 @@ const AutocompletePopover = ({
   children,
   className,
   placement = "bottom",
+  style,
   ...props
 }: AutocompletePopoverProps) => {
   const {slots, triggerRef} = useContext(AutocompleteContext);
+  const [triggerWidth, setTriggerWidth] = useState<string | null>(null);
+
+  const onResize = useCallback(() => {
+    if (triggerRef.current) {
+      setTriggerWidth(triggerRef.current.offsetWidth + "px");
+    }
+  }, [triggerRef]);
+
+  useResizeObserver({ref: triggerRef, onResize});
 
   return (
     <SurfaceContext
@@ -210,6 +220,12 @@ const AutocompletePopover = ({
         data-slot="autocomplete-popover"
         placement={placement}
         triggerRef={triggerRef}
+        style={
+          {
+            "--trigger-width": triggerWidth,
+            ...(typeof style === "object" && style !== null ? style : {}),
+          } as React.CSSProperties
+        }
       >
         {children}
       </PopoverPrimitive>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6368

## 📝 Description

<!--- Add a brief description -->

- Fixes `--trigger-width` CSS variable being `0px` on the Autocomplete popover, causing it to not match the trigger input width
- The root cause is that React Aria's `Select` measures its `ButtonPrimitive` for `--trigger-width`, but in Autocomplete the `ButtonPrimitive` is only the small chevron indicator — not the full trigger. The actual trigger is a `GroupPrimitive`.
- Adds a `useResizeObserver` in `AutocompletePopover` to measure the correct trigger element and override `--trigger-width` via an inline style


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Using the first example from Autocomplete storybook (width = 256px)

<img width="1353" height="739" alt="image" src="https://github.com/user-attachments/assets/6a39502a-78f5-451d-bf0c-59e991485e77" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Using the first example from Autocomplete storybook (width = 256px)

<img width="1556" height="738" alt="Image" src="https://github.com/user-attachments/assets/db2aee8a-0cd1-4804-aa62-95e793365a6b" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
