### PR TITLE
fix(autocomplete): default allowsEmptyCollection to true to fix unresponsiveness on no match (#6382)

### DIFF
--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -49,6 +49,7 @@ interface AutocompleteRootProps<T extends object, M extends "single" | "multiple
 }
 
 const AutocompleteRoot = <T extends object = object, M extends "single" | "multiple" = "single">({
+  allowsEmptyCollection = true,
   children,
   className,
   fullWidth,
@@ -66,6 +67,7 @@ const AutocompleteRoot = <T extends object = object, M extends "single" | "multi
   return (
     <AutocompleteContext value={{slots, triggerRef, clearButtonRef, onClear}}>
       <SelectPrimitive
+        allowsEmptyCollection={allowsEmptyCollection}
         data-slot="autocomplete"
         {...props}
         className={composeTwRenderProps(className, slots?.base())}


### PR DESCRIPTION
### Description
This PR addresses issue #6382 where the Autocomplete component becomes unresponsive (cannot reopen the popover) if closed while in an empty state (no matches during async filtering).

### Changes
- Updated AutocompleteRoot in packages/react/src/components/autocomplete/autocomplete.tsx to default the allowsEmptyCollection prop to true.
- - Passed the allowsEmptyCollection prop down to the underlying react-aria-components SelectPrimitive.
### Context & Rationale
By default, RAC's Select prevents the popover from opening if there are no items. In an Autocomplete context, this locks the UI if a search yield zero results and the popover is closed. Setting allowsEmptyCollection={true} ensures the popover can be reopened to display the "No results found" state or to allow the user to modify their search query.

### Verification
- Verified that react-aria-components@1.16.0 supports this prop on Select.
- - Verified that the package builds and typechecks successfully after the change.
Fixes #6382.
