### PR TITLE
fix(styles): revise tooltip padding

### DIFF
--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -2,7 +2,7 @@
 
 /* Base tooltip styles */
 .tooltip {
-  @apply max-w-xs origin-(--trigger-anchor-point) rounded-xl bg-overlay px-2 py-1 text-xs break-all;
+  @apply max-w-xs origin-(--trigger-anchor-point) rounded-xl bg-overlay p-2 text-xs break-all;
   box-shadow: var(--shadow-overlay);
 
   /* Entering animations */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

There is some space between the tooltip arrow and the content due to the radius of the content. This PR is to revise the tooltip padding to make it more nature and consistent with the popover ones.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="766" height="198" alt="image" src="https://github.com/user-attachments/assets/e224f649-65b0-47cc-83f0-8098bd5d47f5" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="654" height="212" alt="image" src="https://github.com/user-attachments/assets/0c5ad76f-acac-48ff-af6e-895ab2298417" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
