### PR TITLE
docs(native): update hero image and repo links to latest assets

### DIFF
--- a/apps/docs/content/docs/native/getting-started/index.mdx
+++ b/apps/docs/content/docs/native/getting-started/index.mdx
@@ -2,7 +2,7 @@
 title: Introduction
 description: An open-source UI component library for building beautiful and accessible user interfaces.
 icon: book-open
-image: https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light.jpg
+image: https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light-1.webp
 ---
 
 HeroUI Native is a React Native component library built on [Tailwind v4](https://tailwindcss.com/blog/tailwindcss-v4) via [Uniwind](https://uniwind.dev/) and modern mobile development technologies. Every component comes with smooth animations, polished details, and built-in accessibility—ready to use, fully customizable.

--- a/apps/docs/src/components/native-image-hero-view.tsx
+++ b/apps/docs/src/components/native-image-hero-view.tsx
@@ -15,8 +15,8 @@ export const NativeImageHeroView: FC = () => {
       <NativeQRPreviewPopover />
       <DocsImage
         alt="HeroUI v3 Introduction"
-        darkSrc="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-dark-1.jpg"
-        src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light-1.jpg"
+        darkSrc="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-dark-1.webp"
+        src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light-1.webp"
       />
     </div>
   );

--- a/apps/docs/src/components/native-image-hero-view.tsx
+++ b/apps/docs/src/components/native-image-hero-view.tsx
@@ -15,8 +15,8 @@ export const NativeImageHeroView: FC = () => {
       <NativeQRPreviewPopover />
       <DocsImage
         alt="HeroUI v3 Introduction"
-        darkSrc="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-dark.jpg"
-        src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light.jpg"
+        darkSrc="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-dark-1.jpg"
+        src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/heroui-native-og-light-1.jpg"
       />
     </div>
   );

--- a/apps/docs/src/utils/constants.ts
+++ b/apps/docs/src/utils/constants.ts
@@ -17,7 +17,7 @@ export const COMPONENT_PATH =
     ? `${GITHUB_URL}/${REPO_NAME}/tree/v3/packages/react/src/components`
     : `${GITHUB_URL}/${REPO_NAME}/tree/main/packages/react/src/components`;
 
-export const COMPONENT_PATH_NATIVE = `${GITHUB_URL}/${REPO_NAME_NATIVE}/tree/rc/src/components`;
+export const COMPONENT_PATH_NATIVE = `${GITHUB_URL}/${REPO_NAME_NATIVE}/tree/main/src/components`;
 
 export const DOCS_CONTENT_PATH =
   __IS_PRE_RELEASE__ || __PREVIEW__
@@ -34,7 +34,7 @@ export const COMPONENT_STYLES_PATH =
     ? `${GITHUB_URL}/${REPO_NAME}/tree/v3/packages/styles/components`
     : `${GITHUB_URL}/${REPO_NAME}/tree/main/packages/styles/components`;
 
-export const COMPONENT_STYLES_PATH_NATIVE = `${GITHUB_URL}/${REPO_NAME_NATIVE}/blob/rc/src/components`;
+export const COMPONENT_STYLES_PATH_NATIVE = `${GITHUB_URL}/${REPO_NAME_NATIVE}/blob/main/src/components`;
 
 export const THEMES_PATH =
   __IS_PRE_RELEASE__ || __PREVIEW__


### PR DESCRIPTION
## 📝 Description

Updates HeroUI Native documentation assets and repository links to point to the latest image versions and the correct `main` branch instead of `rc`.

## ⛳️ Current behavior (updates)

The Native docs hero images reference outdated asset filenames (`heroui-native-og-light.jpg`, `heroui-native-og-dark.jpg`), and the component source/styles links point to the `rc` branch of the native repository.

## 🚀 New behavior

- Hero images updated to latest versions (`-1` suffix, `.webp` for OG meta image, `.jpg` for light/dark hero views)
- `COMPONENT_PATH_NATIVE` now points to `tree/main/src/components` instead of `tree/rc/src/components`
- `COMPONENT_STYLES_PATH_NATIVE` now points to `blob/main/src/components` instead of `blob/rc/src/components`

## 💣 Is this a breaking change (Yes/No):

**No** - Only updates documentation asset URLs and GitHub link references; no component or API changes.

## 📝 Additional Information

All changes are confined to the docs app (`apps/docs/`). No dependency or build changes. The `rc` → `main` branch update reflects the native repo's promotion to its stable branch.