### PR TITLE
fix(docs): add missing aria-label to extra options menu button

### DIFF
--- a/apps/docs/src/components/ai/page-actions.tsx
+++ b/apps/docs/src/components/ai/page-actions.tsx
@@ -143,7 +143,7 @@ export function ViewOptions({markdownUrl}: {markdownUrl: string}) {
         )}
       </Button>
       <Dropdown isOpen={isOpen} onOpenChange={setOpen}>
-        <Button isIconOnly size="md" variant="tertiary">
+        <Button isIconOnly aria-label="More options" size="md" variant="tertiary">
           <ButtonGroup.Separator />
           <ChevronDown
             className={cn(


### PR DESCRIPTION
### Description
This PR fixes accessibility issue #6371 where the "extra options" dropdown trigger button in the docs site lacked an aria-label.

### Changes
- Added aria-label="More options" to the Button component in apps/docs/src/components/ai/page-actions.tsx.
### Rationale
The dropdown trigger button (next to "Copy Markdown") currently has no descriptive label for screen readers. Adding aria-label="More options" satisfies accessibility standards and improves the user experience for users with visual impairments.

### Verification
- Verified that the @heroui/docs package passes typecheck (tsc --noEmit).
Fixes #6371.