### PR TITLE
fix(styles): prevent Dialog from being programmatically scrolled by focus

### DIFF
--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -145,7 +145,7 @@
   @apply flex w-full flex-col;
   @apply rounded-3xl bg-overlay shadow-overlay outline-none;
   @apply p-6;
-  @apply overflow-hidden;
+  @apply overflow-clip;
   @apply pointer-events-auto;
 
   &[data-placement="auto"] {

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -195,7 +195,7 @@
  * Modifier: dialog--scroll-inside
  */
 .modal__dialog--scroll-inside {
-  @apply overflow-hidden;
+  @apply overflow-clip;
 }
 
 /**


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6447 

## 📝 Description

Fix a visual regression in `Modal` where focusing any element inside `Modal.Body` (Switch, Input, Button, …) shifted the whole Dialog content upward, pushing `Modal.Footer` out of the bottom of the Dialog and leaving a blank gap.

The Dialog itself is never supposed to scroll — only `Modal.Body` scrolls internally. But `.modal__dialog--scroll-inside` used `overflow: hidden`, which still establishes a scroll container: the scrollbar is hidden and users can't scroll manually, but `scrollTop` is still writable via JS, and React Aria's focus management calls `element.scrollIntoView(...)` up the ancestor chain. The Dialog was being picked up as the nearest scrollable ancestor, so `Dialog.scrollTop` was set to a non-zero value, visually translating all its children (Body + Footer) upward.

## ⛳️ Current behavior (updates)

With `size="cover"` + `scroll="inside"` (the default) and enough Body content to overflow:

- Clicking any focusable element inside `Modal.Body` shifts `Modal.Footer` upward.
- `document.querySelector('[data-slot="modal-dialog"]').scrollTop` becomes non-zero.
- `Body` and `Footer` `getBoundingClientRect().top` values both drop by exactly `Dialog.scrollTop` — confirming the Dialog (not just the Body) is scrolling.

Measurements from the new Storybook repro:

|                    | Before Switch click | After Switch click |
| ------------------ | ------------------- | ------------------ |
| `Dialog.scrollTop` | `0`                 | **`220.5`**        |
| `Body.scrollTop`   | `0`                 | `314`              |
| `Body` rect top    | `100`               | `-120.5`           |
| `Footer` rect top  | `790`               | `569.5`            |

## 🚀 New behavior

Change `.modal__dialog--scroll-inside` to use `overflow: clip` instead of `overflow: hidden`. `overflow: clip` is visually identical (clips overflow, no scrollbar) but does **not** establish a scroll container, so:

- `Dialog.scrollTop` stays at `0` — it can't be written by JS.
- `scrollIntoView` walks past the Dialog and correctly targets only `Modal.Body`.
- The Dialog stays visually static; only Body scrolls internally.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
