### PR TITLE
fix(docs): correct swapped accent-foreground values in theme builder

### DIFF
--- a/apps/docs/src/app/themes/utils/generate-css-variables.ts
+++ b/apps/docs/src/app/themes/utils/generate-css-variables.ts
@@ -25,6 +25,7 @@ import {
   getColorVariablesForElement,
   getFieldDerivedVariables,
   getSemanticDerivedVariables,
+  parseOklch,
 } from "./generate-theme-colors";
 
 /**
@@ -190,8 +191,15 @@ export function generateCssVariables(
 
   // Check if this is an adaptive color that needs light/dark variants
   if (adaptiveConfig) {
-    const lightFg = calculateAccentForeground(1, 0, 0); // Light accent needs dark fg
-    const darkFg = calculateAccentForeground(0, 0, 0); // Dark accent needs light fg
+    const lightAccent = parseOklch(adaptiveConfig.light);
+    const darkAccent = parseOklch(adaptiveConfig.dark);
+
+    const lightFg = lightAccent
+      ? calculateAccentForeground(lightAccent.l, lightAccent.c, lightAccent.h)
+      : calculateAccentForeground(0, 0, 0);
+    const darkFg = darkAccent
+      ? calculateAccentForeground(darkAccent.l, darkAccent.c, darkAccent.h)
+      : calculateAccentForeground(1, 0, 0);
 
     // For adaptive colors, we override the accent with predefined values
     const lightVars = getColorVariablesForElement(colors, "light");
@@ -382,8 +390,15 @@ export function generateMinimalCssVariables(
 
   // Override accent for adaptive colors (like black/white)
   if (adaptiveConfig) {
-    const lightFg = calculateAccentForeground(1, 0, 0);
-    const darkFg = calculateAccentForeground(0, 0, 0);
+    const lightAccent = parseOklch(adaptiveConfig.light);
+    const darkAccent = parseOklch(adaptiveConfig.dark);
+
+    const lightFg = lightAccent
+      ? calculateAccentForeground(lightAccent.l, lightAccent.c, lightAccent.h)
+      : calculateAccentForeground(0, 0, 0);
+    const darkFg = darkAccent
+      ? calculateAccentForeground(darkAccent.l, darkAccent.c, darkAccent.h)
+      : calculateAccentForeground(1, 0, 0);
 
     lightVars["--accent"] = adaptiveConfig.light;
     lightVars["--accent-foreground"] = lightFg;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6400

## 📝 Description

<!--- Add a brief description -->

This PR fixes `--accent-foreground` being swapped between light and dark mode in the exported CSS from the Theme Builder for adaptive accent themes (e.g. Uber).

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

```css
/*
 * HeroUI Theme Customization
 * Add this to your global.css after importing @heroui/styles
 * Only includes base variables from variables.css
 * @see https://heroui.com/docs/react/getting-started/theming
 */

