### PR TITLE
fix(docs): add aria-labels to icon-only button demos

### DIFF
--- a/apps/docs/src/demos/button-group/with-icons.tsx
+++ b/apps/docs/src/demos/button-group/with-icons.tsx
@@ -26,14 +26,14 @@ export function WithIcons() {
       <div className="flex flex-col items-start gap-2">
         <p className="text-sm text-muted">Icon only buttons</p>
         <ButtonGroup variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Search">
             <Globe />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Add">
             <ButtonGroup.Separator />
             <Plus />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Delete">
             <ButtonGroup.Separator />
             <TrashBin />
           </Button>

--- a/apps/docs/src/demos/button/icon-only.tsx
+++ b/apps/docs/src/demos/button/icon-only.tsx
@@ -4,13 +4,13 @@ import {Button} from "@heroui/react";
 export function IconOnly() {
   return (
     <div className="flex gap-3">
-      <Button isIconOnly variant="tertiary">
+      <Button isIconOnly variant="tertiary" aria-label="More options">
         <Ellipsis />
       </Button>
-      <Button isIconOnly variant="secondary">
+      <Button isIconOnly variant="secondary" aria-label="Settings">
         <Gear />
       </Button>
-      <Button isIconOnly variant="danger">
+      <Button isIconOnly variant="danger" aria-label="Delete">
         <TrashBin />
       </Button>
     </div>


### PR DESCRIPTION
## 📝 Description

Icon-only buttons in the `Button` and `ButtonGroup` demo files had no `aria-label`, so screen readers announced them as plain "button" with no context. Since these examples are the reference implementation that developers copy, they should demonstrate the correct accessible pattern.

## ⛳️ Current behavior

All 6 icon-only demo buttons are announced as just "button" by screen readers.

## 🚀 New behavior

- `button/icon-only.tsx`: More options, Settings, Delete
- `button-group/with-icons.tsx`: Search, Add, Delete

Each button now has a descriptive `aria-label`.

## 💣 Is this a breaking change (Yes/No):

No