### PR TITLE
feat(docs): add UTM params to Pro search result links

### DIFF
--- a/apps/docs/src/components/search-dialog.tsx
+++ b/apps/docs/src/components/search-dialog.tsx
@@ -262,7 +262,11 @@ export default function CustomSearchDialog(props: SharedProps) {
           </Chip>
         </div>
       ),
-      onSelect: () => window.open(`${PRO_URL}${comp.slug}`, "_blank"),
+      onSelect: () =>
+        window.open(
+          `${PRO_URL}${comp.slug}?utm_source=heroui_docs&utm_medium=search&utm_campaign=pro_components`,
+          "_blank",
+        ),
       type: "action" as const,
     }));
   }, [proComponents, search]);


### PR DESCRIPTION
## Summary
- Add UTM tracking params to Pro component links in OSS search results
- `utm_source=heroui_docs`, `utm_medium=search`, `utm_campaign=pro_components`
- Enables tracking how many users discover Pro components through OSS docs search

Follow-up to #6458.

## Test plan
- [ ] Click a PRO search result and verify the URL contains UTM params

Made with [Cursor](https://cursor.com)