### PR TITLE
refactor(styles): table focus

### DIFF
--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -228,11 +228,10 @@
     @apply status-disabled;
   }
 
-  /* Focus visible — use outline instead of ring for better table row rendering */
+  /* Row focus ring: see “Table row focus ring” block below (after `.table__cell`). */
   &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
-    box-shadow: inset 0 0 0 2px var(--color-focus);
   }
 
   /* Dragging state */
@@ -260,6 +259,48 @@
     @apply rounded-lg outline-none;
     box-shadow: inset 0 0 0 2px var(--color-focus);
   }
+}
+
+/* --------------------------------------------------------------------------
+   Table row focus ring — must follow `.table__cell` (cascade). One continuous
+   inset ring split across cells; `:is(.table__cell, .table__column)` + direct vs
+   `> *:…` covers virtualized wrappers. `:is(:focus-visible, [data-focus-visible])`
+   matches row keyboard focus from RAC.
+   -------------------------------------------------------------------------- */
+.table__row:is(:focus-visible, [data-focus-visible="true"]) :is(.table__cell, .table__column) {
+  @apply shadow-none;
+}
+
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > :is(.table__cell, .table__column):only-child,
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > *:only-child
+  :is(.table__cell, .table__column) {
+  @apply rounded-lg shadow-[inset_0_0_0_2px_var(--color-focus)] outline-none;
+}
+
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > :is(.table__cell, .table__column):first-child:not(:only-child),
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > *:first-child:not(:only-child)
+  :is(.table__cell, .table__column) {
+  @apply rounded-l-lg shadow-[inset_2px_0_0_0_var(--color-focus),inset_0_2px_0_0_var(--color-focus),inset_0_-2px_0_0_var(--color-focus)] outline-none;
+}
+
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > :is(.table__cell, .table__column):last-child:not(:only-child),
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > *:last-child:not(:only-child)
+  :is(.table__cell, .table__column) {
+  @apply rounded-r-lg shadow-[inset_-2px_0_0_0_var(--color-focus),inset_0_2px_0_0_var(--color-focus),inset_0_-2px_0_0_var(--color-focus)] outline-none;
+}
+
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > :is(.table__cell, .table__column):not(:first-child):not(:last-child):not(:only-child),
+.table__row:is(:focus-visible, [data-focus-visible="true"])
+  > *:not(:first-child):not(:last-child):not(:only-child)
+  :is(.table__cell, .table__column) {
+  @apply shadow-[inset_0_2px_0_0_var(--color-focus),inset_0_-2px_0_0_var(--color-focus)] outline-none;
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

- Originally reported from discord [here](https://discord.com/channels/856545348885676062/1494736637781868564). 
- This PR is to update `table.css` so row keyboard focus draws one continuous focus ring around the row (same token as cells), avoids extra vertical strokes between columns, and works for virtualized tables where VirtualizerItem wraps cells. 
- Per-cell focus styles are cleared while the row is focused so React Aria’s row + gridcell focus does not show a second ring.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="627" height="249" alt="image" src="https://github.com/user-attachments/assets/c5efd072-13f7-4344-bbf2-bcca30eb545b" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="609" height="237" alt="image" src="https://github.com/user-attachments/assets/5ec5205a-6776-4da6-a5e9-41c7f5027501" />

<img width="627" height="262" alt="image" src="https://github.com/user-attachments/assets/16c20359-153d-43e8-9c3e-6dd9fdb3980b" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
