### PR TITLE
fix(styles): trigger display

### DIFF
--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -7,8 +7,7 @@
  * Element: trigger - the element that opens the modal
  */
 .alert-dialog__trigger {
-  @apply inline-block;
-  @apply cursor-(--cursor-interactive);
+  @apply inline-flex cursor-(--cursor-interactive) items-center justify-center;
 
   /**
    * Transitions

--- a/packages/styles/components/disclosure.css
+++ b/packages/styles/components/disclosure.css
@@ -9,7 +9,7 @@
 
 .disclosure__trigger {
   cursor: var(--cursor-interactive);
-  @apply inline-block no-highlight;
+  @apply inline-flex items-center justify-center no-highlight;
 
   /* Focus state */
   &:focus-visible:not(:focus),

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -7,7 +7,7 @@
  * Element: trigger - the element that opens the drawer
  */
 .drawer__trigger {
-  @apply inline-block cursor-(--cursor-interactive);
+  @apply inline-flex cursor-(--cursor-interactive) items-center justify-center;
 
   /**
    * Transitions

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -7,7 +7,7 @@
 }
 
 .dropdown__trigger {
-  @apply inline-block;
+  @apply inline-flex items-center justify-center;
   /* Only visible when using a custom trigger  - not passing "Button" as a child - hence we use some button styles (custom trigger) */
   @apply outline-none;
   /**

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -7,7 +7,7 @@
  * Element: trigger - the element that opens the modal
  */
 .modal__trigger {
-  @apply inline-block cursor-(--cursor-interactive);
+  @apply inline-flex cursor-(--cursor-interactive) items-center justify-center;
 
   /**
    * Transitions

--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -68,7 +68,7 @@
 
 /* Popover trigger */
 .popover__trigger {
-  @apply inline-block;
+  @apply inline-flex items-center justify-center;
 
   /**
    * Transitions

--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -59,7 +59,7 @@
 
 /* Tooltip trigger */
 .tooltip__trigger {
-  @apply inline-block;
+  @apply inline-flex items-center justify-center;
 
   /**
    * Transitions


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Previously we changed the trigger to be inline in https://github.com/heroui-inc/heroui/pull/6373. However, if the trigger has button class, `inline-block` from the trigger would be overriding `inline-flex` from .button based on CSS load order. This PR is to change `inline-block` to `inline-flex items-center justify-center` so that it preserves inline behaviour, fix the icon alignment and eliminate the cascade conflict. 

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="190" height="102" alt="image" src="https://github.com/user-attachments/assets/7cf712f5-c735-47f8-aed3-588e1ab4c26f" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="145" height="80" alt="image" src="https://github.com/user-attachments/assets/014aa51e-78a9-4de0-8209-9c8982557e79" />

<img width="221" height="59" alt="image" src="https://github.com/user-attachments/assets/b13b6ebb-00ba-4a07-bdab-40050019d5a3" />

<img width="175" height="71" alt="image" src="https://github.com/user-attachments/assets/ccc06018-b3ab-423e-b6a9-d597ca6eb95e" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
