### PR TITLE
fix(styles): replace rounded-full and hardcoded border-radius with design tokens

### DIFF
--- a/packages/styles/components/accordion.css
+++ b/packages/styles/components/accordion.css
@@ -40,7 +40,7 @@
 
 .accordion__item::after {
   content: "";
-  @apply absolute bottom-0 left-0 h-px w-full rounded-full bg-separator;
+  @apply absolute bottom-0 left-0 h-px w-full rounded-xs bg-separator;
 }
 
 .accordion__item:last-child::after {

--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -228,7 +228,7 @@
 .alert-dialog__icon {
   @apply flex items-center justify-center;
   @apply size-10 shrink-0;
-  @apply rounded-full select-none;
+  @apply rounded-3xl select-none;
 
   [data-slot="alert-dialog-default-icon"] {
     @apply box-content size-5;

--- a/packages/styles/components/avatar.css
+++ b/packages/styles/components/avatar.css
@@ -1,6 +1,6 @@
 /* Base avatar styles */
 .avatar {
-  @apply relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-default;
+  @apply relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-3xl bg-default;
 }
 
 /* Avatar fallback element */
@@ -20,7 +20,7 @@
 
 /* Size modifiers */
 .avatar--sm {
-  @apply size-8;
+  @apply size-8 rounded-2xl;
 }
 
 .avatar--md {
@@ -28,7 +28,7 @@
 }
 
 .avatar--lg {
-  @apply size-12;
+  @apply size-12 rounded-3xl;
 
   .avatar__fallback {
     @apply text-base;

--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -72,9 +72,7 @@
    ========================================================================== */
 
 .button-group__separator {
-  @apply bg-current opacity-15;
-
-  border-radius: 4px;
+  @apply rounded-sm bg-current opacity-15;
   position: absolute;
   pointer-events: none;
 

--- a/packages/styles/components/calendar-year-picker.css
+++ b/packages/styles/components/calendar-year-picker.css
@@ -150,7 +150,7 @@
  * Year Cell
  * -------------------------------------------------------------------------- */
 .calendar-year-picker__year-cell {
-  @apply relative inline-flex items-center justify-center rounded-full px-2.5 py-1.5 text-sm font-medium outline-none select-none no-highlight;
+  @apply relative inline-flex h-8 items-center justify-center rounded-3xl px-2.5 text-sm font-medium outline-none select-none no-highlight;
   touch-action: manipulation;
 
   /**

--- a/packages/styles/components/calendar.css
+++ b/packages/styles/components/calendar.css
@@ -32,7 +32,7 @@
 }
 
 .calendar__nav-button {
-  @apply flex size-6 items-center justify-center rounded-full text-accent;
+  @apply flex size-6 items-center justify-center rounded-2xl text-accent;
 
   will-change: scale;
 
@@ -209,7 +209,7 @@
 
 /* Cell indicator - small dot at bottom center of cell */
 .calendar__cell-indicator {
-  @apply absolute bottom-1 left-1/2 size-[3px] -translate-x-1/2 rounded-full bg-muted;
+  @apply absolute bottom-1 left-1/2 size-[3px] -translate-x-1/2 rounded-xs bg-muted;
 
   /* Indicator color changes when cell is selected */
   [data-selected="true"] > & {

--- a/packages/styles/components/color-area.css
+++ b/packages/styles/components/color-area.css
@@ -41,7 +41,7 @@
    ========================================================================== */
 
 .color-area__thumb {
-  @apply size-4 rounded-full will-change-[width,height];
+  @apply size-4 rounded-xl will-change-[width,height];
 
   /* Current color from React Aria */
   background-color: var(--color-area-thumb-color);

--- a/packages/styles/components/color-slider.css
+++ b/packages/styles/components/color-slider.css
@@ -53,7 +53,7 @@
   }
 
   .color-slider__track {
-    @apply relative rounded-full;
+    @apply relative rounded-2xl;
 
     grid-area: track;
     /* Edge cap pseudo-elements */
@@ -68,7 +68,7 @@
 
   .color-slider__thumb {
     /* Flex container for centering */
-    @apply absolute flex cursor-grab items-center justify-center rounded-full no-highlight;
+    @apply absolute flex cursor-grab items-center justify-center rounded-2xl no-highlight;
 
     /* Border to create white ring around the thumb */
     @apply border-3 border-white shadow-overlay;
@@ -133,9 +133,8 @@
       }
 
       &::before {
+        @apply rounded-tl-2xl rounded-bl-2xl;
         left: -0.625rem;
-        border-top-left-radius: 999px;
-        border-bottom-left-radius: 999px;
         box-shadow:
           inset 1px 0 0 0 rgba(0, 0, 0, 0.1),
           inset 0 1px 0 0 rgba(0, 0, 0, 0.1),
@@ -146,9 +145,8 @@
       }
 
       &::after {
+        @apply rounded-tr-2xl rounded-br-2xl;
         right: -0.625rem;
-        border-top-right-radius: 999px;
-        border-bottom-right-radius: 999px;
         box-shadow:
           inset -1px 0 0 0 rgba(0, 0, 0, 0.1),
           inset 0 1px 0 0 rgba(0, 0, 0, 0.1),

--- a/packages/styles/components/color-swatch-picker.css
+++ b/packages/styles/components/color-swatch-picker.css
@@ -12,7 +12,7 @@
    ========================================================================== */
 
 .color-swatch-picker__item {
-  @apply relative flex size-8 items-center justify-center rounded-full border-2 border-transparent outline-none no-highlight;
+  @apply relative flex size-8 items-center justify-center rounded-2xl border-2 border-transparent outline-none no-highlight;
 
   /* Cursor */
   cursor: var(--cursor-interactive);
@@ -121,13 +121,13 @@
 
 .color-swatch-picker--xs {
   .color-swatch-picker__item {
-    @apply size-4 border;
+    @apply size-4 rounded-lg border;
   }
 }
 
 .color-swatch-picker--sm {
   .color-swatch-picker__item {
-    @apply size-6 border-2;
+    @apply size-6 rounded-xl border-2;
   }
 }
 
@@ -139,13 +139,13 @@
 
 .color-swatch-picker--lg {
   .color-swatch-picker__item {
-    @apply size-9 border-3;
+    @apply size-9 rounded-3xl border-3;
   }
 }
 
 .color-swatch-picker--xl {
   .color-swatch-picker__item {
-    @apply size-10 border-3;
+    @apply size-10 rounded-3xl border-3;
   }
 }
 
@@ -155,7 +155,7 @@
 
 /* Circle variant (default) - no additional styles needed */
 .color-swatch-picker--circle .color-swatch-picker__item {
-  /* Default is already circle (border-radius: 9999px) */
+  /* Default is already circle - radius set per size */
 }
 
 /* Square variant */

--- a/packages/styles/components/color-swatch.css
+++ b/packages/styles/components/color-swatch.css
@@ -13,7 +13,7 @@
 
 /* Shape variants */
 .color-swatch--circle {
-  @apply rounded-full;
+  @apply rounded-2xl;
 }
 
 .color-swatch--square {
@@ -23,20 +23,36 @@
 /* Size variants */
 .color-swatch--xs {
   @apply size-4;
+
+  &.color-swatch--circle {
+    @apply rounded-lg;
+  }
 }
 
 .color-swatch--sm {
   @apply size-6;
+
+  &.color-swatch--circle {
+    @apply rounded-xl;
+  }
 }
 
 .color-swatch--md {
-  /* No styles as this is the default size */
+  /* No additional styles — default size (32px) uses circle's base rounded-2xl */
 }
 
 .color-swatch--lg {
   @apply size-9;
+
+  &.color-swatch--circle {
+    @apply rounded-3xl;
+  }
 }
 
 .color-swatch--xl {
   @apply size-10;
+
+  &.color-swatch--circle {
+    @apply rounded-3xl;
+  }
 }

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -258,7 +258,7 @@
 
   /* The handle bar */
   & > [data-slot="drawer-handle-bar"] {
-    @apply h-1 w-9 rounded-full;
+    @apply h-1 w-9 rounded-xs;
     @apply bg-separator;
   }
 }

--- a/packages/styles/components/input-otp.css
+++ b/packages/styles/components/input-otp.css
@@ -77,12 +77,12 @@
 
 /* Caret */
 .input-otp__caret {
-  @apply absolute h-4 w-[2px] animate-caret-blink rounded-[4px] bg-field-placeholder;
+  @apply absolute h-4 w-[2px] animate-caret-blink rounded-sm bg-field-placeholder;
 }
 
 /* Separator */
 .input-otp__separator {
-  @apply h-[2px] w-[6px] shrink-0 rounded-[4px] bg-separator;
+  @apply h-[2px] w-[6px] shrink-0 rounded-sm bg-separator;
 }
 
 /* Variant property definitions */

--- a/packages/styles/components/meter.css
+++ b/packages/styles/components/meter.css
@@ -26,7 +26,7 @@
   }
 
   .meter__track {
-    @apply relative overflow-hidden rounded-full bg-default;
+    @apply relative overflow-hidden rounded-sm bg-default;
 
     grid-area: track;
 
@@ -35,7 +35,7 @@
   }
 
   .meter__fill {
-    @apply absolute top-0 left-0 h-full rounded-full;
+    @apply absolute top-0 left-0 h-full rounded-sm;
 
     background-color: var(--meter-fill);
 
@@ -65,7 +65,11 @@
 
 .meter--sm {
   .meter__track {
-    @apply h-1;
+    @apply h-1 rounded-xs;
+  }
+
+  .meter__fill {
+    @apply rounded-xs;
   }
 }
 
@@ -75,7 +79,11 @@
 
 .meter--lg {
   .meter__track {
-    @apply h-3;
+    @apply h-3 rounded-md;
+  }
+
+  .meter__fill {
+    @apply rounded-md;
   }
 }
 

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -276,7 +276,7 @@
 .modal__icon {
   @apply flex items-center justify-center;
   @apply size-10 shrink-0;
-  @apply rounded-full select-none;
+  @apply rounded-3xl select-none;
 }
 
 /**

--- a/packages/styles/components/progress-bar.css
+++ b/packages/styles/components/progress-bar.css
@@ -26,7 +26,7 @@
   }
 
   .progress-bar__track {
-    @apply relative overflow-hidden rounded-full bg-default;
+    @apply relative overflow-hidden rounded-sm bg-default;
 
     grid-area: track;
 
@@ -35,7 +35,7 @@
   }
 
   .progress-bar__fill {
-    @apply absolute top-0 left-0 h-full rounded-full;
+    @apply absolute top-0 left-0 h-full rounded-sm;
 
     background-color: var(--progress-bar-fill);
 
@@ -89,7 +89,11 @@
 
 .progress-bar--sm {
   .progress-bar__track {
-    @apply h-1;
+    @apply h-1 rounded-xs;
+  }
+
+  .progress-bar__fill {
+    @apply rounded-xs;
   }
 }
 
@@ -99,7 +103,11 @@
 
 .progress-bar--lg {
   .progress-bar__track {
-    @apply h-3;
+    @apply h-3 rounded-md;
+  }
+
+  .progress-bar__fill {
+    @apply rounded-md;
   }
 }
 

--- a/packages/styles/components/radio.css
+++ b/packages/styles/components/radio.css
@@ -28,7 +28,7 @@
    ========================================================================== */
 
 .radio__control {
-  @apply relative mt-[3px] inline-flex size-4 shrink-0 items-center justify-center rounded-full border [border-width:var(--border-width-field)] bg-field shadow-field outline-none no-highlight;
+  @apply relative mt-[3px] inline-flex size-4 shrink-0 items-center justify-center rounded-lg border [border-width:var(--border-width-field)] bg-field shadow-field outline-none no-highlight;
 
   /**
    * Transitions
@@ -112,7 +112,7 @@
    (e.g., custom icon). When custom content is present, these default dot styles are not applied. */
 .radio__indicator:empty::before {
   content: "";
-  @apply rounded-full bg-field;
+  @apply rounded-lg bg-field;
 
   width: 100%;
   height: 100%;

--- a/packages/styles/components/range-calendar.css
+++ b/packages/styles/components/range-calendar.css
@@ -32,7 +32,7 @@
 }
 
 .range-calendar__nav-button {
-  @apply flex size-6 items-center justify-center rounded-full text-accent;
+  @apply flex size-6 items-center justify-center rounded-xl text-accent;
 
   will-change: scale;
 
@@ -134,7 +134,7 @@
  * RangeCalendar Cells
  * -------------------------------------------------------------------------- */
 .range-calendar__cell {
-  @apply relative z-1 mx-0 my-[2px] rounded-full p-0 outline-none;
+  @apply relative z-1 mx-0 my-[2px] rounded-3xl p-0 outline-none;
   cursor: var(--cursor-interactive);
 
   will-change: background-color, border-color;
@@ -149,7 +149,7 @@
 
   /* Inner interactive circle/capsule (equivalent to React Aria "button-base") */
   .range-calendar__cell-button {
-    @apply flex aspect-square w-full items-center justify-center rounded-full text-sm font-medium text-foreground no-highlight;
+    @apply flex aspect-square w-full items-center justify-center rounded-3xl text-sm font-medium text-foreground no-highlight;
 
     will-change: scale;
     transition: scale 200ms var(--ease-out);
@@ -182,14 +182,14 @@
   &[data-selected="true"]:is(td:first-child > *, [aria-disabled] + td > *) {
     @apply rounded-ss-lg rounded-es-lg;
     &[data-selection-start="true"] {
-      @apply rounded-ss-full rounded-es-full;
+      @apply rounded-ss-3xl rounded-es-3xl;
     }
   }
 
   &[data-selected="true"]:is(td:last-child > *, td:has(+ [aria-disabled]) > *) {
     @apply rounded-se-lg rounded-ee-lg;
     &[data-selection-end="true"] {
-      @apply rounded-se-full rounded-ee-full;
+      @apply rounded-se-3xl rounded-ee-3xl;
     }
   }
 
@@ -208,11 +208,11 @@
   } */
 
   &[data-selection-start="true"]:not([data-outside-month="true"]) {
-    @apply rounded-tl-full rounded-bl-full;
+    @apply rounded-tl-3xl rounded-bl-3xl;
   }
 
   &[data-selection-end="true"]:not([data-outside-month="true"]) {
-    @apply rounded-tr-full rounded-br-full;
+    @apply rounded-tr-3xl rounded-br-3xl;
   }
 
   /* Pressed state */
@@ -275,7 +275,7 @@
 
   &[data-outside-month="true"],
   &[data-selection-start="true"] {
-    @apply rounded-ss-full rounded-es-full;
+    @apply rounded-ss-3xl rounded-es-3xl;
   }
 }
 
@@ -289,13 +289,13 @@
 
   &[data-outside-month="true"],
   &[data-selection-end="true"] {
-    @apply rounded-se-full rounded-ee-full;
+    @apply rounded-se-3xl rounded-ee-3xl;
   }
 }
 
 /* Cell indicator - small dot at bottom center of cell */
 .range-calendar__cell-indicator {
-  @apply absolute bottom-1 left-1/2 size-[3px] -translate-x-1/2 rounded-full bg-muted;
+  @apply absolute bottom-1 left-1/2 size-[3px] -translate-x-1/2 rounded-xs bg-muted;
 
   /* Indicator color changes when cell is selected */
   [data-selected="true"] > & {

--- a/packages/styles/components/separator.css
+++ b/packages/styles/components/separator.css
@@ -2,7 +2,7 @@
 
 /* Base separator with default horizontal orientation */
 .separator {
-  @apply shrink-0 rounded-[4px] border-t-0 border-b-0 bg-separator;
+  @apply shrink-0 rounded-sm border-t-0 border-b-0 bg-separator;
 
   /* Default size - horizontal orientation */
   @apply h-px w-full;

--- a/packages/styles/components/slider.css
+++ b/packages/styles/components/slider.css
@@ -21,7 +21,7 @@
   }
 
   .slider__track {
-    @apply relative rounded-full bg-default;
+    @apply relative rounded-xl bg-default;
 
     grid-area: track;
   }
@@ -32,7 +32,7 @@
 
   .slider__thumb {
     /* Flex container for centering pseudo-elements */
-    @apply absolute flex cursor-grab items-center justify-center rounded-full bg-accent no-highlight;
+    @apply absolute flex cursor-grab items-center justify-center rounded-xl bg-accent no-highlight;
 
     /**
    * Transitions
@@ -46,7 +46,7 @@
 
     /* after: Visible thumb element */
     &::after {
-      @apply relative z-10 rounded-full bg-accent-foreground text-black shadow-field;
+      @apply relative z-10 rounded-lg bg-accent-foreground text-black shadow-field;
       content: "";
 
       /**

--- a/packages/styles/components/switch.css
+++ b/packages/styles/components/switch.css
@@ -52,7 +52,7 @@
 /* Switch control (track) */
 .switch__control {
   /* Default size (medium) */
-  @apply relative flex shrink-0 items-center overflow-hidden rounded-full;
+  @apply relative flex shrink-0 items-center overflow-hidden rounded-xl;
   height: 1.25rem; /* 20px on desktop (14px base), 20px on mobile (16px base) - scales with font-size */
   width: 2.5rem; /* 35px on desktop, 40px on mobile - scales with font-size */
 
@@ -111,6 +111,7 @@
 
 /* Size-specific control dimensions */
 .switch--sm .switch__control {
+  @apply rounded-lg;
   height: 1rem; /* ~14px on desktop, ~16px on mobile */
   width: 2rem; /* ~32px on desktop, ~36px on mobile */
 }
@@ -127,7 +128,7 @@
 /* Switch thumb */
 .switch__thumb {
   /* Default size (medium) with margin-based positioning */
-  @apply ms-0.5 flex origin-center rounded-full bg-white text-black shadow-field;
+  @apply ms-0.5 flex origin-center rounded-lg bg-white text-black shadow-field;
   height: 1rem; /* ~14px on desktop, ~16px on mobile */
   width: 1.375rem; /* ~19px on desktop, ~22px on mobile */
 
@@ -157,6 +158,7 @@
 
 /* Size-specific thumb dimensions */
 .switch--sm .switch__thumb {
+  @apply rounded-md;
   height: 0.75rem; /* ~10.5px on desktop, ~12px on mobile */
   width: 1.03125rem; /* ~14.4px on desktop, ~16.5px on mobile - maintains 1.375:1 ratio */
 
@@ -168,6 +170,7 @@
 }
 
 .switch--lg .switch__thumb {
+  @apply rounded-xl;
   height: 1.25rem; /* ~17.5px on desktop, ~20px on mobile */
   width: 1.71875rem; /* ~24px on desktop, ~27.5px on mobile - maintains 1.375:1 ratio */
 

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -21,7 +21,7 @@
 .tabs__list {
   @apply inline-flex bg-default p-1;
 
-  border-radius: calc(var(--radius-2xl) + 0.25rem);
+  border-radius: calc(var(--radius) * 2.5);
 
   /* Horizontal orientation */
   &[data-orientation="horizontal"] {
@@ -96,9 +96,7 @@
 
 /* Tab separator */
 .tabs__separator {
-  @apply bg-muted/25;
-
-  border-radius: 4px;
+  @apply rounded-sm bg-muted/25;
   position: absolute;
   pointer-events: none;
 

--- a/packages/styles/components/tag.css
+++ b/packages/styles/components/tag.css
@@ -2,7 +2,7 @@
 .tag {
   --optical-offset: 0.031em;
 
-  @apply relative inline-flex items-center gap-1 rounded-full font-medium select-none no-highlight;
+  @apply relative inline-flex items-center gap-1 rounded-xl font-medium select-none no-highlight;
 
   /**
    * Transitions
@@ -61,7 +61,7 @@
 }
 
 .tag--lg {
-  @apply px-2.5 py-1.5 text-sm;
+  @apply rounded-2xl px-2.5 py-1.5 text-sm;
 }
 
 /* Variant */

--- a/packages/styles/components/toggle-button-group.css
+++ b/packages/styles/components/toggle-button-group.css
@@ -89,9 +89,7 @@
    ========================================================================== */
 
 .toggle-button-group__separator {
-  @apply bg-current opacity-15;
-
-  border-radius: 4px;
+  @apply rounded-sm bg-current opacity-15;
   position: absolute;
   pointer-events: none;
 

--- a/packages/styles/components/toolbar.css
+++ b/packages/styles/components/toolbar.css
@@ -28,5 +28,5 @@
 
 /* Attached variant */
 .toolbar--attached {
-  @apply rounded-full bg-surface p-1 shadow-overlay;
+  @apply rounded-3xl bg-surface p-1 shadow-overlay;
 }


### PR DESCRIPTION
This pull request standardizes and refines the border-radius (rounded) styles across a wide range of UI components in the codebase. The changes replace inconsistent or overly generic rounded utilities (such as `rounded-full`) with more precise and scalable values (like `rounded-2xl`, `rounded-3xl`, `rounded-xs`, etc.), improving visual consistency, scalability, and alignment with the design system.

**Border-radius standardization across components:**

* Avatar, modal, and alert-dialog components now use `rounded-3xl` for large round elements, and smaller sizes use `rounded-2xl` or `rounded-lg` as appropriate, replacing previous use of `rounded-full` or no explicit rounding. (`avatar.css` [[1]](diffhunk://#diff-806bc2a140010125db3639154f0e13a7d13da1b074024f6305d8b44850a13281L3-R3) [[2]](diffhunk://#diff-806bc2a140010125db3639154f0e13a7d13da1b074024f6305d8b44850a13281L23-R31); `modal.css` [[3]](diffhunk://#diff-198214ec1fd6ceda47ed7914897638d3bd9bc0ad8368b88371a3cf57b0a0b784L279-R279); `alert-dialog.css` [[4]](diffhunk://#diff-05b74edae5ab33ddcf5c52b9dc17e760fa3f0d6a40868e3f17bf160bd351a4f5L231-R231)
* Calendar, range-calendar, and calendar-year-picker components have had their navigation buttons, cells, and indicators updated to use specific rounded values like `rounded-2xl`, `rounded-3xl`, and `rounded-xs` for improved consistency and clarity. (`calendar.css` [[1]](diffhunk://#diff-cb341a87df9f211402dfb618f31e227d633cd0b673ccfb5f3098c11b6acae5cfL35-R35) [[2]](diffhunk://#diff-cb341a87df9f211402dfb618f31e227d633cd0b673ccfb5f3098c11b6acae5cfL212-R212); `range-calendar.css` [[3]](diffhunk://#diff-5c494db0ac9e3fe95b7ebeb9b7fb0bcb42115b6c28dc7302059cc764722e1eb6L35-R35) [[4]](diffhunk://#diff-5c494db0ac9e3fe95b7ebeb9b7fb0bcb42115b6c28dc7302059cc764722e1eb6L137-R137) [[5]](diffhunk://#diff-5c494db0ac9e3fe95b7ebeb9b7fb0bcb42115b6c28dc7302059cc764722e1eb6L152-R152) [[6]](diffhunk://#diff-5c494db0ac9e3fe95b7ebeb9b7fb0bcb42115b6c28dc7302059cc764722e1eb6L185-R192) [[7]](diffhunk://#diff-5c494db0ac9e3fe95b7ebeb9b7fb0bcb42115b6c28dc7302059cc764722e1eb6L211-R215) [[8]](diffhunk://#diff-5c494db0ac9e3fe95b7ebeb9b7fb0bcb42115b6c28dc7302059cc764722e1eb6L278-R278); `calendar-year-picker.css` [[9]](diffhunk://#diff-e414e24fd9781f91023284698dd051604617c2e9e54ab99e98cdddead2bc41c9L153-R153)
* Color-related components (color-area, color-slider, color-swatch, color-swatch-picker) now use explicit rounded utilities (`rounded-xl`, `rounded-2xl`, `rounded-3xl`, `rounded-lg`, etc.) for thumbs, tracks, and swatches, instead of defaulting to `rounded-full` or custom pixel values. (`color-area.css` [[1]](diffhunk://#diff-8e5f65ba767300f2b38b29d77eebcb8715f1e665aae0e2738a59a060b0604022L44-R44); `color-slider.css` [[2]](diffhunk://#diff-fca46da8148e5aab61a0bfc91c777de05f4062950a85638dffaa5236fcb7d6d8L56-R56) [[3]](diffhunk://#diff-fca46da8148e5aab61a0bfc91c777de05f4062950a85638dffaa5236fcb7d6d8L71-R71) [[4]](diffhunk://#diff-fca46da8148e5aab61a0bfc91c777de05f4062950a85638dffaa5236fcb7d6d8R136-L138) [[5]](diffhunk://#diff-fca46da8148e5aab61a0bfc91c777de05f4062950a85638dffaa5236fcb7d6d8R148-L151); `color-swatch.css` [[6]](diffhunk://#diff-d1b1907d1988a5e4ba0d8bf4361162387e8a2c8b9829c596399144e6f93cdf25L16-R16) [[7]](diffhunk://#diff-d1b1907d1988a5e4ba0d8bf4361162387e8a2c8b9829c596399144e6f93cdf25R26-R57); `color-swatch-picker.css` [[8]](diffhunk://#diff-45050b550c2567e687c93739ec583e8e7c0276b4ecf7c2026cfc0d3f6666f44bL15-R15) [[9]](diffhunk://#diff-45050b550c2567e687c93739ec583e8e7c0276b4ecf7c2026cfc0d3f6666f44bL124-R130) [[10]](diffhunk://#diff-45050b550c2567e687c93739ec583e8e7c0276b4ecf7c2026cfc0d3f6666f44bL142-R148) [[11]](diffhunk://#diff-45050b550c2567e687c93739ec583e8e7c0276b4ecf7c2026cfc0d3f6666f44bL158-R158)
* Meter and progress-bar components have had their tracks and fills updated to use `rounded-sm`, `rounded-xs`, and `rounded-md` depending on size, replacing `rounded-full`. (`meter.css` [[1]](diffhunk://#diff-7694910325c77969dcc233fae8cb805dfde335cc8b67bc6ccc114bdedd8472caL29-R29) [[2]](diffhunk://#diff-7694910325c77969dcc233fae8cb805dfde335cc8b67bc6ccc114bdedd8472caL38-R38) [[3]](diffhunk://#diff-7694910325c77969dcc233fae8cb805dfde335cc8b67bc6ccc114bdedd8472caL68-R72) [[4]](diffhunk://#diff-7694910325c77969dcc233fae8cb805dfde335cc8b67bc6ccc114bdedd8472caL78-R86); `progress-bar.css` [[5]](diffhunk://#diff-cd9174e8763b237d150f63fd507c0712092df6d13db29e3841e966628ce61058L29-R29) [[6]](diffhunk://#diff-cd9174e8763b237d150f63fd507c0712092df6d13db29e3841e966628ce61058L38-R38) [[7]](diffhunk://#diff-cd9174e8763b237d150f63fd507c0712092df6d13db29e3841e966628ce61058L92-R96) [[8]](diffhunk://#diff-cd9174e8763b237d150f63fd507c0712092df6d13db29e3841e966628ce61058L102-R110)
* Radio, button-group, input-otp, drawer, and accordion components now use more precise rounded values (`rounded-lg`, `rounded-sm`, `rounded-xs`, etc.) for controls and separators, replacing previous generic or pixel-based rounding. (`radio.css` [[1]](diffhunk://#diff-af2cfcde2b690c828088037ab0cca5da5c9f898d0393b0ee70158b393b05706eL31-R31) [[2]](diffhunk://#diff-af2cfcde2b690c828088037ab0cca5da5c9f898d0393b0ee70158b393b05706eL115-R115); `button-group.css` [[3]](diffhunk://#diff-9f2a166b087b3411f9139657aec53de1fd785145bf57aebeb1a82f7b00436c0fL75-R75); `input-otp.css` [[4]](diffhunk://#diff-da8ce0e863ce3a4e6d73eb2e77c3e76998f8a35af942dbc6141f194257eafe56L80-R85); `drawer.css` [[5]](diffhunk://#diff-62c682787391bae4d8b436403526dae562a74dae5b1697eda2d0140f9a86fa0bL261-R261); `accordion.css` [[6]](diffhunk://#diff-93c609aee1e8046ab57926214cb3001d2ddc12afdacacf52b4942a735d9f9ab6L43-R43)

These updates ensure a more consistent and maintainable visual language throughout the UI, making it easier to scale and update the design system in the future.