### PR TITLE
fix(styles): remove description horizontal padding from form fields

### DIFF
--- a/packages/styles/components/color-field.css
+++ b/packages/styles/components/color-field.css
@@ -16,10 +16,6 @@
   [data-slot="label"] {
     @apply w-fit;
   }
-
-  [data-slot="description"] {
-    @apply px-1;
-  }
 }
 
 /* Full width modifier */

--- a/packages/styles/components/combo-box.css
+++ b/packages/styles/components/combo-box.css
@@ -13,10 +13,6 @@
     @apply w-fit;
   }
 
-  [data-slot="description"] {
-    @apply px-1;
-  }
-
   [data-slot="input"] {
     @apply min-w-0 flex-1;
 

--- a/packages/styles/components/date-field.css
+++ b/packages/styles/components/date-field.css
@@ -12,10 +12,6 @@
   [data-slot="label"] {
     @apply w-fit;
   }
-
-  [data-slot="description"] {
-    @apply px-1;
-  }
 }
 
 /* Full width modifier */

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -12,10 +12,6 @@
   [data-slot="label"] {
     @apply w-fit;
   }
-
-  [data-slot="description"] {
-    @apply px-1;
-  }
 }
 
 .number-field__group {

--- a/packages/styles/components/search-field.css
+++ b/packages/styles/components/search-field.css
@@ -13,10 +13,6 @@
     @apply w-fit;
   }
 
-  [data-slot="description"] {
-    @apply px-1;
-  }
-
   &[data-empty="true"] {
     [data-slot="search-field-clear-button"] {
       @apply pointer-events-none opacity-0;

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -12,10 +12,6 @@
   [data-slot="label"] {
     @apply w-fit;
   }
-
-  [data-slot="description"] {
-    @apply px-1;
-  }
 }
 
 .select__trigger {

--- a/packages/styles/components/textfield.css
+++ b/packages/styles/components/textfield.css
@@ -9,10 +9,6 @@
       @apply hidden;
     }
   }
-
-  [data-slot="description"] {
-    @apply px-1;
-  }
 }
 
 /* Full width modifier */

--- a/packages/styles/components/time-field.css
+++ b/packages/styles/components/time-field.css
@@ -12,10 +12,6 @@
   [data-slot="label"] {
     @apply w-fit;
   }
-
-  [data-slot="description"] {
-    @apply px-1;
-  }
 }
 
 /* Full width modifier */


### PR DESCRIPTION
## Summary
- Remove `px-1` from Description/helper text styles in v3 form field components
- Keeps description text aligned flush with the field wrapper
- Recreated cleanly from `v3.0.4` after closing #6482, which was accidentally branched from `main`

Resolves HHTA-749

## Validation
- `git diff --check` ✅
- `pnpm --filter @heroui/styles typecheck` blocked locally: `node_modules` missing, `tsc: command not found`