:root,
.light,
.default,
[data-theme="light"],
[data-theme="default"] {
  /* Theme Colors (Light Mode) */
  --accent: oklch(0 0 0);
  --accent-foreground: oklch(15% 0.0000 0.00);
  --background: oklch(97.02% 0.0000 0.00);
  --border: oklch(90.00% 0.0000 0.00);
  --danger: oklch(0.573 0.2249 21.97);
  --danger-foreground: oklch(98% 0.0200 21.97);
  --default: oklch(94.00% 0.0000 0.00);
  --default-foreground: oklch(21.03% 0.0059 0.00);
  --field-background: oklch(100.00% 0.0000 0.00);
  --field-foreground: oklch(21.03% 0.0000 0.00);
  --field-placeholder: oklch(55.17% 0.0000 0.00);
  --focus: oklch(0 0 0);
  --foreground: oklch(21.03% 0.0000 0.00);
  --muted: oklch(55.17% 0.0000 0.00);
  --overlay: oklch(100.00% 0.0000 0.00);
  --overlay-foreground: oklch(21.03% 0.0000 0.00);
  --scrollbar: oklch(87.10% 0.0000 0.00);
  --segment: oklch(100.00% 0.0000 0.00);
  --segment-foreground: oklch(21.03% 0.0000 0.00);
  --separator: oklch(92.00% 0.0000 0.00);
  --success: oklch(0.6277 0.1604 153.06);
  --success-foreground: oklch(98% 0.0160 153.06);
  --surface: oklch(100.00% 0.0000 0.00);
  --surface-foreground: oklch(21.03% 0.0000 0.00);
  --surface-secondary: oklch(95.24% 0.0000 0.00);
  --surface-secondary-foreground: oklch(21.03% 0.0000 0.00);
  --surface-tertiary: oklch(93.73% 0.0000 0.00);
  --surface-tertiary-foreground: oklch(21.03% 0.0000 0.00);
  --warning: oklch(0.8446 0.1525 80.6);
  --warning-foreground: oklch(15% 0.0457 80.60);

  /* Border Radius */
  --radius: 0.25rem;
  --field-radius: 0.25rem;

  /* Font Family */
  /* Make sure to load Inter font in your app */
  --font-sans: var(--font-inter);
}

.dark,
[data-theme="dark"] {
  color-scheme: dark;
  /* Theme Colors (Dark Mode) */
  --accent: oklch(0.9848 0 0);
  --accent-foreground: oklch(99.11% 0 0);
  --background: oklch(12.00% 0.0000 0.00);
  --border: oklch(28.00% 0.0000 0.00);
  --danger: oklch(0.7044 0.1872 23.19);
  --danger-foreground: oklch(15% 0.0500 23.19);
  --default: oklch(27.40% 0.0000 0.00);
  --default-foreground: oklch(99.11% 0 0);
  --field-background: oklch(21.03% 0.0000 0.00);
  --field-foreground: oklch(99.11% 0.0000 0.00);
  --field-placeholder: oklch(70.50% 0.0000 0.00);
  --focus: oklch(0.9848 0 0);
  --foreground: oklch(99.11% 0.0000 0.00);
  --muted: oklch(70.50% 0.0000 0.00);
  --overlay: oklch(21.03% 0.0000 0.00);
  --overlay-foreground: oklch(99.11% 0.0000 0.00);
  --scrollbar: oklch(70.50% 0.0000 0.00);
  --segment: oklch(39.64% 0.0000 0.00);
  --segment-foreground: oklch(99.11% 0.0000 0.00);
  --separator: oklch(25.00% 0.0000 0.00);
  --success: oklch(0.6514 0.1321 156.22);
  --success-foreground: oklch(15% 0.0396 156.22);
  --surface: oklch(21.03% 0.0000 0.00);
  --surface-foreground: oklch(99.11% 0.0000 0.00);
  --surface-secondary: oklch(25.70% 0.0000 0.00);
  --surface-secondary-foreground: oklch(99.11% 0.0000 0.00);
  --surface-tertiary: oklch(27.21% 0.0000 0.00);
  --surface-tertiary-foreground: oklch(99.11% 0.0000 0.00);
  --warning: oklch(0.8803 0.1348 86.06);
  --warning-foreground: oklch(15% 0.0404 86.06);
}
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

