### PR TITLE
fix(docs): keep sidebar scroll within viewport

### DIFF
--- a/apps/docs/src/app/docs/layout.tsx
+++ b/apps/docs/src/app/docs/layout.tsx
@@ -1,8 +1,9 @@
-import type {ReactNode} from "react";
+import type {CSSProperties, ReactNode} from "react";
 
 import {Separator} from "@heroui/react";
 
 import {HeaderBanner, ProBanner} from "@/app/(home)/components/pro-banner";
+import {SHOW_BANNER} from "@/app/(home)/components/pro-constants";
 import {baseOptions} from "@/app/layout.config";
 import {FrameworksTabs} from "@/components/frameworks-tabs";
 import {DocsLayout} from "@/components/fumadocs/layouts/notebook";
@@ -12,11 +13,21 @@ import {HeroUILogo} from "@/components/heroui-logo";
 import {VersionSelector} from "@/components/version-selector";
 import {source} from "@/lib/source";
 
+const DOCS_TOP_BANNER_HEIGHT = "2rem";
+
 export default function Layout({children}: {children: ReactNode}) {
+  // The top banner is rendered in normal flow, so --fd-banner-height would incorrectly
+  // offset sticky docs elements after the banner scrolls away. Reduce only the docs
+  // viewport height to keep the sidebar scroll area inside the visible viewport.
+  const layoutStyle = SHOW_BANNER
+    ? ({"--fd-docs-height": `calc(100dvh - ${DOCS_TOP_BANNER_HEIGHT})`} as CSSProperties)
+    : undefined;
+
   return (
     <>
       <HeaderBanner />
       <DocsLayout
+        containerProps={{style: layoutStyle}}
         tabMode="navbar"
         tree={source.pageTree}
         sidebar={{


### PR DESCRIPTION
## Description

Fixes the docs sidebar scroll area when the top banner is rendered.

The docs top banner is rendered in normal flow, so using `--fd-banner-height` would incorrectly offset sticky docs elements after the banner scrolls away. This instead reduces the docs viewport height only when the banner is enabled, keeping the sidebar scroll area within the visible viewport without changing the banner's sticky behavior.

## Current behavior

On docs pages with the top banner visible, the left sidebar scroll area can extend past the visible viewport, causing the bottom items to be clipped or hard to reach.

## New behavior

When the top banner is enabled, the notebook layout receives a reduced `--fd-docs-height` so the sidebar scroll container fits inside the visible viewport.

## Breaking change

No.

## Verification

- Ran `pnpm --filter @heroui/docs typecheck`
- Manually checked `/docs/react/components` locally with `NEXT_PUBLIC_SHOW_PRE_SALE_BANNER=true`