### PR TITLE
chore(autocomplete): update async filtering examples

### DIFF
--- a/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/autocomplete/asynchronous-filtering.tsx
@@ -24,7 +24,12 @@ export function AsynchronousFiltering() {
   });
 
   return (
-    <Autocomplete className="w-[256px]" placeholder="Search..." selectionMode="single">
+    <Autocomplete
+      allowsEmptyCollection
+      className="w-[256px]"
+      placeholder="Search..."
+      selectionMode="single"
+    >
       <Label>Search a Star Wars characters</Label>
       <Autocomplete.Trigger>
         <Autocomplete.Value />

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -1096,7 +1096,12 @@ export const AsynchronousFiltering: Story = {
     });
 
     return (
-      <Autocomplete className="w-[256px]" placeholder="Search..." selectionMode="single">
+      <Autocomplete
+        allowsEmptyCollection
+        className="w-[256px]"
+        placeholder="Search..."
+        selectionMode="single"
+      >
         <Label>Search a Star Wars characters</Label>
         <Autocomplete.Trigger>
           <Autocomplete.Value />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6382

## 📝 Description

<!--- Add a brief description -->

This PR is to update async filtering examples so that the popover can be re-opened even though there is an empty collection. The usage of `allowsEmptyCollection` has been mentioned in [here](https://heroui.com/docs/react/components/autocomplete#allows-empty-collection). 

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Input 111 > close popover > couldn't open the popover

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Input 111 > close popover > able to open the popover

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