```css
/*
 * HeroUI Theme Customization
 * Add this to your global.css after importing @heroui/styles
 * Only includes base variables from variables.css
 * @see https://heroui.com/docs/react/getting-started/theming
 */

:root,
.light,
.default,
[data-theme="light"],
[data-theme="default"] {
  /* Theme Colors (Light Mode) */
  --accent: oklch(0 0 0);
  --accent-foreground: oklch(99.11% 0 0);
  --background: oklch(97.02% 0.0000 0.00);
  --border: oklch(90.00% 0.0000 0.00);
  --danger: oklch(0.573 0.2249 21.97);
  --danger-foreground: oklch(98% 0.0200 21.97);
  --default: oklch(94.00% 0.0000 0.00);
  --default-foreground: oklch(21.03% 0.0059 0.00);
  --field-background: oklch(100.00% 0.0000 0.00);
  --field-foreground: oklch(21.03% 0.0000 0.00);
  --field-placeholder: oklch(55.17% 0.0000 0.00);
  --focus: oklch(0 0 0);
  --foreground: oklch(21.03% 0.0000 0.00);
  --muted: oklch(55.17% 0.0000 0.00);
  --overlay: oklch(100.00% 0.0000 0.00);
  --overlay-foreground: oklch(21.03% 0.0000 0.00);
  --scrollbar: oklch(87.10% 0.0000 0.00);
  --segment: oklch(100.00% 0.0000 0.00);
  --segment-foreground: oklch(21.03% 0.0000 0.00);
  --separator: oklch(92.00% 0.0000 0.00);
  --success: oklch(0.6277 0.1604 153.06);
  --success-foreground: oklch(98% 0.0160 153.06);
  --surface: oklch(100.00% 0.0000 0.00);
  --surface-foreground: oklch(21.03% 0.0000 0.00);
  --surface-secondary: oklch(95.24% 0.0000 0.00);
  --surface-secondary-foreground: oklch(21.03% 0.0000 0.00);
  --surface-tertiary: oklch(93.73% 0.0000 0.00);
  --surface-tertiary-foreground: oklch(21.03% 0.0000 0.00);
  --warning: oklch(0.8446 0.1525 80.6);
  --warning-foreground: oklch(15% 0.0457 80.60);

  /* Border Radius */
  --radius: 0.25rem;
  --field-radius: 0.25rem;

  /* Font Family */
  /* Make sure to load Inter font in your app */
  --font-sans: var(--font-inter);
}

.dark,
[data-theme="dark"] {
  color-scheme: dark;
  /* Theme Colors (Dark Mode) */
  --accent: oklch(0.9848 0 0);
  --accent-foreground: oklch(15% 0.0000 0.00);
  --background: oklch(12.00% 0.0000 0.00);
  --border: oklch(28.00% 0.0000 0.00);
  --danger: oklch(0.7044 0.1872 23.19);
  --danger-foreground: oklch(15% 0.0500 23.19);
  --default: oklch(27.40% 0.0000 0.00);
  --default-foreground: oklch(99.11% 0 0);
  --field-background: oklch(21.03% 0.0000 0.00);
  --field-foreground: oklch(99.11% 0.0000 0.00);
  --field-placeholder: oklch(70.50% 0.0000 0.00);
  --focus: oklch(0.9848 0 0);
  --foreground: oklch(99.11% 0.0000 0.00);
  --muted: oklch(70.50% 0.0000 0.00);
  --overlay: oklch(21.03% 0.0000 0.00);
  --overlay-foreground: oklch(99.11% 0.0000 0.00);
  --scrollbar: oklch(70.50% 0.0000 0.00);
  --segment: oklch(39.64% 0.0000 0.00);
  --segment-foreground: oklch(99.11% 0.0000 0.00);
  --separator: oklch(25.00% 0.0000 0.00);
  --success: oklch(0.6514 0.1321 156.22);
  --success-foreground: oklch(15% 0.0396 156.22);
  --surface: oklch(21.03% 0.0000 0.00);
  --surface-foreground: oklch(99.11% 0.0000 0.00);
  --surface-secondary: oklch(25.70% 0.0000 0.00);
  --surface-secondary-foreground: oklch(99.11% 0.0000 0.00);
  --surface-tertiary: oklch(27.21% 0.0000 0.00);
  --surface-tertiary-foreground: oklch(99.11% 0.0000 0.00);
  --warning: oklch(0.8803 0.1348 86.06);
  --warning-foreground: oklch(15% 0.0404 86.06);
}
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
