### PR TITLE
docs(drawer): add confirm close demo

### DIFF
--- a/apps/docs/content/docs/react/components/(overlays)/drawer.mdx
+++ b/apps/docs/content/docs/react/components/(overlays)/drawer.mdx
@@ -72,6 +72,12 @@ The `Drawer.Body` automatically handles overflow with native scrolling. Drag-to-
 
 <ComponentPreview name="drawer-with-form" />
 
+### Confirm Close
+
+Use controlled state to keep the drawer open while asking the user to confirm before discarding unsaved changes.
+
+<ComponentPreview name="drawer-confirm-close" />
+
 ### Navigation Drawer
 
 <ComponentPreview name="drawer-navigation" />

--- a/apps/docs/src/demos/drawer/confirm-close.tsx
+++ b/apps/docs/src/demos/drawer/confirm-close.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {AlertDialog, Button, Description, Drawer, Label, TextArea, TextField} from "@heroui/react";
+import React from "react";
+
+export function ConfirmClose() {
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = React.useState(false);
+  const [draftNote, setDraftNote] = React.useState("");
+  const [savedNote, setSavedNote] = React.useState("");
+
+  const hasUnsavedChanges = draftNote !== savedNote;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSavedNote(draftNote);
+    setIsDrawerOpen(false);
+  };
+
+  const handleDrawerOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setIsDrawerOpen(true);
+
+      return;
+    }
+
+    if (hasUnsavedChanges) {
+      setIsConfirmOpen(true);
+
+      return;
+    }
+
+    setIsDrawerOpen(false);
+  };
+
+  const discardChanges = () => {
+    setDraftNote(savedNote);
+    setIsConfirmOpen(false);
+    setIsDrawerOpen(false);
+  };
+
+  return (
+    <div className="flex w-full max-w-md flex-col items-start gap-3 rounded-2xl bg-surface p-4 shadow-sm">
+      <div className="flex w-full flex-col gap-1">
+        <p className="text-xs text-muted">
+          Saved note:{" "}
+          <span className="font-mono font-medium text-foreground">
+            {savedNote ? "saved" : "empty"}
+          </span>
+        </p>
+        <p className="line-clamp-2 text-sm leading-6 text-foreground">
+          {savedNote || "No note saved yet."}
+        </p>
+      </div>
+      <Button size="sm" variant="secondary" onPress={() => setIsDrawerOpen(true)}>
+        Open Drawer
+      </Button>
+
+      <Drawer.Backdrop isOpen={isDrawerOpen} onOpenChange={handleDrawerOpenChange}>
+        <Drawer.Content placement="right">
+          <Drawer.Dialog>
+            <Drawer.CloseTrigger />
+            <Drawer.Header>
+              <Drawer.Heading>Edit note</Drawer.Heading>
+              <Description>Save your note, or discard it if you change your mind.</Description>
+            </Drawer.Header>
+            <Drawer.Body>
+              <form className="flex flex-col gap-4" id="drawer-note-form" onSubmit={handleSubmit}>
+                <TextField name="note" value={draftNote} onChange={setDraftNote}>
+                  <Label>Note</Label>
+                  <TextArea autoFocus placeholder="Write a short note..." rows={8} />
+                </TextField>
+              </form>
+            </Drawer.Body>
+            <Drawer.Footer>
+              <Button
+                type="button"
+                variant="secondary"
+                onPress={() => handleDrawerOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button form="drawer-note-form" type="submit">
+                Save note
+              </Button>
+            </Drawer.Footer>
+          </Drawer.Dialog>
+        </Drawer.Content>
+      </Drawer.Backdrop>
+
+      <AlertDialog.Backdrop isOpen={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <AlertDialog.Container>
+          <AlertDialog.Dialog className="sm:max-w-[400px]">
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Icon status="warning" />
+              <AlertDialog.Heading>Discard changes?</AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body>
+              <p>You have unsaved changes. If you leave now, they will be lost.</p>
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button slot="close" variant="tertiary">
+                Keep editing
+              </Button>
+              <Button variant="danger" onPress={discardChanges}>
+                Discard changes
+              </Button>
+            </AlertDialog.Footer>
+          </AlertDialog.Dialog>
+        </AlertDialog.Container>
+      </AlertDialog.Backdrop>
+    </div>
+  );
+}

--- a/apps/docs/src/demos/drawer/index.ts
+++ b/apps/docs/src/demos/drawer/index.ts
@@ -1,6 +1,7 @@
 export {BackdropVariants} from "./backdrop-variants";
 export {Basic} from "./basic";
 export {Controlled} from "./controlled";
+export {ConfirmClose} from "./confirm-close";
 export {Navigation} from "./navigation";
 export {NonDismissable} from "./non-dismissable";
 export {Placements} from "./placements";

--- a/apps/docs/src/demos/index.ts
+++ b/apps/docs/src/demos/index.ts
@@ -1015,6 +1015,10 @@ export const demos: Record<string, DemoItem> = {
     component: DrawerDemos.Controlled,
     file: "drawer/controlled.tsx",
   },
+  "drawer-confirm-close": {
+    component: DrawerDemos.ConfirmClose,
+    file: "drawer/confirm-close.tsx",
+  },
   // Disclosure demos
   "disclosure-basic": {
     component: DisclosureDemos.Basic,


### PR DESCRIPTION
## Summary

Adds a Drawer documentation example that shows how to confirm before closing when a form has unsaved changes.

The demo uses controlled Drawer state to keep the Drawer open when a close request happens, then opens an AlertDialog so the user can either keep editing or discard the draft.

## Why

This is a common pattern for form-like Drawer usage, and it complements the existing `With Form` and `Controlled State` examples by showing how they can be composed with AlertDialog.

## Notes

I tried to keep the example aligned with the existing Drawer demos by using a simple single-scenario layout and avoiding extra explanatory UI inside the demo.

If this recipe does not fit the direction or scope of the HeroUI docs, I’m happy to adjust it or close the PR.

## Validation

- `pnpm exec prettier --check apps/docs/src/demos/drawer/confirm-close.tsx apps/docs/src/demos/drawer/index.ts apps/docs/src/demos/index.ts 'apps/docs/content/docs/react/components/(overlays)/drawer.mdx'`
- `pnpm typecheck:docs`
- `pnpm lint:docs`