### PR TITLE
fix(tabs): scope secondary variant CSS to prevent leaking into nested Tabs

### DIFF
--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -177,8 +177,11 @@
    ========================================================================== */
 
 .tabs--secondary {
+  /* Scope all secondary styles through direct > .tabs__list-container child
+     to prevent leaking into nested Tabs with a different variant (#6381) */
+
   /* Tab list - remove background, add bottom/left border */
-  .tabs__list {
+  > .tabs__list-container > .tabs__list {
     @apply bg-transparent p-0;
 
     border-radius: 0;
@@ -204,7 +207,7 @@
   }
 
   /* Tab - adjust for secondary variant */
-  .tabs__tab {
+  > .tabs__list-container .tabs__tab {
     @apply rounded-none;
 
     /* Selected state - use text-foreground */
@@ -214,12 +217,12 @@
   }
 
   /* Hide separators in secondary variant */
-  .tabs__separator {
+  > .tabs__list-container .tabs__separator {
     display: none;
   }
 
   /* Tab indicator - line style */
-  .tabs__indicator {
+  > .tabs__list-container .tabs__indicator {
     @apply bg-accent;
 
     box-shadow: none;
@@ -227,14 +230,14 @@
   }
 
   /* Horizontal orientation - bottom line indicator */
-  &[data-orientation="horizontal"] .tabs__indicator {
+  &[data-orientation="horizontal"] > .tabs__list-container .tabs__indicator {
     top: auto;
     bottom: 0;
     height: 2px;
   }
 
   /* Vertical orientation - left line indicator */
-  &[data-orientation="vertical"] .tabs__indicator {
+  &[data-orientation="vertical"] > .tabs__list-container .tabs__indicator {
     left: 0;
     top: 0;
     width: 2px;

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -177,9 +177,6 @@
    ========================================================================== */
 
 .tabs--secondary {
-  /* Scope all secondary styles through direct > .tabs__list-container child
-     to prevent leaking into nested Tabs with a different variant (#6381) */
-
   /* Tab list - remove background, add bottom/left border */
   > .tabs__list-container > .tabs__list {
     @apply bg-transparent p-0;


### PR DESCRIPTION
### What

Fixes #6381

### Problem

The secondary variant styles use descendant selectors (e.g. `.tabs--secondary .tabs__tab`) which leak into nested `Tabs` components that use a different variant. When a primary `Tabs` is nested inside a secondary `Tabs`, the inner tabs incorrectly inherit the secondary (underline) styling because their elements are still DOM descendants of the outer `.tabs--secondary`.

### Root Cause

CSS descendant selectors in `.tabs--secondary` match ALL nested `.tabs__tab`, `.tabs__list`, `.tabs__indicator`, etc. elements regardless of which `Tabs` instance they belong to.

### Fix

Scoped all secondary variant selectors through the direct child `> .tabs__list-container`. This correctly stops at the Tabs component boundary because nested `Tabs` have their own `.tabs__list-container` that is NOT a direct child of the outer `.tabs--secondary`.

Before: `.tabs--secondary .tabs__list { ... }`  
After: `.tabs--secondary > .tabs__list-container > .tabs__list { ... }`  

This is a **CSS-only fix** (9 insertions, 6 deletions in `tabs.css`).