### PR TITLE
fix(a11y): accessibility issues

### DIFF
--- a/apps/docs/src/demos/button-group/with-icons.tsx
+++ b/apps/docs/src/demos/button-group/with-icons.tsx
@@ -26,14 +26,14 @@ export function WithIcons() {
       <div className="flex flex-col items-start gap-2">
         <p className="text-sm text-muted">Icon only buttons</p>
         <ButtonGroup variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Search">
             <Globe />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Add">
             <ButtonGroup.Separator />
             <Plus />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Delete">
             <ButtonGroup.Separator />
             <TrashBin />
           </Button>

--- a/apps/docs/src/demos/button/icon-only.tsx
+++ b/apps/docs/src/demos/button/icon-only.tsx
@@ -4,13 +4,13 @@ import {Button} from "@heroui/react";
 export function IconOnly() {
   return (
     <div className="flex gap-3">
-      <Button isIconOnly variant="tertiary">
+      <Button isIconOnly variant="tertiary" aria-label="More options">
         <Ellipsis />
       </Button>
-      <Button isIconOnly variant="secondary">
+      <Button isIconOnly variant="secondary" aria-label="Settings">
         <Gear />
       </Button>
-      <Button isIconOnly variant="danger">
+      <Button isIconOnly variant="danger" aria-label="Delete">
         <TrashBin />
       </Button>
     </div>

--- a/apps/docs/src/demos/popover/with-arrow.tsx
+++ b/apps/docs/src/demos/popover/with-arrow.tsx
@@ -18,7 +18,7 @@ export function PopoverWithArrow() {
       </Popover>
 
       <Popover>
-        <Button isIconOnly variant="tertiary">
+        <Button aria-label="More options" isIconOnly variant="tertiary">
           <Ellipsis />
         </Button>
         <Popover.Content className="max-w-64" offset={10}>

--- a/apps/docs/src/demos/table/custom-cells.tsx
+++ b/apps/docs/src/demos/table/custom-cells.tsx
@@ -164,7 +164,7 @@ export function CustomCells() {
                 <Table.Cell className="font-medium">
                   <div className="flex items-center gap-2">
                     #{user.id.toString()}{" "}
-                    <Button isIconOnly size="sm" variant="ghost">
+                    <Button aria-label={`Copy ID #${user.id}`} isIconOnly size="sm" variant="ghost">
                       <Icon className="size-4 text-muted" icon="gravity-ui:copy" />
                     </Button>
                   </div>
@@ -194,13 +194,13 @@ export function CustomCells() {
                 </Table.Cell>
                 <Table.Cell>
                   <div className="flex items-center gap-1">
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button aria-label={`View ${user.name}`} isIconOnly size="sm" variant="tertiary">
                       <Icon className="size-4" icon="gravity-ui:eye" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button aria-label={`Edit ${user.name}`} isIconOnly size="sm" variant="tertiary">
                       <Icon className="size-4" icon="gravity-ui:pencil" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="danger-soft">
+                    <Button aria-label={`Delete ${user.name}`} isIconOnly size="sm" variant="danger-soft">
                       <Icon className="size-4" icon="gravity-ui:trash-bin" />
                     </Button>
                   </div>

--- a/apps/docs/src/demos/tooltip/basic.tsx
+++ b/apps/docs/src/demos/tooltip/basic.tsx
@@ -12,7 +12,7 @@ export function TooltipBasic() {
       </Tooltip>
 
       <Tooltip delay={0}>
-        <Button isIconOnly variant="tertiary">
+        <Button aria-label="More information" isIconOnly variant="tertiary">
           <CircleInfo />
         </Button>
         <Tooltip.Content>

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -6,7 +6,7 @@ import type {CheckboxRenderProps} from "react-aria-components";
 
 import {checkboxVariants} from "@heroui/styles";
 import React, {createContext, useContext} from "react";
-import {Checkbox as CheckboxPrimitive} from "react-aria-components";
+import {Checkbox as CheckboxPrimitive, LabelContext} from "react-aria-components";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {CheckboxGroupContext} from "../checkbox-group/checkbox-group";
@@ -40,7 +40,15 @@ const CheckboxRoot = ({children, className, variant, ...props}: CheckboxRootProp
     >
       {(values) => (
         <CheckboxContext value={{slots, state: values}}>
-          {typeof children === "function" ? children(values) : children}
+          {/*
+           * Override LabelContext so that any <Label> rendered inside the
+           * Checkbox (which itself renders as <label>) uses a <span> instead.
+           * Nested <label> elements are invalid HTML per the spec.
+           * https://github.com/heroui-inc/heroui/issues/6434
+           */}
+          <LabelContext.Provider value={{elementType: "span"}}>
+            {typeof children === "function" ? children(values) : children}
+          </LabelContext.Provider>
         </CheckboxContext>
       )}
     </CheckboxPrimitive>

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -5,7 +5,7 @@ import type {ComponentPropsWithRef} from "react";
 
 import {switchVariants} from "@heroui/styles";
 import React, {createContext, useContext} from "react";
-import {Switch as SwitchPrimitive} from "react-aria-components";
+import {Switch as SwitchPrimitive, LabelContext} from "react-aria-components";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 
@@ -33,7 +33,11 @@ const SwitchRoot = ({children, className, size, ...props}: SwitchRootProps) => {
         {...props}
         className={composeTwRenderProps(className, slots.base())}
       >
-        {(values) => <>{typeof children === "function" ? children(values) : children}</>}
+        {(values) => (
+          <LabelContext.Provider value={{elementType: "span"}}>
+            {typeof children === "function" ? children(values) : children}
+          </LabelContext.Provider>
+        )}
       </SwitchPrimitive>
     </SwitchContext>
   );


### PR DESCRIPTION
## Summary

Three accessibility fixes across components and documentation demos.

---

### Fix 1 — Checkbox: prevent nested `<label>` elements (#6434)

**Problem:** `CheckboxPrimitive` (from react-aria-components) renders a `<label>` as its root. When a `<Label>` component is placed inside `Checkbox.Content`, the DOM contains a `<label>` nested inside another `<label>` — invalid HTML per spec and confusing for assistive technology.

**Fix:** Provide `LabelContext` with `{ elementType: 'span' }` inside `CheckboxRoot` so any `<Label>` inside the Checkbox tree renders as `<span>` rather than `<label>`.

---

### Fix 2 — Switch: same nested `<label>` fix

`SwitchPrimitive` has the same root-`<label>` pattern. Applied the identical `LabelContext` override inside `SwitchRoot`.

---

### Fix 3 — Docs: add `aria-label` to icon-only buttons (WCAG 4.1.2) (#6427)

Icon-only buttons in several demos were missing accessible names, causing screen readers to announce only "button" with no context — a WCAG 2.1 SC 4.1.2 violation.

Fixed in:
- `table/custom-cells.tsx` — copy-ID, view, edit, delete buttons now have contextual labels (e.g., `"View Jane Doe"`, `"Delete Jane Doe"`)
- `tooltip/basic.tsx` — `aria-label="More information"` on icon-only trigger
- `popover/with-arrow.tsx` — `aria-label="More options"` on icon-only trigger