### PR TITLE
feat(styles): add --backdrop variable for overlay components

### DIFF
--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -79,15 +79,14 @@
  * Modifier: backdrop--opaque
  */
 .alert-dialog__backdrop--opaque {
-  background-color: var(--backdrop);
+  @apply bg-backdrop;
 }
 
 /**
  * Modifier: backdrop--blur
  */
 .alert-dialog__backdrop--blur {
-  background-color: var(--backdrop);
-  @apply backdrop-blur-md;
+  @apply bg-backdrop backdrop-blur-md;
 }
 
 /**

--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -79,14 +79,15 @@
  * Modifier: backdrop--opaque
  */
 .alert-dialog__backdrop--opaque {
-  @apply bg-black/50 dark:bg-black/60;
+  background-color: var(--backdrop);
 }
 
 /**
  * Modifier: backdrop--blur
  */
 .alert-dialog__backdrop--blur {
-  @apply bg-black/50 backdrop-blur-md dark:bg-black/60;
+  background-color: var(--backdrop);
+  @apply backdrop-blur-md;
 }
 
 /**

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -78,14 +78,15 @@
  * Modifier: backdrop--opaque
  */
 .drawer__backdrop--opaque {
-  @apply bg-black/50 dark:bg-black/60;
+  background-color: var(--backdrop);
 }
 
 /**
  * Modifier: backdrop--blur
  */
 .drawer__backdrop--blur {
-  @apply bg-black/50 backdrop-blur-md dark:bg-black/60;
+  background-color: var(--backdrop);
+  @apply backdrop-blur-md;
 }
 
 /**

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -78,15 +78,14 @@
  * Modifier: backdrop--opaque
  */
 .drawer__backdrop--opaque {
-  background-color: var(--backdrop);
+  @apply bg-backdrop;
 }
 
 /**
  * Modifier: backdrop--blur
  */
 .drawer__backdrop--blur {
-  background-color: var(--backdrop);
-  @apply backdrop-blur-md;
+  @apply bg-backdrop backdrop-blur-md;
 }
 
 /**

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -78,14 +78,15 @@
  * Modifier: backdrop--opaque
  */
 .modal__backdrop--opaque {
-  @apply bg-black/50 dark:bg-black/60;
+  background-color: var(--backdrop);
 }
 
 /**
  * Modifier: backdrop--blur
  */
 .modal__backdrop--blur {
-  @apply bg-black/50 backdrop-blur-md dark:bg-black/60;
+  background-color: var(--backdrop);
+  @apply backdrop-blur-md;
 }
 
 /**

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -78,15 +78,14 @@
  * Modifier: backdrop--opaque
  */
 .modal__backdrop--opaque {
-  background-color: var(--backdrop);
+  @apply bg-backdrop;
 }
 
 /**
  * Modifier: backdrop--blur
  */
 .modal__backdrop--blur {
-  background-color: var(--backdrop);
-  @apply backdrop-blur-md;
+  @apply bg-backdrop backdrop-blur-md;
 }
 
 /**

--- a/packages/styles/themes/default/variables.css
+++ b/packages/styles/themes/default/variables.css
@@ -90,6 +90,9 @@
     --focus: var(--accent);
     --link: var(--foreground);
 
+    /* Backdrop */
+    --backdrop: rgba(0, 0, 0, 0.5);
+
     /* Shadows */
     /* --surface-shadow: 0 0px 0px 0 rgba(24, 24, 27, 0.03), 0 2px 10px 0 rgba(24, 24, 27, 0.08); */
     --surface-shadow:
@@ -153,6 +156,9 @@
     --separator: oklch(25% 0.006 286.033);
     --focus: var(--accent);
     --link: var(--foreground);
+
+    /* Backdrop */
+    --backdrop: rgba(0, 0, 0, 0.6);
 
     /* Shadows */
     --surface-shadow: 0 0 0 0 transparent inset; /* No shadow on dark mode */

--- a/packages/styles/themes/shared/theme.css
+++ b/packages/styles/themes/shared/theme.css
@@ -40,6 +40,8 @@
   --color-danger: var(--danger);
   --color-danger-foreground: var(--danger-foreground);
 
+  --color-backdrop: var(--backdrop);
+
   --shadow-surface: var(--surface-shadow);
   --shadow-overlay: var(--overlay-shadow);
   --shadow-field: var(--field-shadow);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Adds a `--backdrop` CSS variable and replaces hardcoded `bg-black/50 dark:bg-black/60` backdrop colors in Modal, Drawer, and Alert Dialog with `bg-backdrop`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="1618" height="792" alt="image" src="https://github.com/user-attachments/assets/0c36f612-b326-4735-b6e7-327259c47f50" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="1614" height="758" alt="image" src="https://github.com/user-attachments/assets/b7ddad7c-d494-4e26-b88e-ddb72c91b156" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
