### PR TITLE
fix(toast): InvalidStateError when view transitions abort

### DIFF
--- a/packages/react/src/components/toast/toast-queue.ts
+++ b/packages/react/src/components/toast/toast-queue.ts
@@ -12,6 +12,46 @@ import {flushSync} from "react-dom";
 
 import {DEFAULT_RAC_MAX_VISIBLE_TOAST, DEFAULT_TOAST_TIMEOUT} from "./constants";
 
+type ViewTransitionLike = {
+  finished?: Promise<unknown>;
+  ready?: Promise<unknown>;
+  updateCallbackDone?: Promise<unknown>;
+};
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (update: () => void) => ViewTransitionLike;
+};
+
+function safelyRunWithViewTransition(update: () => void) {
+  if (typeof document === "undefined") {
+    update();
+
+    return;
+  }
+
+  const startViewTransition = (document as ViewTransitionDocument).startViewTransition;
+
+  if (typeof startViewTransition !== "function") {
+    update();
+
+    return;
+  }
+
+  try {
+    const transition = startViewTransition.call(document, () => {
+      flushSync(update);
+    });
+
+    // View transitions are purely cosmetic here, so absorb browser aborts during
+    // navigation/unmounts rather than surfacing unhandled promise rejections.
+    void transition?.ready?.catch(() => {});
+    void transition?.finished?.catch(() => {});
+    void transition?.updateCallbackDone?.catch(() => {});
+  } catch {
+    update();
+  }
+}
+
 /* ------------------------------------------------------------------------------------------------
  * Toast Queue Options
  * --------------------------------------------------------------------------------------------- */
@@ -33,17 +73,7 @@ export class ToastQueue<T extends object = ToastContentValue> {
     this.maxVisibleToasts = options?.maxVisibleToasts;
     this.queue = new ToastQueuePrimitive<T>({
       maxVisibleToasts: DEFAULT_RAC_MAX_VISIBLE_TOAST,
-      wrapUpdate: options?.wrapUpdate
-        ? options.wrapUpdate
-        : (fn: () => void) => {
-            if ("startViewTransition" in document) {
-              document.startViewTransition(() => {
-                flushSync(fn);
-              });
-            } else {
-              fn();
-            }
-          },
+      wrapUpdate: options?.wrapUpdate ? options.wrapUpdate : safelyRunWithViewTransition,
     });
   }
 
@@ -123,20 +153,20 @@ function createToastFunction(queue: ToastQueue<ToastContentValue>) {
 
     return queue.add(
       {
-        title: message,
+        actionProps: options?.actionProps,
         description: options?.description,
         indicator: options?.indicator,
-        variant: options?.variant || "default",
-        actionProps: options?.actionProps,
         isLoading: options?.isLoading,
+        title: message,
+        variant: options?.variant || "default",
       },
       {
-        timeout,
         onClose: () => {
           requestAnimationFrame(() => {
             options?.onClose?.();
           });
         },
+        timeout,
       },
     );
   };
@@ -166,9 +196,9 @@ function createToastFunction(queue: ToastQueue<ToastContentValue>) {
     const promiseFn = typeof promise === "function" ? promise() : promise;
     const loadingId = queue.add(
       {
+        isLoading: true,
         title: options.loading,
         variant: "default",
-        isLoading: true,
       },
       {
         timeout: 0, // Don't auto-close loading toasts

--- a/packages/react/src/components/toast/toast.test.tsx
+++ b/packages/react/src/components/toast/toast.test.tsx
@@ -1,0 +1,107 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+import {ToastQueue, toast} from "./toast-queue";
+
+type MockViewTransition = {
+  finished?: Promise<unknown>;
+  ready?: Promise<unknown>;
+  updateCallbackDone?: Promise<unknown>;
+};
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const setStartViewTransition = (callback: (update: () => void) => MockViewTransition) => {
+  Object.defineProperty(document, "startViewTransition", {
+    configurable: true,
+    value: vi.fn(callback),
+    writable: true,
+  });
+};
+
+describe("toast view transitions", () => {
+  beforeEach(() => {
+    toast.clear();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {},
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    toast.clear();
+    vi.restoreAllMocks();
+    delete (globalThis as typeof globalThis & {document?: Document}).document;
+  });
+
+  it("falls back to a normal update when starting a view transition throws", () => {
+    const queue = new ToastQueue();
+
+    setStartViewTransition(() => {
+      throw new DOMException(
+        "Transition was aborted because of invalid state",
+        "InvalidStateError",
+      );
+    });
+
+    expect(() =>
+      queue.add(
+        {
+          title: "Saved",
+          variant: "success",
+        },
+        {timeout: 0},
+      ),
+    ).not.toThrow();
+    expect(queue.visibleToasts).toHaveLength(1);
+  });
+
+  it("does not leak aborted transition promises when a pending toast resolves after unmount", async () => {
+    let resolvePromise!: (value: {count: number}) => void;
+    const pendingPromise = new Promise<{count: number}>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const transitionError = new DOMException(
+      "Transition was aborted because of invalid state",
+      "InvalidStateError",
+    );
+
+    setStartViewTransition((update) => {
+      update();
+
+      return {
+        finished: Promise.reject(transitionError),
+        ready: Promise.reject(transitionError),
+        updateCallbackDone: Promise.reject(transitionError),
+      };
+    });
+
+    const queue = toast.getQueue();
+    const subscriber = vi.fn();
+    const unsubscribe = queue.subscribe(subscriber);
+
+    toast.promise(pendingPromise, {
+      error: (error) => error.message,
+      loading: "Saving changes...",
+      success: (result) => `Saved ${result.count} items`,
+    });
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+
+    resolvePromise({count: 3});
+    await pendingPromise;
+    await flushMicrotasks();
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(queue.visibleToasts).toHaveLength(1);
+    expect(queue.visibleToasts[0]?.content).toMatchObject({
+      title: "Saved 3 items",
+      variant: "success",
+    });
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+  root: "packages/react",
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
- closes: #6409

## Summary
- guard toast queue updates when `document.startViewTransition` throws or its transition promises reject
- fall back to a normal `flushSync` update when the browser aborts the transition during navigation or unmounts
- add regressions for synchronous `InvalidStateError` failures and `toast.promise` resolving after the subscriber unmounts

## Root cause
HeroUI wraps toast queue mutations in `document.startViewTransition(() => flushSync(fn))`.
When a route change, Strict Mode effect replay, or unmount interrupts that browser transition, the View Transition API can either throw synchronously or reject its transition promises with `InvalidStateError`. Because those promise rejections were left unhandled, `toast.success()` / `toast.promise()` could surface an uncaught DOMException even though the toast update itself was otherwise valid.

## Impact
This keeps the existing toast API intact while making the animation layer best-effort instead of fatal. Toasts still render and resolve normally, but aborted browser transitions no longer bubble as uncaught promise rejections.

## Validation
- `pnpm exec vitest run --config packages/react/vitest.config.ts src/components/toast/toast.test.tsx`
- `pnpm exec tsc --noEmit -p packages/react/tsconfig.json`
- `pnpm build:react`
