### PR TITLE
fix(docs): add aria-labels to table icon-only action buttons

### DIFF
--- a/apps/docs/src/demos/table/custom-cells.tsx
+++ b/apps/docs/src/demos/table/custom-cells.tsx
@@ -164,7 +164,7 @@ export function CustomCells() {
                 <Table.Cell className="font-medium">
                   <div className="flex items-center gap-2">
                     #{user.id.toString()}{" "}
-                    <Button isIconOnly size="sm" variant="ghost">
+                    <Button aria-label="Copy ID" isIconOnly size="sm" variant="ghost">
                       <Icon className="size-4 text-muted" icon="gravity-ui:copy" />
                     </Button>
                   </div>
@@ -194,13 +194,13 @@ export function CustomCells() {
                 </Table.Cell>
                 <Table.Cell>
                   <div className="flex items-center gap-1">
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button aria-label="View user" isIconOnly size="sm" variant="tertiary">
                       <Icon className="size-4" icon="gravity-ui:eye" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button aria-label="Edit user" isIconOnly size="sm" variant="tertiary">
                       <Icon className="size-4" icon="gravity-ui:pencil" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="danger-soft">
+                    <Button aria-label="Delete user" isIconOnly size="sm" variant="danger-soft">
                       <Icon className="size-4" icon="gravity-ui:trash-bin" />
                     </Button>
                   </div>


### PR DESCRIPTION
## 📝 Description

Adds `aria-label` to the 4 icon-only `Button` components in the Table custom-cells demo (`apps/docs/src/demos/table/custom-cells.tsx`).

## ⛳️ Current behavior

Screen readers announce all 4 action buttons as just `"button"` — no context about what they do.

## 🚀 New behavior

- Copy button → `aria-label="Copy ID"`
- View button → `aria-label="View user"`
- Edit button → `aria-label="Edit user"`
- Delete button → `aria-label="Delete user"`

Fixes WCAG 2.1 Level A violation (SC 4.1.2: Name, Role, Value).

Closes #6427

## 💣 Is this a breaking change (Yes/No):

No