### PR TITLE
fix(drawer): support controlled usage without trigger child

### DIFF
--- a/packages/react/src/components/drawer/drawer.stories.tsx
+++ b/packages/react/src/components/drawer/drawer.stories.tsx
@@ -3,12 +3,11 @@ import type {Meta} from "@storybook/react";
 import {Icon} from "@iconify/react";
 import React from "react";
 
+import {useOverlayState} from "../../hooks/use-overlay-state";
 import {Button} from "../button";
 import {Input} from "../input";
 import {Label} from "../label";
 import {TextField} from "../textfield";
-
-import {useOverlayState} from "../../hooks/use-overlay-state";
 
 import {Drawer} from "./index";
 
@@ -343,9 +342,9 @@ export const ControlledWithoutTrigger = () => {
               </Drawer.Header>
               <Drawer.Body>
                 <p>
-                  This drawer is opened externally via <code>useOverlayState</code> without a trigger
-                  child inside the Drawer root. This is useful for drawers driven by URL params,
-                  row selections, or other external events.
+                  This drawer is opened externally via <code>useOverlayState</code> without a
+                  trigger child inside the Drawer root. This is useful for drawers driven by URL
+                  params, row selections, or other external events.
                 </p>
               </Drawer.Body>
               <Drawer.Footer>

--- a/packages/react/src/components/drawer/drawer.stories.tsx
+++ b/packages/react/src/components/drawer/drawer.stories.tsx
@@ -311,8 +311,6 @@ export const Controlled = () => {
 /**
  * Controlled drawer using `useOverlayState` + `Drawer` root without a trigger child.
  * This pattern is common for drawers opened by external events (URL changes, row clicks, etc.).
- * Before the fix, this would not work because `DrawerRoot` always wrapped children
- * in `DialogTrigger`, which requires a pressable trigger as its first child.
  */
 export const ControlledWithoutTrigger = () => {
   const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/components/drawer/drawer.stories.tsx
+++ b/packages/react/src/components/drawer/drawer.stories.tsx
@@ -8,6 +8,8 @@ import {Input} from "../input";
 import {Label} from "../label";
 import {TextField} from "../textfield";
 
+import {useOverlayState} from "../../hooks/use-overlay-state";
+
 import {Drawer} from "./index";
 
 export default {
@@ -303,6 +305,58 @@ export const Controlled = () => {
           </Drawer.Dialog>
         </Drawer.Content>
       </Drawer.Backdrop>
+    </div>
+  );
+};
+
+/**
+ * Controlled drawer using `useOverlayState` + `Drawer` root without a trigger child.
+ * This pattern is common for drawers opened by external events (URL changes, row clicks, etc.).
+ * Before the fix, this would not work because `DrawerRoot` always wrapped children
+ * in `DialogTrigger`, which requires a pressable trigger as its first child.
+ */
+export const ControlledWithoutTrigger = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const state = useOverlayState({isOpen, onOpenChange: setIsOpen});
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <Button variant="secondary" onPress={() => setIsOpen(true)}>
+          Open Drawer (External)
+        </Button>
+        <p className="text-sm text-muted">
+          Status:{" "}
+          <span className="font-mono font-medium text-foreground">
+            {isOpen ? "open" : "closed"}
+          </span>
+        </p>
+      </div>
+
+      <Drawer state={state}>
+        <Drawer.Backdrop>
+          <Drawer.Content placement="right">
+            <Drawer.Dialog>
+              <Drawer.CloseTrigger />
+              <Drawer.Header>
+                <Drawer.Heading>Controlled Without Trigger</Drawer.Heading>
+              </Drawer.Header>
+              <Drawer.Body>
+                <p>
+                  This drawer is opened externally via <code>useOverlayState</code> without a trigger
+                  child inside the Drawer root. This is useful for drawers driven by URL params,
+                  row selections, or other external events.
+                </p>
+              </Drawer.Body>
+              <Drawer.Footer>
+                <Button variant="secondary" onPress={() => setIsOpen(false)}>
+                  Close
+                </Button>
+              </Drawer.Footer>
+            </Drawer.Dialog>
+          </Drawer.Content>
+        </Drawer.Backdrop>
+      </Drawer>
     </div>
   );
 };

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -228,6 +228,21 @@ const DrawerRoot = ({children, state, ...props}: DrawerRootProps) => {
     [state],
   );
 
+  // When a controlled `state` is provided, skip the DialogTrigger wrapper.
+  // DialogTrigger expects its first child to be a pressable trigger element,
+  // which breaks controlled drawers that have no trigger (e.g. opened via URL params).
+  // Instead, provide the overlay state directly via OverlayTriggerStateContext
+  // so that ModalOverlay (Drawer.Backdrop) can read it from context.
+  if (state) {
+    return (
+      <DrawerContext value={drawerContext}>
+        <OverlayTriggerStateContext value={state}>
+          {children}
+        </OverlayTriggerStateContext>
+      </DrawerContext>
+    );
+  }
+
   return (
     <DrawerContext value={drawerContext}>
       <DrawerTriggerPrimitive data-slot="drawer-root" {...mergeProps(props, controlledProps)}>

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -219,7 +219,7 @@ interface DrawerRootProps extends ComponentPropsWithRef<typeof DrawerTriggerPrim
 
 const DrawerRoot = ({children, state, ...props}: DrawerRootProps) => {
   const drawerContext = useMemo<DrawerContext>(
-    () => ({slots: drawerVariants(), placement: undefined, isDismissable: true}),
+    () => ({isDismissable: true, placement: undefined, slots: drawerVariants()}),
     [],
   );
 
@@ -236,9 +236,7 @@ const DrawerRoot = ({children, state, ...props}: DrawerRootProps) => {
   if (state) {
     return (
       <DrawerContext value={drawerContext}>
-        <OverlayTriggerStateContext value={state}>
-          {children}
-        </OverlayTriggerStateContext>
+        <OverlayTriggerStateContext value={state}>{children}</OverlayTriggerStateContext>
       </DrawerContext>
     );
   }
@@ -299,7 +297,7 @@ const DrawerBackdrop = ({
   const updatedSlots = useMemo(() => drawerVariants({variant}), [variant]);
 
   const updatedDrawerContext = useMemo<DrawerContext>(
-    () => ({slots: {...contextSlots, ...updatedSlots}, isDismissable}),
+    () => ({isDismissable, slots: {...contextSlots, ...updatedSlots}}),
     [contextSlots, updatedSlots, isDismissable],
   );
 
@@ -342,7 +340,7 @@ const DrawerContent = ({
   const updatedSlots = useMemo(() => drawerVariants({placement}), [placement]);
 
   const updatedDrawerContext = useMemo<DrawerContext>(
-    () => ({placement, isDismissable, slots: {...contextSlots, ...updatedSlots}}),
+    () => ({isDismissable, placement, slots: {...contextSlots, ...updatedSlots}}),
     [contextSlots, placement, isDismissable, updatedSlots],
   );
 


### PR DESCRIPTION
## Summary
- When `state` prop is provided, skip `DialogTrigger` wrapper and provide state via `OverlayTriggerStateContext` directly
- `DialogTrigger` requires a pressable first child — without one, `Drawer.Backdrop` is misinterpreted as the trigger
- Added `ControlledWithoutTrigger` story demonstrating the fix

## Root Cause
`DrawerRoot` unconditionally wraps children in `DialogTrigger` (from react-aria-components). When no trigger child is present (controlled drawers opened by external events), the overlay never mounts as visible.

## Fix
Detect controlled mode (`state` prop) and render children inside `OverlayTriggerStateContext.Provider` instead of `DialogTrigger`. `ModalOverlay` reads overlay state from this context natively.

Fixes #6347

> Re-opened from #6356, which was auto-closed when the `v3.0.2` branch was deleted after release.