### PR TITLE
chore: add AGENTS.md and configure pnpm onlyBuiltDependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Environment Prerequisites
+
+- **Node.js v22+** is required (installed via binary tarball to `/usr/local/`)
+- **pnpm v10.26.2** is the package manager (activated via `corepack`)
+- The `packageManager` field in root `package.json` declares `pnpm@10.26.2`
+
+### Key Commands
+
+All standard commands are documented in `CLAUDE.md` and `CONTRIBUTING.md`. Quick reference:
+
+| Action | Command |
+|--------|---------|
+| Install deps | `pnpm i --hoist` |
+| Lint | `pnpm lint` |
+| Build | `pnpm build` |
+| Dev (Storybook) | `pnpm dev` (runs on port 6006) |
+| Dev (Docs) | `pnpm dev:docs` (runs on port 3000) |
+| Test | `pnpm test` |
+| Typecheck | `pnpm typecheck` |
+
+### Non-obvious Gotchas
+
+1. **Native build scripts**: The `pnpm.onlyBuiltDependencies` field in root `package.json` allows native addon compilation for `esbuild`, `@swc/core`, `@parcel/watcher`, etc. If this field is missing or packages are added, you'll see "Ignored build scripts" warnings and Storybook/builds may fail.
+
+2. **postinstall runs builds**: `pnpm i` triggers a `postinstall` hook that builds `@heroui/styles` and runs `typegen:docs`. If it fails (e.g., network issue on first install), run `pnpm --filter @heroui/styles build` manually.
+
+3. **No test files currently exist**: `pnpm test` completes with no output because there are no `*.test.*` or `*.spec.*` files yet. The vitest config package exists at `packages/vitest` but no tests are authored yet.
+
+4. **Commit hooks (Husky)**: Pre-commit runs `lint-staged`, commit-msg runs `commitlint`. All commits must follow `type(scope): message` convention (see `CLAUDE.md` for allowed types).
+
+5. **Storybook is the primary dev workflow**: `pnpm dev` starts Storybook at port 6006. This is the recommended way to develop and test components visually.
+
+6. **Build order matters**: Turbo handles `^build` dependencies. `@heroui/styles` must build before `@heroui/react`. Running `pnpm build` from root handles this automatically.

--- a/package.json
+++ b/package.json
@@ -101,7 +101,18 @@
     "overrides": {
       "shiki": "3.20.0",
       "ts-morph": "27.0.2"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@swc/core",
+      "core-js",
+      "esbuild",
+      "lmdb",
+      "msgpackr-extract",
+      "protobufjs",
+      "sharp",
+      "unrs-resolver"
+    ]
   },
   "engines": {
     "node": ">=20.x",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Add `AGENTS.md` with Cursor Cloud specific development instructions and configure `pnpm.onlyBuiltDependencies` in root `package.json` to allow native addon builds (esbuild, @swc/core, @parcel/watcher, etc.) without interactive approval.

## ⛳️ Current behavior (updates)

- No `AGENTS.md` file existed for cloud agent instructions
- Native dependencies like `esbuild` and `@swc/core` required interactive `pnpm approve-builds` to compile their platform binaries

## 🚀 New behavior

- `AGENTS.md` provides non-obvious development caveats for future cloud agents
- `pnpm.onlyBuiltDependencies` allows critical native packages to build automatically during `pnpm install`, enabling non-interactive CI/cloud setups

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

### Environment verification

- Node.js v22.15.0, pnpm v10.26.2
- All lint checks pass (`pnpm lint`)
- Build succeeds (`pnpm build`)
- Storybook dev server starts and serves components on port 6006

[storybook_demo.mp4](https://cursor.com/agents/bc-558755f5-9467-430c-88aa-b369f97b6c0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_demo.mp4)

[Storybook Button Sizes story](https://cursor.com/agents/bc-558755f5-9467-430c-88aa-b369f97b6c0b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_button_sizes.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-558755f5-9467-430c-88aa-b369f97b6c0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-558755f5-9467-430c-88aa-b369f97b6c0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

