### PR TITLE
fix(number-field): stabilize formatOptions reference to prevent input…

### DIFF
--- a/packages/react/src/components/number-field/number-field.tsx
+++ b/packages/react/src/components/number-field/number-field.tsx
@@ -12,6 +12,7 @@ import {
   NumberField as NumberFieldPrimitive,
 } from "react-aria-components";
 
+import {shallowEqual} from "../../utils/assertion";
 import {composeTwRenderProps} from "../../utils/compose";
 import {IconMinus, IconPlus} from "../icons";
 
@@ -33,6 +34,7 @@ interface NumberFieldRootProps
 const NumberFieldRoot = ({
   children,
   className,
+  formatOptions,
   fullWidth,
   variant,
   ...props
@@ -41,11 +43,21 @@ const NumberFieldRoot = ({
     () => numberFieldVariants({fullWidth, variant}),
     [fullWidth, variant],
   );
+  const [prevFormatOptions, setPrevFormatOptions] = React.useState(formatOptions);
+  const [stableFormatOptions, setStableFormatOptions] = React.useState(formatOptions);
+
+  if (prevFormatOptions !== formatOptions) {
+    setPrevFormatOptions(formatOptions);
+    if (!shallowEqual(stableFormatOptions, formatOptions)) {
+      setStableFormatOptions(formatOptions);
+    }
+  }
 
   return (
     <NumberFieldContext value={{slots}}>
       <NumberFieldPrimitive
         data-slot="number-field"
+        formatOptions={stableFormatOptions}
         {...props}
         className={composeTwRenderProps(className, slots?.base())}
       >

--- a/packages/react/src/utils/assertion.ts
+++ b/packages/react/src/utils/assertion.ts
@@ -34,3 +34,17 @@ export const dataAttr = (condition: boolean | undefined) =>
 
 export const isNumeric = (value?: string | number) =>
   value != null && parseInt(value.toString(), 10) > 0;
+
+export function shallowEqual<T extends object>(
+  a: T | null | undefined,
+  b: T | null | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a) as (keyof T)[];
+  const keysB = Object.keys(b) as (keyof T)[];
+
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every((k) => Object.is(a[k], b[k]));
+}


### PR DESCRIPTION
Closes #6414 

## 📝 Description

`NumberField` was incorrectly resetting its displayed input value whenever a parent component re-rendered with a
  changed prop. This happened even when the user had typed a value into the field.

  The root cause is in `useNumberFieldState` (`@react-stately/numberfield`), which tracks `formatOptions` changes using
   reference equality (`!==`). Since `formatOptions` is commonly passed as an inline object literal, a new reference is
   created on every parent re-render — triggering `setInputValue(format(numberValue))` unnecessarily and reverting the
  displayed text to the last committed value.

  To address this within HeroUI, `NumberFieldRoot` now stabilizes the `formatOptions` reference using React's
  derived-state pattern. A new reference is only propagated to React Aria when the contents actually differ, verified
  via a shallow equality check.

  A `shallowEqual` utility has been added to `packages/react/src/utils/assertion.ts` for this purpose.

 **Note:** The root cause lies in `adobe/react-spectrum`, and I plan to open an issue and attempt a fix there as
  well. However, if the upstream change takes time to land or cannot be merged due to other constraints, I believe this
   workaround will help HeroUI users in the meantime.

## ⛳️ Current behavior (updates)

 When a parent component re-renders due to an unrelated prop change, `NumberField` resets its displayed value back to
  `defaultValue` (or empty if none is set), discarding any value the user had typed.

## 🚀 New behavior

  `NumberField` retains the user's typed value across parent re-renders. The displayed value is only updated when
  `formatOptions` content genuinely changes.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
- Added `shallowEqual<T extends object>` utility to `packages/react/src/utils/assertion.ts`