### PR TITLE
feat: Redesign colors documentation with light/dark previews and CSS variables

### DIFF
--- a/apps/docs/content/docs/native/getting-started/(handbook)/colors.mdx
+++ b/apps/docs/content/docs/native/getting-started/(handbook)/colors.mdx
@@ -7,7 +7,7 @@ links:
   tailwind: theme
 ---
 
-import {ColorSectionSideBySide, ColorSectionStacked, ColorSectionFormField} from "@/components/color-section";
+import {ColorSectionSideBySide, ColorSectionStacked, ColorSectionFormField, ColorSectionPrimitive} from "@/components/color-section";
 
 HeroUI Native's color system is built around semantic intent, not visual abundance. Instead of exposing large raw palettes, the system defines a small, meaningful set of color roles that cover the majority of interface needs.
 
@@ -212,6 +212,19 @@ Other colors serve specific utility roles across the interface. They exist to st
     { label: "Backdrop", variable: "--backdrop" },
     { label: "Overlay", variable: "--overlay", border: true },
     { label: "Segment", variable: "--segment", border: true },
+  ]}
+/>
+
+## Primitive
+
+Primitive colors are mode agnostic values used as foundations for semantic color tokens. They do not change between light and dark themes.
+
+<ColorSectionPrimitive
+  colors={[
+    { label: "White", variable: "--white", border: true, tooltip: "--white: oklch(100% 0 0)" },
+    { label: "Black", variable: "--black", tooltip: "--black: oklch(0% 0 0)" },
+    { label: "Snow", variable: "--snow", border: true, tooltip: "--snow: oklch(0.9911 0 0)" },
+    { label: "Eclipse", variable: "--eclipse", tooltip: "--eclipse: oklch(0.2103 0.0059 285.89)" },
   ]}
 />
 

--- a/apps/docs/content/docs/native/getting-started/(handbook)/colors.mdx
+++ b/apps/docs/content/docs/native/getting-started/(handbook)/colors.mdx
@@ -7,108 +7,211 @@ links:
   tailwind: theme
 ---
 
-import {ColorSwatch, ColorPalette} from "@/components/color-swatch";
+import {ColorSectionSideBySide, ColorSectionStacked, ColorSectionFormField} from "@/components/color-section";
 
-HeroUI Native uses CSS variables for colors that automatically switch between light and dark themes. All colors use the `oklch` color space for better color transitions.
+HeroUI Native's color system is built around semantic intent, not visual abundance. Instead of exposing large raw palettes, the system defines a small, meaningful set of color roles that cover the majority of interface needs.
 
-## How It Works
+Most colors in the system are derived automatically from a limited number of base values. This allows HeroUI to maintain consistent contrast, hierarchy, and theming behavior while keeping the system easy to reason about and modify.
 
-HeroUI Native's color system is built on top of [Tailwind CSS v4](https://tailwindcss.com/docs/theme)'s theme via [Uniwind](https://uniwind.dev/). When you import `heroui-native/styles`, it uses Tailwind's built-in color palettes and maps them to semantic variables.
+Colors should communicate purpose and state first. Visual variation comes from scale, emphasis, and context.
 
-**Naming pattern:**
+## Accent
 
-- Colors without a suffix are backgrounds (e.g., `--accent`)
-- Colors with `-foreground` are for text on that background (e.g., `--accent-foreground`)
+The accent color represents the primary brand or product identity. It is used to draw attention to key actions, highlights, and moments of emphasis.
 
-**Usage:**
+Accent should be used intentionally and sparingly. Overuse reduces its impact and can harm visual hierarchy. In most cases, components derive multiple accent-related values (hover, subtle backgrounds, focus states) automatically from the base accent color.
 
-```tsx
-import { View, Text } from 'react-native';
+<ColorSectionSideBySide
+  name="Accent"
+  baseVariable="--accent"
+  hoverVariable="--accent"
+  hoverCssValue="color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%)"
+  foregroundVariable="--accent-foreground"
+  soft={{
+    baseVariable: "--accent",
+    baseCssValue: "color-mix(in oklab, var(--accent) 15%, transparent)",
+    hoverVariable: "--accent",
+    hoverCssValue: "color-mix(in oklab, var(--accent) 20%, transparent)",
+    foregroundVariable: "--accent",
+    foregroundCssValue: "var(--accent)",
+  }}
+/>
 
-// This gives you the right background and text colors
-<View className="bg-background flex-1">
-  <View className="bg-accent p-4 rounded-lg">
-    <Text className="text-accent-foreground">Hello</Text>
-  </View>
-</View>;
-```
+## Default (neutrals)
 
-### Base Colors
+Default colors form the neutral backbone of the system. They are used for most non-emphasized UI elements.
 
-These four colors stay the same in all themes:
+<ColorSectionSideBySide
+  name="Default"
+  baseVariable="--default"
+  hoverVariable="--default"
+  hoverCssValue="color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%)"
+  foregroundVariable="--default-foreground"
+/>
 
-<div className="flex flex-wrap gap-4 sm:gap-6">
-  <ColorSwatch name="White" variable="--white" />
-  <ColorSwatch name="Black" variable="--black" />
-  <ColorSwatch name="Snow" variable="--snow" />
-  <ColorSwatch name="Eclipse" variable="--eclipse" />
-</div>
+## Success
 
-### Background & Surface
+Success colors communicate positive outcomes, confirmations, and completed states. They are typically used in feedback components, status indicators, and validation states.
 
-<ColorPalette
-  colors={[
-    { name: "Background", variable: "--background", foreground: "--foreground" },
-    { name: "Foreground", variable: "--foreground" },
-    { name: "Surface", variable: "--surface", foreground: "--surface-foreground" },
-    { name: "Surface Foreground", variable: "--surface-foreground" },
-    { name: "Overlay", variable: "--overlay", foreground: "--overlay-foreground" },
-    { name: "Overlay Foreground", variable: "--overlay-foreground" },
+<ColorSectionSideBySide
+  name="Success"
+  baseVariable="--success"
+  hoverVariable="--success"
+  hoverCssValue="color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%)"
+  foregroundVariable="--success-foreground"
+  soft={{
+    baseVariable: "--success",
+    baseCssValue: "color-mix(in oklab, var(--success) 15%, transparent)",
+    hoverVariable: "--success",
+    hoverCssValue: "color-mix(in oklab, var(--success) 20%, transparent)",
+    foregroundVariable: "--success",
+    foregroundCssValue: "var(--success)",
+  }}
+/>
+
+## Warning
+
+Warning colors indicate caution, risk, or actions that require attention but are not destructive. They are commonly used for alerts, messages, and transitional states where the user should pause or review information.
+
+<ColorSectionSideBySide
+  name="Warning"
+  baseVariable="--warning"
+  hoverVariable="--warning"
+  hoverCssValue="color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%)"
+  foregroundVariable="--warning-foreground"
+  soft={{
+    baseVariable: "--warning",
+    baseCssValue: "color-mix(in oklab, var(--warning) 15%, transparent)",
+    hoverVariable: "--warning",
+    hoverCssValue: "color-mix(in oklab, var(--warning) 20%, transparent)",
+    foregroundVariable: "--warning",
+    foregroundCssValue: "var(--warning)",
+  }}
+/>
+
+## Danger
+
+Danger colors represent destructive, irreversible, or critical actions and states. They should be immediately recognizable and used consistently for errors, destructive buttons, and critical alerts.
+
+<ColorSectionSideBySide
+  name="Danger"
+  baseVariable="--danger"
+  hoverVariable="--danger"
+  hoverCssValue="color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%)"
+  foregroundVariable="--danger-foreground"
+  soft={{
+    baseVariable: "--danger",
+    baseCssValue: "color-mix(in oklab, var(--danger) 15%, transparent)",
+    hoverVariable: "--danger",
+    hoverCssValue: "color-mix(in oklab, var(--danger) 20%, transparent)",
+    foregroundVariable: "--danger",
+    foregroundCssValue: "var(--danger)",
+  }}
+/>
+
+## Foreground
+
+Foreground colors are used for primary content such as text and icons. These colors are optimized for readability and accessibility and adapt automatically to background and surface contexts. Foreground colors should never be hard-coded at the component level.
+
+<ColorSectionStacked
+  lightColors={[
+    { label: "Foreground", variable: "--foreground" },
+    { label: "Muted", variable: "--muted" },
+    { label: "Segment", variable: "--segment" },
+    { label: "Overlay", variable: "--overlay" },
+    { label: "Link", variable: "--link" },
+  ]}
+  darkColors={[
+    { label: "Foreground", variable: "--foreground", border: true },
+    { label: "Muted", variable: "--muted", border: true },
+    { label: "Segment", variable: "--segment", border: true },
+    { label: "Overlay", variable: "--overlay", border: true },
+    { label: "Link", variable: "--link", border: true },
   ]}
 />
 
-### Primary Colors
+## Background
 
-**Accent** — Your main brand color (used for primary actions)
-**Accent Soft** — A lighter version for secondary actions
+Background colors define the base canvas of the interface. They establish overall contrast and mood while staying visually quiet.
 
-<ColorPalette
-  colors={[
-    { name: "Accent", variable: "--accent", foreground: "--accent-foreground" },
-    { name: "Accent Foreground", variable: "--accent-foreground" },
-    { name: "Accent Soft", variable: "--accent-soft", foreground: "--accent-soft-foreground" },
-    { name: "Accent Soft Foreground", variable: "--accent-soft-foreground" },
+<ColorSectionStacked
+  lightColors={[
+    { label: "Background", variable: "--background", border: true },
+    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true },
+    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true },
+    { label: "Inverse", variable: "--foreground" },
+  ]}
+  darkColors={[
+    { label: "Background", variable: "--background", border: true },
+    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true },
+    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true },
+    { label: "Inverse", variable: "--foreground", border: true },
   ]}
 />
 
-### Status Colors
+## Surface
 
-For alerts, validation, and status messages:
+Surface colors sit on top of backgrounds and are used for containers such as cards, panels, modals, and dropdown. Surfaces help create visual separation and hierarchy through elevation, contrast, and layering rather than strong color shifts.
 
-<ColorPalette
-  colors={[
-    { name: "Success", variable: "--success", foreground: "--success-foreground" },
-    { name: "Success Foreground", variable: "--success-foreground" },
-    { name: "Warning", variable: "--warning", foreground: "--warning-foreground" },
-    { name: "Warning Foreground", variable: "--warning-foreground" },
-    { name: "Danger", variable: "--danger", foreground: "--danger-foreground" },
-    { name: "Danger Foreground", variable: "--danger-foreground" },
+<ColorSectionStacked
+  lightColors={[
+    { label: "Surface", variable: "--surface", border: true },
+    { label: "Secondary", variable: "--surface-secondary", border: true },
+    { label: "Tertiary", variable: "--surface-tertiary", border: true },
+  ]}
+  darkColors={[
+    { label: "Surface", variable: "--surface", border: true },
+    { label: "Secondary", variable: "--surface-secondary", border: true },
+    { label: "Tertiary", variable: "--surface-tertiary", border: true },
   ]}
 />
 
-### Form Field Colors
+## Form field
 
-For consistent form field styling across input components:
+Form field colors are specialized tokens used for inputs, controls, and interactive fields. They account for multiple states such as default, focus, and hover. Isolating them ensures form elements have a distinct visual language from buttons and the rest of the UI.
 
-<ColorPalette
-  colors={[
-    { name: "Field Background", variable: "--field-background", foreground: "--field-foreground" },
-    { name: "Field Foreground", variable: "--field-foreground" },
-    { name: "Field Placeholder", variable: "--field-placeholder" },
-    { name: "Field Border", variable: "--field-border" },
+<ColorSectionFormField
+  colors={{
+    bg: "--field-background",
+    bgHover: "color-mix(in oklab, var(--field-background) 90%, var(--field-foreground) 10%)",
+    placeholder: "--field-placeholder",
+    foreground: "--field-foreground",
+  }}
+/>
+
+## Separator
+
+Separator colors are used for dividers, outlines, and subtle boundaries. They exist to structure content and guide the eye without adding noise. Separator colors should remain low contrast and unobtrusive.
+
+<ColorSectionStacked
+  lightColors={[
+    { label: "Separator", variable: "--separator", border: true },
+    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true },
+    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true },
+  ]}
+  darkColors={[
+    { label: "Separator", variable: "--separator", border: true },
+    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true },
+    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true },
   ]}
 />
 
-### Other Colors
+## Other
 
-<ColorPalette
-  colors={[
-    { name: "Default", variable: "--default", foreground: "--default-foreground" },
-    { name: "Default Foreground", variable: "--default-foreground" },
-    { name: "Muted", variable: "--muted", foreground: "--foreground" },
-    { name: "Border", variable: "--border" },
-    { name: "Focus", variable: "--focus" },
-    { name: "Link", variable: "--link" },
+Other colors serve specific utility roles across the interface. They exist to structure content and guide the eye without adding noise.
+
+<ColorSectionStacked
+  lightColors={[
+    { label: "Border", variable: "--border" },
+    { label: "Backdrop", variable: "--backdrop" },
+    { label: "Overlay", variable: "--overlay", border: true },
+    { label: "Segment", variable: "--segment", border: true },
+  ]}
+  darkColors={[
+    { label: "Border", variable: "--border" },
+    { label: "Backdrop", variable: "--backdrop" },
+    { label: "Overlay", variable: "--overlay", border: true },
+    { label: "Segment", variable: "--segment", border: true },
   ]}
 />
 
@@ -118,7 +221,6 @@ For consistent form field styling across input components:
 
 ```tsx
 import { View, Text } from 'react-native';
-import { Button } from 'heroui-native';
 
 <View className="bg-background flex-1 p-4">
   <Text className="text-foreground mb-4">Content</Text>
@@ -171,7 +273,7 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --background: oklch(0.9702 0 0);
         --foreground: var(--eclipse);
 
-        /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
+        /* Surface */
         --surface: var(--white);
         --surface-foreground: var(--foreground);
 
@@ -181,7 +283,7 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --surface-tertiary: oklch(0.9373 0.0013 286.37);
         --surface-tertiary-foreground: var(--foreground);
 
-        /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
+        /* Overlay */
         --overlay: var(--white);
         --overlay-foreground: var(--foreground);
         --backdrop: oklch(0% 0 0 / 20%);
@@ -198,7 +300,7 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --field-background: var(--white);
         --field-foreground: oklch(0.2103 0.0059 285.89);
         --field-placeholder: var(--muted);
-        --field-border: transparent; /* no border by default on form fields */
+        --field-border: transparent;
 
         /* Status Colors */
         --success: oklch(0.7329 0.1935 150.81);
@@ -219,17 +321,6 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --separator: oklch(74% 0.004 286.32);
         --focus: var(--accent);
         --link: var(--foreground);
-
-        /* Shadows */
-        --surface-shadow:
-          0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
-          0 0 1px 0 rgba(0, 0, 0, 0.06);
-        --overlay-shadow:
-          0 2px 8px 0 rgba(0, 0, 0, 0.02), 0 -6px 12px 0 rgba(0, 0, 0, 0.01),
-          0 14px 28px 0 rgba(0, 0, 0, 0.03);
-        --field-shadow:
-          0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
-          0 0 1px 0 rgba(0, 0, 0, 0.06);
       }
 
       @variant dark {
@@ -237,7 +328,7 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --background: oklch(12% 0.005 285.823);
         --foreground: var(--snow);
 
-        /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
+        /* Surface */
         --surface: oklch(0.2103 0.0059 285.89);
         --surface-foreground: var(--foreground);
 
@@ -247,7 +338,7 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --surface-tertiary: oklch(0.2721 0.0024 247.91);
         --surface-tertiary-foreground: var(--foreground);
 
-        /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) - lighter for contrast */
+        /* Overlay */
         --overlay: oklch(0.2103 0.0059 285.89);
         --overlay-foreground: var(--foreground);
         --backdrop: oklch(0% 0 0 / 20%);
@@ -260,11 +351,11 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --accent: oklch(0.6204 0.195 253.83);
         --accent-foreground: var(--snow);
 
-        /* Form Field Defaults - Colors (only the ones that are different from light theme) */
+        /* Form Fields */
         --field-background: oklch(0.2103 0.0059 285.89);
         --field-foreground: var(--foreground);
         --field-placeholder: var(--muted);
-        --field-border: transparent; /* no border by default on form fields */
+        --field-border: transparent;
 
         /* Status Colors */
         --success: oklch(0.7329 0.1935 150.81);
@@ -285,17 +376,11 @@ The complete theme definition can be found in ([variables.css](https://github.co
         --separator: oklch(40% 0.006 286.033);
         --focus: var(--accent);
         --link: var(--foreground);
-
-        /* Shadows */
-        --surface-shadow: 0 0 0 0 transparent inset; /* No shadow on dark mode */
-        --overlay-shadow: 0 0 1px 0 rgba(255, 255, 255, 0.2) inset;
-        --field-shadow: 0 0 0 0 transparent inset; /* Transparent shadow to allow ring utilities to work */
       }
     }
   }
 `}
 />
-
 
 ## Customizing Colors
 
@@ -378,16 +463,3 @@ const [accent, accentForeground, success, danger] = useThemeColor([
 ```
 
 This enhancement improves performance when working with multiple color values and makes it easier to manage complex theming scenarios where multiple colors need to be selected and applied together.
-
-## Quick Tips
-
-- Always use color variables, not hard-coded values
-- Use foreground/background pairs for good contrast
-- Test in both light and dark modes
-- The system respects user's theme preference automatically
-
-## Related
-
-- [Theming](/docs/native/getting-started/theming) - Learn about the theming system
-- [Styling](/docs/native/getting-started/styling) - Styling components with CSS
-- [Design Principles](/docs/native/getting-started/design-principles) - Understanding HeroUI's design philosophy

--- a/apps/docs/content/docs/react/getting-started/(handbook)/colors.mdx
+++ b/apps/docs/content/docs/react/getting-started/(handbook)/colors.mdx
@@ -7,114 +7,215 @@ links:
   tailwind: theme
 ---
 
-import {ColorSwatch, ColorPalette} from "@/components/color-swatch";
+import {ColorSectionSideBySide, ColorSectionStacked, ColorSectionFormField} from "@/components/color-section";
 
-HeroUI uses CSS variables for colors that automatically switch between light and dark themes. All colors use the `oklch` color space for better color transitions.
+HeroUI's color system is built around semantic intent, not visual abundance. Instead of exposing large raw palettes, the system defines a small, meaningful set of color roles that cover the majority of interface needs.
+
+Most colors in the system are derived automatically from a limited number of base values. This allows HeroUI to maintain consistent contrast, hierarchy, and theming behavior while keeping the system easy to reason about and modify.
+
+Colors should communicate purpose and state first. Visual variation comes from scale, emphasis, and context.
 
 <Callout type="info">
   **Want to create your own theme?** Try the [Theme Builder](/themes) to visually customize colors, radius, fonts, and more — then export the CSS to use in your project.
 </Callout>
 
-## How It Works
+## Accent
 
-HeroUI's color system is built on top of Tailwind CSS v4's theme. When you import `@heroui/styles`, it uses Tailwind's built-in color palettes and maps them to semantic variables.
+The accent color represents the primary brand or product identity. It is used to draw attention to key actions, highlights, and moments of emphasis.
 
-**Naming pattern:**
-- Colors without a suffix are backgrounds (e.g., `--accent`)
-- Colors with `-foreground` are for text on that background (e.g., `--accent-foreground`)
+Accent should be used intentionally and sparingly. Overuse reduces its impact and can harm visual hierarchy. In most cases, components derive multiple accent-related values (hover, subtle backgrounds, focus states) automatically from the base accent color.
 
-**Usage:**
-```html
-<html class="light" data-theme="light">
-  <body class="bg-background text-foreground">
-    <!-- Your app -->
-  </body>
-</html>
-```
+<ColorSectionSideBySide
+  name="Accent"
+  baseVariable="--accent"
+  hoverVariable="--accent"
+  hoverCssValue="color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%)"
+  foregroundVariable="--accent-foreground"
+  soft={{
+    baseVariable: "--accent",
+    baseCssValue: "color-mix(in oklab, var(--accent) 15%, transparent)",
+    hoverVariable: "--accent",
+    hoverCssValue: "color-mix(in oklab, var(--accent) 20%, transparent)",
+    foregroundVariable: "--accent",
+    foregroundCssValue: "var(--accent)",
+  }}
+/>
 
-```tsx
-// This gives you the right background and text colors
-<div className="bg-accent text-accent-foreground">Hello</div>
-```
+## Default (neutrals)
 
-### Base Colors
+Default colors form the neutral backbone of the system. They are used for most non-emphasized UI elements.
 
-These four colors stay the same in all themes:
+<ColorSectionSideBySide
+  name="Default"
+  baseVariable="--default"
+  hoverVariable="--default"
+  hoverCssValue="color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%)"
+  foregroundVariable="--default-foreground"
+/>
 
-<div className="flex flex-wrap gap-4 sm:gap-6">
-  <ColorSwatch name="White" variable="--white" />
-  <ColorSwatch name="Black" variable="--black" />
-  <ColorSwatch name="Snow" variable="--snow" />
-  <ColorSwatch name="Eclipse" variable="--eclipse" />
-</div>
+## Success
 
-### Background & Surface
+Success colors communicate positive outcomes, confirmations, and completed states. They are typically used in feedback components, status indicators, and validation states.
 
-<ColorPalette
-  colors={[
-    { name: "Background", variable: "--background", foreground: "--foreground" },
-    { name: "Foreground", variable: "--foreground" },
-    { name: "Surface", variable: "--surface", foreground: "--surface-foreground" },
-    { name: "Surface Foreground", variable: "--surface-foreground" },
-    { name: "Overlay", variable: "--overlay", foreground: "--overlay-foreground" },
-    { name: "Overlay Foreground", variable: "--overlay-foreground" },
+<ColorSectionSideBySide
+  name="Success"
+  baseVariable="--success"
+  hoverVariable="--success"
+  hoverCssValue="color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%)"
+  foregroundVariable="--success-foreground"
+  soft={{
+    baseVariable: "--success",
+    baseCssValue: "color-mix(in oklab, var(--success) 15%, transparent)",
+    hoverVariable: "--success",
+    hoverCssValue: "color-mix(in oklab, var(--success) 20%, transparent)",
+    foregroundVariable: "--success",
+    foregroundCssValue: "var(--success)",
+  }}
+/>
+
+## Warning
+
+Warning colors indicate caution, risk, or actions that require attention but are not destructive. They are commonly used for alerts, messages, and transitional states where the user should pause or review information.
+
+<ColorSectionSideBySide
+  name="Warning"
+  baseVariable="--warning"
+  hoverVariable="--warning"
+  hoverCssValue="color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%)"
+  foregroundVariable="--warning-foreground"
+  soft={{
+    baseVariable: "--warning",
+    baseCssValue: "color-mix(in oklab, var(--warning) 15%, transparent)",
+    hoverVariable: "--warning",
+    hoverCssValue: "color-mix(in oklab, var(--warning) 20%, transparent)",
+    foregroundVariable: "--warning",
+    foregroundCssValue: "var(--warning)",
+  }}
+/>
+
+## Danger
+
+Danger colors represent destructive, irreversible, or critical actions and states. They should be immediately recognizable and used consistently for errors, destructive buttons, and critical alerts.
+
+<ColorSectionSideBySide
+  name="Danger"
+  baseVariable="--danger"
+  hoverVariable="--danger"
+  hoverCssValue="color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%)"
+  foregroundVariable="--danger-foreground"
+  soft={{
+    baseVariable: "--danger",
+    baseCssValue: "color-mix(in oklab, var(--danger) 15%, transparent)",
+    hoverVariable: "--danger",
+    hoverCssValue: "color-mix(in oklab, var(--danger) 20%, transparent)",
+    foregroundVariable: "--danger",
+    foregroundCssValue: "var(--danger)",
+  }}
+/>
+
+## Foreground
+
+Foreground colors are used for primary content such as text and icons. These colors are optimized for readability and accessibility and adapt automatically to background and surface contexts. Foreground colors should never be hard-coded at the component level.
+
+<ColorSectionStacked
+  lightColors={[
+    { label: "Foreground", variable: "--foreground" },
+    { label: "Muted", variable: "--muted" },
+    { label: "Segment", variable: "--segment" },
+    { label: "Overlay", variable: "--overlay" },
+    { label: "Link", variable: "--link" },
+  ]}
+  darkColors={[
+    { label: "Foreground", variable: "--foreground", border: true },
+    { label: "Muted", variable: "--muted", border: true },
+    { label: "Segment", variable: "--segment", border: true },
+    { label: "Overlay", variable: "--overlay", border: true },
+    { label: "Link", variable: "--link", border: true },
   ]}
 />
 
-### Primary Colors
+## Background
 
-**Accent** — Your main brand color (used for primary actions)
-**Accent Soft** — A lighter version for secondary actions
+Background colors define the base canvas of the interface. They establish overall contrast and mood while staying visually quiet.
 
-<ColorPalette
-  colors={[
-    { name: "Accent", variable: "--accent", foreground: "--accent-foreground" },
-    { name: "Accent Foreground", variable: "--accent-foreground" },
-    { name: "Accent Soft", variable: "--accent-soft", foreground: "--accent-soft-foreground" },
-    { name: "Accent Soft Foreground", variable: "--accent-soft-foreground" },
+<ColorSectionStacked
+  lightColors={[
+    { label: "Background", variable: "--background", border: true },
+    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true },
+    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true },
+    { label: "Inverse", variable: "--foreground" },
+  ]}
+  darkColors={[
+    { label: "Background", variable: "--background", border: true },
+    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true },
+    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true },
+    { label: "Inverse", variable: "--foreground", border: true },
   ]}
 />
 
-### Status Colors
+## Surface
 
-For alerts, validation, and status messages:
+Surface colors sit on top of backgrounds and are used for containers such as cards, panels, modals, and dropdown. Surfaces help create visual separation and hierarchy through elevation, contrast, and layering rather than strong color shifts.
 
-<ColorPalette
-  colors={[
-    { name: "Success", variable: "--success", foreground: "--success-foreground" },
-    { name: "Success Foreground", variable: "--success-foreground" },
-    { name: "Warning", variable: "--warning", foreground: "--warning-foreground" },
-    { name: "Warning Foreground", variable: "--warning-foreground" },
-    { name: "Danger", variable: "--danger", foreground: "--danger-foreground" },
-    { name: "Danger Foreground", variable: "--danger-foreground" },
+<ColorSectionStacked
+  lightColors={[
+    { label: "Surface", variable: "--surface", border: true },
+    { label: "Secondary", variable: "--surface-secondary", border: true },
+    { label: "Tertiary", variable: "--surface-tertiary", border: true },
+  ]}
+  darkColors={[
+    { label: "Surface", variable: "--surface", border: true },
+    { label: "Secondary", variable: "--surface-secondary", border: true },
+    { label: "Tertiary", variable: "--surface-tertiary", border: true },
   ]}
 />
 
-### Form Field Colors
+## Form field
 
-For consistent form field styling across input components:
+Form field colors are specialized tokens used for inputs, controls, and interactive fields. They account for multiple states such as default, focus, and hover. Isolating them ensures form elements have a distinct visual language from buttons and the rest of the UI.
 
-<ColorPalette
-  colors={[
-    { name: "Field Background", variable: "--field-background", foreground: "--field-foreground" },
-    { name: "Field Foreground", variable: "--field-foreground" },
-    { name: "Field Placeholder", variable: "--field-placeholder" },
-    { name: "Field Border", variable: "--field-border" },
+<ColorSectionFormField
+  colors={{
+    bg: "--field-background",
+    bgHover: "color-mix(in oklab, var(--field-background) 90%, var(--field-foreground) 10%)",
+    placeholder: "--field-placeholder",
+    foreground: "--field-foreground",
+  }}
+/>
+
+## Separator
+
+Separator colors are used for dividers, outlines, and subtle boundaries. They exist to structure content and guide the eye without adding noise. Separator colors should remain low contrast and unobtrusive.
+
+<ColorSectionStacked
+  lightColors={[
+    { label: "Separator", variable: "--separator", border: true },
+    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true },
+    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true },
+  ]}
+  darkColors={[
+    { label: "Separator", variable: "--separator", border: true },
+    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true },
+    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true },
   ]}
 />
 
-### Other Colors
+## Other
 
-<ColorPalette
-  colors={[
-    { name: "Default", variable: "--default", foreground: "--default-foreground" },
-    { name: "Default Foreground", variable: "--default-foreground" },
-    { name: "Muted", variable: "--muted", foreground: "--foreground" },
-    { name: "Border", variable: "--border" },
-    { name: "Focus", variable: "--focus" },
-    { name: "Link", variable: "--link" },
-    { name: "Backdrop", variable: "--backdrop" },
-    { name: "Scrollbar", variable: "--scrollbar" },
+Other colors serve specific utility roles across the interface. They exist to structure content and guide the eye without adding noise.
+
+<ColorSectionStacked
+  lightColors={[
+    { label: "Border", variable: "--border" },
+    { label: "Backdrop", variable: "--backdrop" },
+    { label: "Overlay", variable: "--overlay", border: true },
+    { label: "Segment", variable: "--segment", border: true },
+  ]}
+  darkColors={[
+    { label: "Border", variable: "--border" },
+    { label: "Backdrop", variable: "--backdrop" },
+    { label: "Overlay", variable: "--overlay", border: true },
+    { label: "Segment", variable: "--segment", border: true },
   ]}
 />
 
@@ -315,7 +416,6 @@ The complete theme definition can be found in ([variables.css](https://github.co
 `}
 />
 
-
 ## Customizing Colors
 
 **Override existing colors:**
@@ -365,17 +465,3 @@ Now you can use it:
 ```
 
 > **Note**: To learn more about theme variables and how they work in Tailwind CSS v4, see the [Tailwind CSS Theme documentation](https://tailwindcss.com/docs/theme).
-
-
-## Quick Tips
-
-- Always use color variables, not hard-coded values
-- Use foreground/background pairs for good contrast
-- Test in both light and dark modes
-- The system respects user's theme preference automatically
-
-## Related
-
-- [Theming](/docs/handbook/theming) - Learn about the theming system
-- [Styling](/docs/handbook/styling) - Styling components with CSS
-- [Design Principles](/docs/getting-started/design-principles) - Understanding HeroUI's design philosophy

--- a/apps/docs/content/docs/react/getting-started/(handbook)/colors.mdx
+++ b/apps/docs/content/docs/react/getting-started/(handbook)/colors.mdx
@@ -7,7 +7,7 @@ links:
   tailwind: theme
 ---
 
-import {ColorSectionSideBySide, ColorSectionStacked, ColorSectionFormField} from "@/components/color-section";
+import {ColorSectionSideBySide, ColorSectionStacked, ColorSectionFormField, ColorSectionPrimitive} from "@/components/color-section";
 
 HeroUI's color system is built around semantic intent, not visual abundance. Instead of exposing large raw palettes, the system defines a small, meaningful set of color roles that cover the majority of interface needs.
 
@@ -28,16 +28,22 @@ Accent should be used intentionally and sparingly. Overuse reduces its impact an
 <ColorSectionSideBySide
   name="Accent"
   baseVariable="--accent"
+  baseTooltip={"--accent: oklch(0.6204 0.195 253.83)"}
   hoverVariable="--accent"
   hoverCssValue="color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%)"
+  hoverTooltip={"--color-accent-hover:\n  color-mix(\n    in oklab,\n    var(--accent) 90%,\n    var(--accent-foreground) 10%\n  )"}
   foregroundVariable="--accent-foreground"
+  foregroundTooltip={"--accent-foreground: var(--snow)"}
   soft={{
     baseVariable: "--accent",
     baseCssValue: "color-mix(in oklab, var(--accent) 15%, transparent)",
+    baseTooltip: "--color-accent-soft:\n  color-mix(\n    in oklab,\n    var(--accent) 15%,\n    transparent\n  )",
     hoverVariable: "--accent",
     hoverCssValue: "color-mix(in oklab, var(--accent) 20%, transparent)",
+    hoverTooltip: "--color-accent-soft-hover:\n  color-mix(\n    in oklab,\n    var(--accent) 20%,\n    transparent\n  )",
     foregroundVariable: "--accent",
     foregroundCssValue: "var(--accent)",
+    foregroundTooltip: "--color-accent-soft-foreground: var(--accent)",
   }}
 />
 
@@ -48,9 +54,12 @@ Default colors form the neutral backbone of the system. They are used for most n
 <ColorSectionSideBySide
   name="Default"
   baseVariable="--default"
+  baseTooltip={"--default: oklch(94% 0.001 286.375)"}
   hoverVariable="--default"
   hoverCssValue="color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%)"
+  hoverTooltip={"--color-default-hover:\n  color-mix(\n    in oklab,\n    var(--default) 96%,\n    var(--default-foreground) 4%\n  )"}
   foregroundVariable="--default-foreground"
+  foregroundTooltip={"--default-foreground: var(--eclipse)"}
 />
 
 ## Success
@@ -60,16 +69,22 @@ Success colors communicate positive outcomes, confirmations, and completed state
 <ColorSectionSideBySide
   name="Success"
   baseVariable="--success"
+  baseTooltip={"--success: oklch(0.7329 0.1935 150.81)"}
   hoverVariable="--success"
   hoverCssValue="color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%)"
+  hoverTooltip={"--color-success-hover:\n  color-mix(\n    in oklab,\n    var(--success) 90%,\n    var(--success-foreground) 10%\n  )"}
   foregroundVariable="--success-foreground"
+  foregroundTooltip={"--success-foreground: var(--eclipse)"}
   soft={{
     baseVariable: "--success",
     baseCssValue: "color-mix(in oklab, var(--success) 15%, transparent)",
+    baseTooltip: "--color-success-soft:\n  color-mix(\n    in oklab,\n    var(--success) 15%,\n    transparent\n  )",
     hoverVariable: "--success",
     hoverCssValue: "color-mix(in oklab, var(--success) 20%, transparent)",
+    hoverTooltip: "--color-success-soft-hover:\n  color-mix(\n    in oklab,\n    var(--success) 20%,\n    transparent\n  )",
     foregroundVariable: "--success",
     foregroundCssValue: "var(--success)",
+    foregroundTooltip: "--color-success-soft-foreground: var(--success)",
   }}
 />
 
@@ -80,16 +95,22 @@ Warning colors indicate caution, risk, or actions that require attention but are
 <ColorSectionSideBySide
   name="Warning"
   baseVariable="--warning"
+  baseTooltip={"--warning: oklch(0.7819 0.1585 72.33)"}
   hoverVariable="--warning"
   hoverCssValue="color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%)"
+  hoverTooltip={"--color-warning-hover:\n  color-mix(\n    in oklab,\n    var(--warning) 90%,\n    var(--warning-foreground) 10%\n  )"}
   foregroundVariable="--warning-foreground"
+  foregroundTooltip={"--warning-foreground: var(--eclipse)"}
   soft={{
     baseVariable: "--warning",
     baseCssValue: "color-mix(in oklab, var(--warning) 15%, transparent)",
+    baseTooltip: "--color-warning-soft:\n  color-mix(\n    in oklab,\n    var(--warning) 15%,\n    transparent\n  )",
     hoverVariable: "--warning",
     hoverCssValue: "color-mix(in oklab, var(--warning) 20%, transparent)",
+    hoverTooltip: "--color-warning-soft-hover:\n  color-mix(\n    in oklab,\n    var(--warning) 20%,\n    transparent\n  )",
     foregroundVariable: "--warning",
     foregroundCssValue: "var(--warning)",
+    foregroundTooltip: "--color-warning-soft-foreground: var(--warning)",
   }}
 />
 
@@ -100,16 +121,22 @@ Danger colors represent destructive, irreversible, or critical actions and state
 <ColorSectionSideBySide
   name="Danger"
   baseVariable="--danger"
+  baseTooltip={"--danger: oklch(0.6532 0.2328 25.74)"}
   hoverVariable="--danger"
   hoverCssValue="color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%)"
+  hoverTooltip={"--color-danger-hover:\n  color-mix(\n    in oklab,\n    var(--danger) 90%,\n    var(--danger-foreground) 10%\n  )"}
   foregroundVariable="--danger-foreground"
+  foregroundTooltip={"--danger-foreground: var(--snow)"}
   soft={{
     baseVariable: "--danger",
     baseCssValue: "color-mix(in oklab, var(--danger) 15%, transparent)",
+    baseTooltip: "--color-danger-soft:\n  color-mix(\n    in oklab,\n    var(--danger) 15%,\n    transparent\n  )",
     hoverVariable: "--danger",
     hoverCssValue: "color-mix(in oklab, var(--danger) 20%, transparent)",
+    hoverTooltip: "--color-danger-soft-hover:\n  color-mix(\n    in oklab,\n    var(--danger) 20%,\n    transparent\n  )",
     foregroundVariable: "--danger",
     foregroundCssValue: "var(--danger)",
+    foregroundTooltip: "--color-danger-soft-foreground: var(--danger)",
   }}
 />
 
@@ -119,18 +146,18 @@ Foreground colors are used for primary content such as text and icons. These col
 
 <ColorSectionStacked
   lightColors={[
-    { label: "Foreground", variable: "--foreground" },
-    { label: "Muted", variable: "--muted" },
-    { label: "Segment", variable: "--segment" },
-    { label: "Overlay", variable: "--overlay" },
-    { label: "Link", variable: "--link" },
+    { label: "Foreground", variable: "--foreground", tooltip: "--foreground: var(--eclipse)" },
+    { label: "Muted", variable: "--muted", tooltip: "--muted: oklch(0.5517 0.0138 285.94)" },
+    { label: "Segment", variable: "--segment", tooltip: "--segment: var(--white)" },
+    { label: "Overlay", variable: "--overlay", tooltip: "--overlay: var(--white)" },
+    { label: "Link", variable: "--link", tooltip: "--link: var(--foreground)" },
   ]}
   darkColors={[
-    { label: "Foreground", variable: "--foreground", border: true },
-    { label: "Muted", variable: "--muted", border: true },
-    { label: "Segment", variable: "--segment", border: true },
-    { label: "Overlay", variable: "--overlay", border: true },
-    { label: "Link", variable: "--link", border: true },
+    { label: "Foreground", variable: "--foreground", border: true, tooltip: "--foreground: var(--snow)" },
+    { label: "Muted", variable: "--muted", border: true, tooltip: "--muted: oklch(70.5% 0.015 286.067)" },
+    { label: "Segment", variable: "--segment", border: true, tooltip: "--segment: oklch(0.3964 0.01 285.93)" },
+    { label: "Overlay", variable: "--overlay", border: true, tooltip: "--overlay: oklch(0.2103 0.0059 285.89)" },
+    { label: "Link", variable: "--link", border: true, tooltip: "--link: var(--foreground)" },
   ]}
 />
 
@@ -140,16 +167,16 @@ Background colors define the base canvas of the interface. They establish overal
 
 <ColorSectionStacked
   lightColors={[
-    { label: "Background", variable: "--background", border: true },
-    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true },
-    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true },
-    { label: "Inverse", variable: "--foreground" },
+    { label: "Background", variable: "--background", border: true, tooltip: "--background: oklch(0.9702 0 0)" },
+    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true, tooltip: "--color-background-secondary:\n  color-mix(\n    in oklab,\n    var(--background) 96%,\n    var(--foreground) 4%\n  )" },
+    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true, tooltip: "--color-background-tertiary:\n  color-mix(\n    in oklab,\n    var(--background) 92%,\n    var(--foreground) 8%\n  )" },
+    { label: "Inverse", variable: "--foreground", tooltip: "--color-background-inverse: var(--foreground)" },
   ]}
   darkColors={[
-    { label: "Background", variable: "--background", border: true },
-    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true },
-    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true },
-    { label: "Inverse", variable: "--foreground", border: true },
+    { label: "Background", variable: "--background", border: true, tooltip: "--background: oklch(12% 0.005 285.823)" },
+    { label: "Secondary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 96%, var(--foreground) 4%)", border: true, tooltip: "--color-background-secondary:\n  color-mix(\n    in oklab,\n    var(--background) 96%,\n    var(--foreground) 4%\n  )" },
+    { label: "Tertiary", variable: "--background", cssValue: "color-mix(in oklab, var(--background) 92%, var(--foreground) 8%)", border: true, tooltip: "--color-background-tertiary:\n  color-mix(\n    in oklab,\n    var(--background) 92%,\n    var(--foreground) 8%\n  )" },
+    { label: "Inverse", variable: "--foreground", border: true, tooltip: "--color-background-inverse: var(--foreground)" },
   ]}
 />
 
@@ -159,14 +186,14 @@ Surface colors sit on top of backgrounds and are used for containers such as car
 
 <ColorSectionStacked
   lightColors={[
-    { label: "Surface", variable: "--surface", border: true },
-    { label: "Secondary", variable: "--surface-secondary", border: true },
-    { label: "Tertiary", variable: "--surface-tertiary", border: true },
+    { label: "Surface", variable: "--surface", border: true, tooltip: "--surface: var(--white)" },
+    { label: "Secondary", variable: "--surface-secondary", border: true, tooltip: "--surface-secondary: oklch(0.9524 0.0013 286.37)" },
+    { label: "Tertiary", variable: "--surface-tertiary", border: true, tooltip: "--surface-tertiary: oklch(0.9373 0.0013 286.37)" },
   ]}
   darkColors={[
-    { label: "Surface", variable: "--surface", border: true },
-    { label: "Secondary", variable: "--surface-secondary", border: true },
-    { label: "Tertiary", variable: "--surface-tertiary", border: true },
+    { label: "Surface", variable: "--surface", border: true, tooltip: "--surface: oklch(0.2103 0.0059 285.89)" },
+    { label: "Secondary", variable: "--surface-secondary", border: true, tooltip: "--surface-secondary: oklch(0.257 0.0037 286.14)" },
+    { label: "Tertiary", variable: "--surface-tertiary", border: true, tooltip: "--surface-tertiary: oklch(0.2721 0.0024 247.91)" },
   ]}
 />
 
@@ -177,9 +204,14 @@ Form field colors are specialized tokens used for inputs, controls, and interact
 <ColorSectionFormField
   colors={{
     bg: "--field-background",
+    bgTooltip: "--field-background: var(--white)",
     bgHover: "color-mix(in oklab, var(--field-background) 90%, var(--field-foreground) 10%)",
+    bgHoverTooltip: "--color-field-hover:\n  color-mix(\n    in oklab,\n    var(--field-background, var(--default)) 90%,\n    var(--field-foreground, var(--foreground)) 2%\n  )",
+    bgFocusTooltip: "--color-field-focus:\n  var(--field-background, var(--default))",
     placeholder: "--field-placeholder",
+    placeholderTooltip: "--field-placeholder: var(--muted)",
     foreground: "--field-foreground",
+    foregroundTooltip: "--field-foreground: oklch(0.2103 0.0059 285.89)",
   }}
 />
 
@@ -189,14 +221,14 @@ Separator colors are used for dividers, outlines, and subtle boundaries. They ex
 
 <ColorSectionStacked
   lightColors={[
-    { label: "Separator", variable: "--separator", border: true },
-    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true },
-    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true },
+    { label: "Separator", variable: "--separator", border: true, tooltip: "--separator: oklch(92% 0.004 286.32)" },
+    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true, tooltip: "--color-separator-secondary:\n  color-mix(\n    in oklab,\n    var(--surface) 85%,\n    var(--surface-foreground) 15%\n  )" },
+    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true, tooltip: "--color-separator-tertiary:\n  color-mix(\n    in oklab,\n    var(--surface) 81%,\n    var(--surface-foreground) 19%\n  )" },
   ]}
   darkColors={[
-    { label: "Separator", variable: "--separator", border: true },
-    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true },
-    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true },
+    { label: "Separator", variable: "--separator", border: true, tooltip: "--separator: oklch(25% 0.006 286.033)" },
+    { label: "Secondary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%)", border: true, tooltip: "--color-separator-secondary:\n  color-mix(\n    in oklab,\n    var(--surface) 85%,\n    var(--surface-foreground) 15%\n  )" },
+    { label: "Tertiary", variable: "--surface", cssValue: "color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%)", border: true, tooltip: "--color-separator-tertiary:\n  color-mix(\n    in oklab,\n    var(--surface) 81%,\n    var(--surface-foreground) 19%\n  )" },
   ]}
 />
 
@@ -206,16 +238,29 @@ Other colors serve specific utility roles across the interface. They exist to st
 
 <ColorSectionStacked
   lightColors={[
-    { label: "Border", variable: "--border" },
-    { label: "Backdrop", variable: "--backdrop" },
-    { label: "Overlay", variable: "--overlay", border: true },
-    { label: "Segment", variable: "--segment", border: true },
+    { label: "Border", variable: "--border", tooltip: "--border: oklch(90% 0.004 286.32)" },
+    { label: "Backdrop", variable: "--backdrop", tooltip: "--backdrop: rgba(0, 0, 0, 0.5)" },
+    { label: "Overlay", variable: "--overlay", border: true, tooltip: "--overlay: var(--white)" },
+    { label: "Segment", variable: "--segment", border: true, tooltip: "--segment: var(--white)" },
   ]}
   darkColors={[
-    { label: "Border", variable: "--border" },
-    { label: "Backdrop", variable: "--backdrop" },
-    { label: "Overlay", variable: "--overlay", border: true },
-    { label: "Segment", variable: "--segment", border: true },
+    { label: "Border", variable: "--border", tooltip: "--border: oklch(28% 0.006 286.033)" },
+    { label: "Backdrop", variable: "--backdrop", tooltip: "--backdrop: rgba(0, 0, 0, 0.6)" },
+    { label: "Overlay", variable: "--overlay", border: true, tooltip: "--overlay: oklch(0.2103 0.0059 285.89)" },
+    { label: "Segment", variable: "--segment", border: true, tooltip: "--segment: oklch(0.3964 0.01 285.93)" },
+  ]}
+/>
+
+## Primitive
+
+Primitive colors are mode agnostic values used as foundations for semantic color tokens. They do not change between light and dark themes.
+
+<ColorSectionPrimitive
+  colors={[
+    { label: "White", variable: "--white", border: true, tooltip: "--white: oklch(100% 0 0)" },
+    { label: "Black", variable: "--black", tooltip: "--black: oklch(0% 0 0)" },
+    { label: "Snow", variable: "--snow", border: true, tooltip: "--snow: oklch(0.9911 0 0)" },
+    { label: "Eclipse", variable: "--eclipse", tooltip: "--eclipse: oklch(0.2103 0.0059 285.89)" },
   ]}
 />
 

--- a/apps/docs/src/app/(home)/components/demo-showcase.tsx
+++ b/apps/docs/src/app/(home)/components/demo-showcase.tsx
@@ -210,7 +210,7 @@ export function DemoShowcase() {
           </div>
         </div>
         {/* Mobile: always show DemoComponents */}
-        <div className="mt-5 flex w-full justify-center lg:hidden">
+        <div className="flex w-full justify-center rounded-2xl bg-background py-8 lg:hidden">
           <DemoComponents />
         </div>
         {/* Desktop: respect tab selection */}

--- a/apps/docs/src/components/color-section.tsx
+++ b/apps/docs/src/components/color-section.tsx
@@ -60,12 +60,20 @@ function ColorHeader({
 }) {
   return (
     <div
-      className="flex h-16 items-center justify-between rounded-xl px-4 py-5"
+      className="flex items-center justify-between rounded-xl px-4 py-3"
       style={{backgroundColor: `var(${bgVariable})`}}
     >
-      <span className="text-lg font-medium tracking-tight" style={contrastStyle(bgVariable)}>
-        {name}
-      </span>
+      <div className="flex flex-col">
+        <span className="text-lg font-medium tracking-tight" style={contrastStyle(bgVariable)}>
+          {name}
+        </span>
+        <span
+          className="font-mono text-[10px] leading-tight opacity-50"
+          style={contrastStyle(bgVariable)}
+        >
+          {bgVariable}
+        </span>
+      </div>
       <span className="text-xs font-medium" style={contrastStyle(bgVariable)}>
         {theme}
       </span>
@@ -78,12 +86,15 @@ function ColorBlock({
   cssValue,
   hasBorder,
   label,
+  varName,
 }: {
   label: string;
   bgVariable: string;
   /** Raw CSS color expression (e.g. color-mix). When set, used for background instead of var(bgVariable). */
   cssValue?: string;
   hasBorder?: boolean;
+  /** Variable name to display. Defaults to bgVariable. */
+  varName?: string;
 }) {
   const bgValue = cssValue || `var(${bgVariable})`;
 
@@ -91,12 +102,18 @@ function ColorBlock({
     <div
       style={{backgroundColor: bgValue}}
       className={cn(
-        "flex h-[45px] items-center rounded-xl px-4 py-3.5",
+        "flex flex-col justify-center rounded-xl px-4 py-2",
         hasBorder && "border border-black/12 dark:border-white/12",
       )}
     >
       <span className="text-sm font-medium tracking-tight" style={contrastStyle(bgVariable)}>
         {label}
+      </span>
+      <span
+        className="font-mono text-[10px] leading-tight opacity-50"
+        style={contrastStyle(bgVariable)}
+      >
+        {varName || bgVariable}
       </span>
     </div>
   );
@@ -133,8 +150,17 @@ function ThemeColumn({
           >
             {name}
           </span>
-          <ColorBlock bgVariable={hoverVariable} cssValue={hoverCssValue} label="Hover" />
-          <ColorBlock bgVariable={foregroundVariable} label="Foreground" />
+          <ColorBlock
+            bgVariable={hoverVariable}
+            cssValue={hoverCssValue}
+            label="Hover"
+            varName={`${baseVariable}-hover`}
+          />
+          <ColorBlock
+            bgVariable={foregroundVariable}
+            label="Foreground"
+            varName={`${baseVariable}-foreground`}
+          />
         </div>
         {!!soft && (
           <div className="relative flex flex-1 flex-col gap-2.5 overflow-hidden rounded-xl p-4">
@@ -148,10 +174,13 @@ function ThemeColumn({
             </span>
             <div className="relative">
               <div
-                className="flex h-[45px] items-center rounded-xl border border-black/12 px-4 py-3.5 dark:border-white/12"
+                className="flex flex-col justify-center rounded-xl border border-black/12 px-4 py-2 dark:border-white/12"
                 style={{backgroundColor: soft.hoverCssValue || `var(${soft.hoverVariable})`}}
               >
                 <span className="text-sm font-medium tracking-tight text-foreground">Hover</span>
+                <span className="font-mono text-[10px] leading-tight text-foreground opacity-50">
+                  {baseVariable}-soft-hover
+                </span>
               </div>
             </div>
             <div className="relative">
@@ -159,6 +188,7 @@ function ThemeColumn({
                 bgVariable={soft.foregroundVariable}
                 cssValue={soft.foregroundCssValue}
                 label="Foreground"
+                varName={`${baseVariable}-soft-foreground`}
               />
             </div>
           </div>
@@ -218,12 +248,15 @@ function StackedSwatch({
       <div
         style={{backgroundColor: bgValue}}
         className={cn(
-          "flex h-16 items-center justify-between rounded-xl px-4 py-5",
+          "flex h-16 flex-col justify-center rounded-xl px-4 py-2",
           border && "border border-border",
         )}
       >
-        <span className="text-lg font-medium tracking-tight" style={contrastStyle(variable)}>
+        <span className="text-sm font-medium tracking-tight" style={contrastStyle(variable)}>
           {label}
+        </span>
+        <span className="font-mono text-[10px] opacity-60" style={contrastStyle(variable)}>
+          {variable}
         </span>
       </div>
     </div>
@@ -292,36 +325,67 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
             className="flex flex-1 flex-col gap-2.5 rounded-xl border border-black/12 p-4"
             style={{backgroundColor: `var(${colors.bg})`}}
           >
-            <span className="text-base font-medium tracking-tight" style={contrastStyle(colors.bg)}>
-              Bg
-            </span>
-            <ColorBlock hasBorder bgVariable={colors.bg} cssValue={colors.bgHover} label="Hover" />
-            <ColorBlock hasBorder bgVariable={colors.bg} label="Focus" />
+            <div>
+              <span
+                className="text-base font-medium tracking-tight"
+                style={contrastStyle(colors.bg)}
+              >
+                Bg
+              </span>
+              <div className="font-mono text-[10px] opacity-60" style={contrastStyle(colors.bg)}>
+                {colors.bg}
+              </div>
+            </div>
+            <ColorBlock
+              hasBorder
+              bgVariable={colors.bg}
+              cssValue={colors.bgHover}
+              label="Hover"
+              varName="--color-field-hover"
+            />
+            <ColorBlock
+              hasBorder
+              bgVariable={colors.bg}
+              label="Focus"
+              varName="--color-field-focus"
+            />
           </div>
           <div className="flex flex-col gap-4">
             <div className="flex-1">
               <div
-                className="flex h-full items-center rounded-xl border border-border px-4 py-5"
+                className="flex h-full flex-col justify-center rounded-xl border border-border px-4 py-3"
                 style={{backgroundColor: `var(${colors.placeholder})`}}
               >
                 <span
-                  className="text-lg font-medium tracking-tight"
+                  className="text-sm font-medium tracking-tight"
                   style={contrastStyle(colors.placeholder)}
                 >
                   Placeholder
+                </span>
+                <span
+                  className="font-mono text-[10px] opacity-60"
+                  style={contrastStyle(colors.placeholder)}
+                >
+                  {colors.placeholder}
                 </span>
               </div>
             </div>
             <div className="flex-1">
               <div
-                className="flex h-full items-center rounded-xl px-4 py-5"
+                className="flex h-full flex-col justify-center rounded-xl px-4 py-3"
                 style={{backgroundColor: `var(${colors.foreground})`}}
               >
                 <span
-                  className="text-lg font-medium tracking-tight"
+                  className="text-sm font-medium tracking-tight"
                   style={contrastStyle(colors.foreground)}
                 >
                   Foreground
+                </span>
+                <span
+                  className="font-mono text-[10px] opacity-60"
+                  style={contrastStyle(colors.foreground)}
+                >
+                  {colors.foreground}
                 </span>
               </div>
             </div>

--- a/apps/docs/src/components/color-section.tsx
+++ b/apps/docs/src/components/color-section.tsx
@@ -137,11 +137,11 @@ function ThemeColumn({
   soft?: SideBySideProps["soft"];
 }) {
   return (
-    <div className="flex flex-1 flex-col gap-3" data-theme={theme.toLowerCase()}>
+    <div className="flex flex-1 flex-col gap-2" data-theme={theme.toLowerCase()}>
       <ColorHeader bgVariable={baseVariable} name={name} theme={theme} />
-      <div className={cn("flex gap-3", soft ? "flex-row" : "flex-col")}>
+      <div className={cn("flex gap-2", soft ? "flex-row" : "flex-col")}>
         <div
-          className="flex flex-1 flex-col gap-2.5 rounded-xl p-4"
+          className="flex flex-1 flex-col gap-1.5 rounded-xl p-3"
           style={{backgroundColor: `var(${baseVariable})`}}
         >
           <span
@@ -163,7 +163,7 @@ function ThemeColumn({
           />
         </div>
         {!!soft && (
-          <div className="relative flex flex-1 flex-col gap-2.5 overflow-hidden rounded-xl p-4">
+          <div className="relative flex flex-1 flex-col gap-1.5 overflow-hidden rounded-xl p-3">
             <div className="absolute inset-0" style={{backgroundColor: "var(--surface)"}} />
             <div
               className="absolute inset-0"
@@ -207,7 +207,7 @@ export function ColorSectionSideBySide({
   soft,
 }: SideBySideProps) {
   return (
-    <div className="not-prose flex flex-col gap-8 sm:flex-row">
+    <div className="not-prose flex flex-col gap-4 sm:flex-row">
       <ThemeColumn
         baseVariable={baseVariable}
         foregroundVariable={foregroundVariable}
@@ -271,11 +271,11 @@ export function ColorSectionStacked({
   darkColors: StackedColor[];
 }) {
   return (
-    <div className="not-prose flex flex-col gap-4">
+    <div className="not-prose flex flex-col gap-2">
       <div data-theme="light">
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
           <ThemeChip theme="Light" />
-          <div className="flex flex-wrap gap-4">
+          <div className="flex flex-wrap gap-2">
             {lightColors.map((color) => (
               <StackedSwatch
                 key={color.variable}
@@ -289,9 +289,9 @@ export function ColorSectionStacked({
         </div>
       </div>
       <div data-theme="dark">
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
           <ThemeChip theme="Dark" />
-          <div className="flex flex-wrap gap-4">
+          <div className="flex flex-wrap gap-2">
             {darkColors.map((color) => (
               <StackedSwatch
                 key={color.variable}
@@ -318,11 +318,11 @@ interface FormFieldColors {
 function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "light" | "dark"}) {
   return (
     <div data-theme={theme}>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
         <ThemeChip theme={theme === "light" ? "Light" : "Dark"} />
-        <div className="flex flex-wrap gap-4">
+        <div className="flex flex-wrap gap-2">
           <div
-            className="flex flex-1 flex-col gap-2.5 rounded-xl border border-black/12 p-4"
+            className="flex flex-1 flex-col gap-1.5 rounded-xl border border-black/12 p-3"
             style={{backgroundColor: `var(${colors.bg})`}}
           >
             <div>
@@ -350,7 +350,7 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
               varName="--color-field-focus"
             />
           </div>
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
             <div className="flex-1">
               <div
                 className="flex h-full flex-col justify-center rounded-xl border border-border px-4 py-3"
@@ -398,7 +398,7 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
 
 export function ColorSectionFormField({colors}: {colors: FormFieldColors}) {
   return (
-    <div className="not-prose flex flex-col gap-4">
+    <div className="not-prose flex flex-col gap-2">
       <FormFieldThemeBlock colors={colors} theme="light" />
       <FormFieldThemeBlock colors={colors} theme="dark" />
     </div>

--- a/apps/docs/src/components/color-section.tsx
+++ b/apps/docs/src/components/color-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {Chip} from "@heroui/react";
+import {Chip, Tooltip} from "@heroui/react";
 import * as React from "react";
 
 import {Iconify} from "@/components/iconify";
@@ -14,28 +14,53 @@ const contrastStyle = (bgVar: string): React.CSSProperties => ({
   filter: "invert(1) grayscale(1) contrast(100)",
 });
 
+function ColorTooltip({
+  children,
+  className,
+  content,
+}: {
+  children: React.ReactNode;
+  content?: string;
+  className?: string;
+}) {
+  return (
+    <Tooltip delay={0}>
+      <Tooltip.Trigger className={className}>{children}</Tooltip.Trigger>
+      <Tooltip.Content className="max-w-xs">
+        <pre className="font-mono text-xs leading-relaxed whitespace-pre-wrap">{content}</pre>
+      </Tooltip.Content>
+    </Tooltip>
+  );
+}
+
 interface SideBySideProps {
   name: string;
   baseVariable: string;
+  baseTooltip?: string;
   hoverVariable: string;
   hoverCssValue?: string;
+  hoverTooltip?: string;
   foregroundVariable: string;
+  foregroundTooltip?: string;
   soft?: {
     baseVariable: string;
     baseCssValue?: string;
+    baseTooltip?: string;
     hoverVariable: string;
     hoverCssValue?: string;
+    hoverTooltip?: string;
     foregroundVariable: string;
     foregroundCssValue?: string;
+    foregroundTooltip?: string;
   };
 }
 
 interface StackedColor {
   label: string;
   variable: string;
-  /** Raw CSS color expression (e.g. color-mix). When set, used instead of var(variable). */
   cssValue?: string;
   border?: boolean;
+  tooltip?: string;
 }
 
 function ThemeChip({theme}: {theme: "Light" | "Dark"}) {
@@ -53,31 +78,27 @@ function ColorHeader({
   bgVariable,
   name,
   theme,
+  tooltip,
 }: {
   name: string;
   theme: "Light" | "Dark";
   bgVariable: string;
+  tooltip: string;
 }) {
   return (
-    <div
-      className="flex items-center justify-between rounded-xl px-4 py-3"
-      style={{backgroundColor: `var(${bgVariable})`}}
-    >
-      <div className="flex flex-col">
+    <ColorTooltip content={tooltip}>
+      <div
+        className="flex cursor-default items-center justify-between rounded-xl px-4 py-3"
+        style={{backgroundColor: `var(${bgVariable})`}}
+      >
         <span className="text-lg font-medium tracking-tight" style={contrastStyle(bgVariable)}>
           {name}
         </span>
-        <span
-          className="font-mono text-[10px] leading-tight opacity-50"
-          style={contrastStyle(bgVariable)}
-        >
-          {bgVariable}
+        <span className="text-xs font-medium" style={contrastStyle(bgVariable)}>
+          {theme}
         </span>
       </div>
-      <span className="text-xs font-medium" style={contrastStyle(bgVariable)}>
-        {theme}
-      </span>
-    </div>
+    </ColorTooltip>
   );
 }
 
@@ -86,43 +107,40 @@ function ColorBlock({
   cssValue,
   hasBorder,
   label,
-  varName,
+  tooltip,
 }: {
   label: string;
   bgVariable: string;
-  /** Raw CSS color expression (e.g. color-mix). When set, used for background instead of var(bgVariable). */
   cssValue?: string;
   hasBorder?: boolean;
-  /** Variable name to display. Defaults to bgVariable. */
-  varName?: string;
+  tooltip: string;
 }) {
   const bgValue = cssValue || `var(${bgVariable})`;
 
   return (
-    <div
-      style={{backgroundColor: bgValue}}
-      className={cn(
-        "flex flex-col justify-center rounded-xl px-4 py-2",
-        hasBorder && "border border-black/12 dark:border-white/12",
-      )}
-    >
-      <span className="text-sm font-medium tracking-tight" style={contrastStyle(bgVariable)}>
-        {label}
-      </span>
-      <span
-        className="font-mono text-[10px] leading-tight opacity-50"
-        style={contrastStyle(bgVariable)}
+    <ColorTooltip className="block w-full" content={tooltip}>
+      <div
+        style={{backgroundColor: bgValue}}
+        className={cn(
+          "flex w-full cursor-default items-center rounded-xl px-4 py-2.5",
+          hasBorder && "border border-black/12 dark:border-white/12",
+        )}
       >
-        {varName || bgVariable}
-      </span>
-    </div>
+        <span className="text-sm font-medium tracking-tight" style={contrastStyle(bgVariable)}>
+          {label}
+        </span>
+      </div>
+    </ColorTooltip>
   );
 }
 
 function ThemeColumn({
+  baseTooltip,
   baseVariable,
+  foregroundTooltip,
   foregroundVariable,
   hoverCssValue,
+  hoverTooltip,
   hoverVariable,
   name,
   soft,
@@ -131,15 +149,18 @@ function ThemeColumn({
   theme: "Light" | "Dark";
   name: string;
   baseVariable: string;
+  baseTooltip: string;
   hoverVariable: string;
   hoverCssValue?: string;
+  hoverTooltip: string;
   foregroundVariable: string;
+  foregroundTooltip: string;
   soft?: SideBySideProps["soft"];
 }) {
   return (
     <div className="flex flex-1 flex-col gap-2" data-theme={theme.toLowerCase()}>
-      <ColorHeader bgVariable={baseVariable} name={name} theme={theme} />
-      <div className={cn("flex gap-2", soft ? "flex-row" : "flex-col")}>
+      <ColorHeader bgVariable={baseVariable} name={name} theme={theme} tooltip={baseTooltip} />
+      <div className={cn("flex gap-2", soft ? "flex-col sm:flex-row" : "flex-col")}>
         <div
           className="flex flex-1 flex-col gap-1.5 rounded-xl p-3"
           style={{backgroundColor: `var(${baseVariable})`}}
@@ -154,12 +175,12 @@ function ThemeColumn({
             bgVariable={hoverVariable}
             cssValue={hoverCssValue}
             label="Hover"
-            varName={`${baseVariable}-hover`}
+            tooltip={hoverTooltip}
           />
           <ColorBlock
             bgVariable={foregroundVariable}
             label="Foreground"
-            varName={`${baseVariable}-foreground`}
+            tooltip={foregroundTooltip}
           />
         </div>
         {!!soft && (
@@ -173,22 +194,21 @@ function ThemeColumn({
               {name} Soft
             </span>
             <div className="relative">
-              <div
-                className="flex flex-col justify-center rounded-xl border border-black/12 px-4 py-2 dark:border-white/12"
-                style={{backgroundColor: soft.hoverCssValue || `var(${soft.hoverVariable})`}}
-              >
-                <span className="text-sm font-medium tracking-tight text-foreground">Hover</span>
-                <span className="font-mono text-[10px] leading-tight text-foreground opacity-50">
-                  {baseVariable}-soft-hover
-                </span>
-              </div>
+              <ColorTooltip className="block w-full" content={soft.hoverTooltip}>
+                <div
+                  className="flex w-full cursor-default items-center rounded-xl border border-black/12 px-4 py-2.5 dark:border-white/12"
+                  style={{backgroundColor: soft.hoverCssValue || `var(${soft.hoverVariable})`}}
+                >
+                  <span className="text-sm font-medium tracking-tight text-foreground">Hover</span>
+                </div>
+              </ColorTooltip>
             </div>
             <div className="relative">
               <ColorBlock
                 bgVariable={soft.foregroundVariable}
                 cssValue={soft.foregroundCssValue}
                 label="Foreground"
-                varName={`${baseVariable}-soft-foreground`}
+                tooltip={soft.foregroundTooltip}
               />
             </div>
           </div>
@@ -199,9 +219,12 @@ function ThemeColumn({
 }
 
 export function ColorSectionSideBySide({
+  baseTooltip,
   baseVariable,
+  foregroundTooltip,
   foregroundVariable,
   hoverCssValue,
+  hoverTooltip,
   hoverVariable,
   name,
   soft,
@@ -209,18 +232,24 @@ export function ColorSectionSideBySide({
   return (
     <div className="not-prose flex flex-col gap-4 sm:flex-row">
       <ThemeColumn
+        baseTooltip={baseTooltip}
         baseVariable={baseVariable}
+        foregroundTooltip={foregroundTooltip}
         foregroundVariable={foregroundVariable}
         hoverCssValue={hoverCssValue}
+        hoverTooltip={hoverTooltip}
         hoverVariable={hoverVariable}
         name={name}
         soft={soft}
         theme="Light"
       />
       <ThemeColumn
+        baseTooltip={baseTooltip}
         baseVariable={baseVariable}
+        foregroundTooltip={foregroundTooltip}
         foregroundVariable={foregroundVariable}
         hoverCssValue={hoverCssValue}
+        hoverTooltip={hoverTooltip}
         hoverVariable={hoverVariable}
         name={name}
         soft={soft}
@@ -234,32 +263,31 @@ function StackedSwatch({
   border,
   cssValue,
   label,
+  tooltip,
   variable,
 }: {
   label: string;
   variable: string;
   cssValue?: string;
   border?: boolean;
+  tooltip: string;
 }) {
   const bgValue = cssValue || `var(${variable})`;
 
   return (
-    <div className="flex flex-1 flex-col">
+    <ColorTooltip className="min-w-0 basis-[calc(50%-4px)] sm:flex-1 sm:basis-0" content={tooltip}>
       <div
         style={{backgroundColor: bgValue}}
         className={cn(
-          "flex h-16 flex-col justify-center rounded-xl px-4 py-2",
+          "flex h-14 w-full cursor-default items-center rounded-xl px-4",
           border && "border border-border",
         )}
       >
         <span className="text-sm font-medium tracking-tight" style={contrastStyle(variable)}>
           {label}
         </span>
-        <span className="font-mono text-[10px] opacity-60" style={contrastStyle(variable)}>
-          {variable}
-        </span>
       </div>
-    </div>
+    </ColorTooltip>
   );
 }
 
@@ -275,13 +303,14 @@ export function ColorSectionStacked({
       <div data-theme="light">
         <div className="flex flex-col gap-2">
           <ThemeChip theme="Light" />
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2 sm:flex-nowrap">
             {lightColors.map((color) => (
               <StackedSwatch
-                key={color.variable}
+                key={color.variable + color.label}
                 border={color.border}
                 cssValue={color.cssValue}
                 label={color.label}
+                tooltip={color.tooltip}
                 variable={color.variable}
               />
             ))}
@@ -291,13 +320,14 @@ export function ColorSectionStacked({
       <div data-theme="dark">
         <div className="flex flex-col gap-2">
           <ThemeChip theme="Dark" />
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2 sm:flex-nowrap">
             {darkColors.map((color) => (
               <StackedSwatch
-                key={color.variable}
+                key={color.variable + color.label}
                 border={color.border}
                 cssValue={color.cssValue}
                 label={color.label}
+                tooltip={color.tooltip}
                 variable={color.variable}
               />
             ))}
@@ -308,11 +338,33 @@ export function ColorSectionStacked({
   );
 }
 
+export function ColorSectionPrimitive({colors}: {colors: StackedColor[]}) {
+  return (
+    <div className="not-prose flex flex-wrap gap-2 sm:flex-nowrap">
+      {colors.map((color) => (
+        <StackedSwatch
+          key={color.variable + color.label}
+          border={color.border}
+          cssValue={color.cssValue}
+          label={color.label}
+          tooltip={color.tooltip}
+          variable={color.variable}
+        />
+      ))}
+    </div>
+  );
+}
+
 interface FormFieldColors {
   bg: string;
+  bgTooltip?: string;
   bgHover: string;
+  bgHoverTooltip?: string;
+  bgFocusTooltip?: string;
   placeholder: string;
+  placeholderTooltip?: string;
   foreground: string;
+  foregroundTooltip?: string;
 }
 
 function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "light" | "dark"}) {
@@ -320,40 +372,37 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
     <div data-theme={theme}>
       <div className="flex flex-col gap-2">
         <ThemeChip theme={theme === "light" ? "Light" : "Dark"} />
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <div
             className="flex flex-1 flex-col gap-1.5 rounded-xl border border-black/12 p-3"
             style={{backgroundColor: `var(${colors.bg})`}}
           >
-            <div>
+            <ColorTooltip content={colors.bgTooltip}>
               <span
-                className="text-base font-medium tracking-tight"
+                className="cursor-default text-base font-medium tracking-tight"
                 style={contrastStyle(colors.bg)}
               >
                 Bg
               </span>
-              <div className="font-mono text-[10px] opacity-60" style={contrastStyle(colors.bg)}>
-                {colors.bg}
-              </div>
-            </div>
+            </ColorTooltip>
             <ColorBlock
               hasBorder
               bgVariable={colors.bg}
               cssValue={colors.bgHover}
               label="Hover"
-              varName="--color-field-hover"
+              tooltip={colors.bgHoverTooltip}
             />
             <ColorBlock
               hasBorder
               bgVariable={colors.bg}
               label="Focus"
-              varName="--color-field-focus"
+              tooltip={colors.bgFocusTooltip}
             />
           </div>
-          <div className="flex flex-col gap-2">
-            <div className="flex-1">
+          <div className="flex min-w-0 flex-row gap-2 sm:w-40 sm:flex-col">
+            <ColorTooltip className="min-w-0 flex-1" content={colors.placeholderTooltip}>
               <div
-                className="flex h-full flex-col justify-center rounded-xl border border-border px-4 py-3"
+                className="flex h-full cursor-default items-center rounded-xl border border-border px-4 py-3"
                 style={{backgroundColor: `var(${colors.placeholder})`}}
               >
                 <span
@@ -362,17 +411,11 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
                 >
                   Placeholder
                 </span>
-                <span
-                  className="font-mono text-[10px] opacity-60"
-                  style={contrastStyle(colors.placeholder)}
-                >
-                  {colors.placeholder}
-                </span>
               </div>
-            </div>
-            <div className="flex-1">
+            </ColorTooltip>
+            <ColorTooltip className="min-w-0 flex-1" content={colors.foregroundTooltip}>
               <div
-                className="flex h-full flex-col justify-center rounded-xl px-4 py-3"
+                className="flex h-full cursor-default items-center rounded-xl px-4 py-3"
                 style={{backgroundColor: `var(${colors.foreground})`}}
               >
                 <span
@@ -381,14 +424,8 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
                 >
                   Foreground
                 </span>
-                <span
-                  className="font-mono text-[10px] opacity-60"
-                  style={contrastStyle(colors.foreground)}
-                >
-                  {colors.foreground}
-                </span>
               </div>
-            </div>
+            </ColorTooltip>
           </div>
         </div>
       </div>

--- a/apps/docs/src/components/color-section.tsx
+++ b/apps/docs/src/components/color-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import {Chip, Tooltip} from "@heroui/react";
+import {Chip, Tooltip, toast} from "@heroui/react";
+import {converter, parse} from "culori";
 import * as React from "react";
 
 import {Iconify} from "@/components/iconify";
@@ -14,6 +15,51 @@ const contrastStyle = (bgVar: string): React.CSSProperties => ({
   filter: "invert(1) grayscale(1) contrast(100)",
 });
 
+const getTokenName = (content: string | undefined, fallback: string) => {
+  if (!content) return fallback;
+
+  return content.split(":")[0]?.trim() || fallback;
+};
+
+const toOklch = converter("oklch");
+
+const formatNumber = (value: number | undefined) => {
+  if (typeof value !== "number") return "0";
+
+  return Number(value.toFixed(4)).toString();
+};
+
+const toOklchCss = (value: string) => {
+  const parsed = parse(value);
+
+  if (!parsed) return value;
+
+  const oklch = toOklch(parsed);
+
+  if (!oklch) return value;
+
+  if (typeof oklch.alpha === "number" && oklch.alpha < 1) {
+    return `oklch(${formatNumber(oklch.l)} ${formatNumber(oklch.c)} ${formatNumber(oklch.h)} / ${formatNumber(oklch.alpha)})`;
+  }
+
+  return `oklch(${formatNumber(oklch.l)} ${formatNumber(oklch.c)} ${formatNumber(oklch.h)})`;
+};
+
+const copyColorValue = async (
+  event: React.MouseEvent<HTMLElement>,
+  fallback: string | undefined,
+) => {
+  const computedValue = getComputedStyle(event.currentTarget).backgroundColor || fallback;
+  const value = computedValue ? toOklchCss(computedValue) : fallback || "";
+
+  if (!value) return;
+
+  await navigator.clipboard.writeText(value);
+  toast.success("Copied color value", {
+    description: value,
+  });
+};
+
 function ColorTooltip({
   children,
   className,
@@ -23,6 +69,10 @@ function ColorTooltip({
   content?: string;
   className?: string;
 }) {
+  if (!content) {
+    return <div className={className}>{children}</div>;
+  }
+
   return (
     <Tooltip delay={0}>
       <Tooltip.Trigger className={className}>{children}</Tooltip.Trigger>
@@ -83,17 +133,28 @@ function ColorHeader({
   name: string;
   theme: "Light" | "Dark";
   bgVariable: string;
-  tooltip: string;
+  tooltip?: string;
 }) {
+  const token = getTokenName(tooltip, bgVariable);
+
   return (
     <ColorTooltip content={tooltip}>
       <div
-        className="flex cursor-default items-center justify-between rounded-xl px-4 py-3"
+        className="flex cursor-pointer items-center justify-between rounded-xl px-4 py-3"
         style={{backgroundColor: `var(${bgVariable})`}}
+        onClick={copyColorValue}
       >
-        <span className="text-lg font-medium tracking-tight" style={contrastStyle(bgVariable)}>
-          {name}
-        </span>
+        <div className="flex flex-col">
+          <span className="text-lg font-medium tracking-tight" style={contrastStyle(bgVariable)}>
+            {name}
+          </span>
+          <span
+            className="font-mono text-[10px] leading-tight opacity-60 sm:hidden"
+            style={contrastStyle(bgVariable)}
+          >
+            {token}
+          </span>
+        </div>
         <span className="text-xs font-medium" style={contrastStyle(bgVariable)}>
           {theme}
         </span>
@@ -113,21 +174,29 @@ function ColorBlock({
   bgVariable: string;
   cssValue?: string;
   hasBorder?: boolean;
-  tooltip: string;
+  tooltip?: string;
 }) {
   const bgValue = cssValue || `var(${bgVariable})`;
+  const token = getTokenName(tooltip, bgVariable);
 
   return (
     <ColorTooltip className="block w-full" content={tooltip}>
       <div
         style={{backgroundColor: bgValue}}
         className={cn(
-          "flex w-full cursor-default items-center rounded-xl px-4 py-2.5",
+          "flex w-full cursor-pointer flex-col justify-center rounded-xl px-4 py-2.5",
           hasBorder && "border border-black/12 dark:border-white/12",
         )}
+        onClick={(event) => copyColorValue(event, cssValue || bgVariable)}
       >
         <span className="text-sm font-medium tracking-tight" style={contrastStyle(bgVariable)}>
           {label}
+        </span>
+        <span
+          className="font-mono text-[10px] leading-tight opacity-60 sm:hidden"
+          style={contrastStyle(bgVariable)}
+        >
+          {token}
         </span>
       </div>
     </ColorTooltip>
@@ -149,12 +218,12 @@ function ThemeColumn({
   theme: "Light" | "Dark";
   name: string;
   baseVariable: string;
-  baseTooltip: string;
+  baseTooltip?: string;
   hoverVariable: string;
   hoverCssValue?: string;
-  hoverTooltip: string;
+  hoverTooltip?: string;
   foregroundVariable: string;
-  foregroundTooltip: string;
+  foregroundTooltip?: string;
   soft?: SideBySideProps["soft"];
 }) {
   return (
@@ -194,14 +263,28 @@ function ThemeColumn({
               {name} Soft
             </span>
             <div className="relative">
-              <ColorTooltip className="block w-full" content={soft.hoverTooltip}>
-                <div
-                  className="flex w-full cursor-default items-center rounded-xl border border-black/12 px-4 py-2.5 dark:border-white/12"
-                  style={{backgroundColor: soft.hoverCssValue || `var(${soft.hoverVariable})`}}
-                >
-                  <span className="text-sm font-medium tracking-tight text-foreground">Hover</span>
-                </div>
-              </ColorTooltip>
+              {(() => {
+                const token = getTokenName(soft.hoverTooltip, soft.hoverVariable);
+
+                return (
+                  <ColorTooltip className="block w-full" content={soft.hoverTooltip}>
+                    <div
+                      className="flex w-full cursor-pointer flex-col justify-center rounded-xl border border-black/12 px-4 py-2.5 dark:border-white/12"
+                      style={{backgroundColor: soft.hoverCssValue || `var(${soft.hoverVariable})`}}
+                      onClick={(event) =>
+                        copyColorValue(event, soft.hoverCssValue || soft.hoverVariable)
+                      }
+                    >
+                      <span className="text-sm font-medium tracking-tight text-foreground">
+                        Hover
+                      </span>
+                      <span className="font-mono text-[10px] leading-tight text-foreground opacity-60 sm:hidden">
+                        {token}
+                      </span>
+                    </div>
+                  </ColorTooltip>
+                );
+              })()}
             </div>
             <div className="relative">
               <ColorBlock
@@ -270,21 +353,29 @@ function StackedSwatch({
   variable: string;
   cssValue?: string;
   border?: boolean;
-  tooltip: string;
+  tooltip?: string;
 }) {
   const bgValue = cssValue || `var(${variable})`;
+  const token = getTokenName(tooltip, variable);
 
   return (
-    <ColorTooltip className="min-w-0 basis-[calc(50%-4px)] sm:flex-1 sm:basis-0" content={tooltip}>
+    <ColorTooltip className="min-w-0 basis-full sm:flex-1 sm:basis-0" content={tooltip}>
       <div
         style={{backgroundColor: bgValue}}
         className={cn(
-          "flex h-14 w-full cursor-default items-center rounded-xl px-4",
+          "flex min-h-14 w-full cursor-pointer flex-col justify-center rounded-xl px-4 py-2",
           border && "border border-border",
         )}
+        onClick={(event) => copyColorValue(event, cssValue || variable)}
       >
         <span className="text-sm font-medium tracking-tight" style={contrastStyle(variable)}>
           {label}
+        </span>
+        <span
+          className="truncate font-mono text-[10px] leading-tight opacity-60 sm:hidden"
+          style={contrastStyle(variable)}
+        >
+          {token}
         </span>
       </div>
     </ColorTooltip>
@@ -402,8 +493,9 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
           <div className="flex min-w-0 flex-row gap-2 sm:w-40 sm:flex-col">
             <ColorTooltip className="min-w-0 flex-1" content={colors.placeholderTooltip}>
               <div
-                className="flex h-full cursor-default items-center rounded-xl border border-border px-4 py-3"
+                className="flex h-full cursor-pointer items-center rounded-xl border border-border px-4 py-3"
                 style={{backgroundColor: `var(${colors.placeholder})`}}
+                onClick={(event) => copyColorValue(event, colors.placeholder)}
               >
                 <span
                   className="text-sm font-medium tracking-tight"
@@ -415,8 +507,9 @@ function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "
             </ColorTooltip>
             <ColorTooltip className="min-w-0 flex-1" content={colors.foregroundTooltip}>
               <div
-                className="flex h-full cursor-default items-center rounded-xl px-4 py-3"
+                className="flex h-full cursor-pointer items-center rounded-xl px-4 py-3"
                 style={{backgroundColor: `var(${colors.foreground})`}}
+                onClick={(event) => copyColorValue(event, colors.foreground)}
               >
                 <span
                   className="text-sm font-medium tracking-tight"

--- a/apps/docs/src/components/color-section.tsx
+++ b/apps/docs/src/components/color-section.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import {Chip} from "@heroui/react";
+import * as React from "react";
+
+import {Iconify} from "@/components/iconify";
+import {cn} from "@/utils/cn";
+
+const contrastStyle = (bgVar: string): React.CSSProperties => ({
+  WebkitBackgroundClip: "text",
+  backgroundClip: "text",
+  backgroundColor: `var(${bgVar})`,
+  color: "transparent",
+  filter: "invert(1) grayscale(1) contrast(100)",
+});
+
+interface SideBySideProps {
+  name: string;
+  baseVariable: string;
+  hoverVariable: string;
+  hoverCssValue?: string;
+  foregroundVariable: string;
+  soft?: {
+    baseVariable: string;
+    baseCssValue?: string;
+    hoverVariable: string;
+    hoverCssValue?: string;
+    foregroundVariable: string;
+    foregroundCssValue?: string;
+  };
+}
+
+interface StackedColor {
+  label: string;
+  variable: string;
+  /** Raw CSS color expression (e.g. color-mix). When set, used instead of var(variable). */
+  cssValue?: string;
+  border?: boolean;
+}
+
+function ThemeChip({theme}: {theme: "Light" | "Dark"}) {
+  return (
+    <div>
+      <Chip size="sm">
+        <Iconify className="size-3.5" icon="gear" />
+        <Chip.Label>{theme}</Chip.Label>
+      </Chip>
+    </div>
+  );
+}
+
+function ColorHeader({
+  bgVariable,
+  name,
+  theme,
+}: {
+  name: string;
+  theme: "Light" | "Dark";
+  bgVariable: string;
+}) {
+  return (
+    <div
+      className="flex h-16 items-center justify-between rounded-xl px-4 py-5"
+      style={{backgroundColor: `var(${bgVariable})`}}
+    >
+      <span className="text-lg font-medium tracking-tight" style={contrastStyle(bgVariable)}>
+        {name}
+      </span>
+      <span className="text-xs font-medium" style={contrastStyle(bgVariable)}>
+        {theme}
+      </span>
+    </div>
+  );
+}
+
+function ColorBlock({
+  bgVariable,
+  cssValue,
+  hasBorder,
+  label,
+}: {
+  label: string;
+  bgVariable: string;
+  /** Raw CSS color expression (e.g. color-mix). When set, used for background instead of var(bgVariable). */
+  cssValue?: string;
+  hasBorder?: boolean;
+}) {
+  const bgValue = cssValue || `var(${bgVariable})`;
+
+  return (
+    <div
+      style={{backgroundColor: bgValue}}
+      className={cn(
+        "flex h-[45px] items-center rounded-xl px-4 py-3.5",
+        hasBorder && "border border-black/12 dark:border-white/12",
+      )}
+    >
+      <span className="text-sm font-medium tracking-tight" style={contrastStyle(bgVariable)}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function ThemeColumn({
+  baseVariable,
+  foregroundVariable,
+  hoverCssValue,
+  hoverVariable,
+  name,
+  soft,
+  theme,
+}: {
+  theme: "Light" | "Dark";
+  name: string;
+  baseVariable: string;
+  hoverVariable: string;
+  hoverCssValue?: string;
+  foregroundVariable: string;
+  soft?: SideBySideProps["soft"];
+}) {
+  return (
+    <div className="flex flex-1 flex-col gap-3" data-theme={theme.toLowerCase()}>
+      <ColorHeader bgVariable={baseVariable} name={name} theme={theme} />
+      <div className={cn("flex gap-3", soft ? "flex-row" : "flex-col")}>
+        <div
+          className="flex flex-1 flex-col gap-2.5 rounded-xl p-4"
+          style={{backgroundColor: `var(${baseVariable})`}}
+        >
+          <span
+            className="text-base font-medium tracking-tight"
+            style={contrastStyle(baseVariable)}
+          >
+            {name}
+          </span>
+          <ColorBlock bgVariable={hoverVariable} cssValue={hoverCssValue} label="Hover" />
+          <ColorBlock bgVariable={foregroundVariable} label="Foreground" />
+        </div>
+        {!!soft && (
+          <div className="relative flex flex-1 flex-col gap-2.5 overflow-hidden rounded-xl p-4">
+            <div className="absolute inset-0" style={{backgroundColor: "var(--surface)"}} />
+            <div
+              className="absolute inset-0"
+              style={{backgroundColor: soft.baseCssValue || `var(${soft.baseVariable})`}}
+            />
+            <span className="relative text-base font-medium tracking-tight text-foreground">
+              {name} Soft
+            </span>
+            <div className="relative">
+              <div
+                className="flex h-[45px] items-center rounded-xl border border-black/12 px-4 py-3.5 dark:border-white/12"
+                style={{backgroundColor: soft.hoverCssValue || `var(${soft.hoverVariable})`}}
+              >
+                <span className="text-sm font-medium tracking-tight text-foreground">Hover</span>
+              </div>
+            </div>
+            <div className="relative">
+              <ColorBlock
+                bgVariable={soft.foregroundVariable}
+                cssValue={soft.foregroundCssValue}
+                label="Foreground"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ColorSectionSideBySide({
+  baseVariable,
+  foregroundVariable,
+  hoverCssValue,
+  hoverVariable,
+  name,
+  soft,
+}: SideBySideProps) {
+  return (
+    <div className="not-prose flex flex-col gap-8 sm:flex-row">
+      <ThemeColumn
+        baseVariable={baseVariable}
+        foregroundVariable={foregroundVariable}
+        hoverCssValue={hoverCssValue}
+        hoverVariable={hoverVariable}
+        name={name}
+        soft={soft}
+        theme="Light"
+      />
+      <ThemeColumn
+        baseVariable={baseVariable}
+        foregroundVariable={foregroundVariable}
+        hoverCssValue={hoverCssValue}
+        hoverVariable={hoverVariable}
+        name={name}
+        soft={soft}
+        theme="Dark"
+      />
+    </div>
+  );
+}
+
+function StackedSwatch({
+  border,
+  cssValue,
+  label,
+  variable,
+}: {
+  label: string;
+  variable: string;
+  cssValue?: string;
+  border?: boolean;
+}) {
+  const bgValue = cssValue || `var(${variable})`;
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <div
+        style={{backgroundColor: bgValue}}
+        className={cn(
+          "flex h-16 items-center justify-between rounded-xl px-4 py-5",
+          border && "border border-border",
+        )}
+      >
+        <span className="text-lg font-medium tracking-tight" style={contrastStyle(variable)}>
+          {label}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ColorSectionStacked({
+  darkColors,
+  lightColors,
+}: {
+  lightColors: StackedColor[];
+  darkColors: StackedColor[];
+}) {
+  return (
+    <div className="not-prose flex flex-col gap-4">
+      <div data-theme="light">
+        <div className="flex flex-col gap-4">
+          <ThemeChip theme="Light" />
+          <div className="flex flex-wrap gap-4">
+            {lightColors.map((color) => (
+              <StackedSwatch
+                key={color.variable}
+                border={color.border}
+                cssValue={color.cssValue}
+                label={color.label}
+                variable={color.variable}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div data-theme="dark">
+        <div className="flex flex-col gap-4">
+          <ThemeChip theme="Dark" />
+          <div className="flex flex-wrap gap-4">
+            {darkColors.map((color) => (
+              <StackedSwatch
+                key={color.variable}
+                border={color.border}
+                cssValue={color.cssValue}
+                label={color.label}
+                variable={color.variable}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface FormFieldColors {
+  bg: string;
+  bgHover: string;
+  placeholder: string;
+  foreground: string;
+}
+
+function FormFieldThemeBlock({colors, theme}: {colors: FormFieldColors; theme: "light" | "dark"}) {
+  return (
+    <div data-theme={theme}>
+      <div className="flex flex-col gap-4">
+        <ThemeChip theme={theme === "light" ? "Light" : "Dark"} />
+        <div className="flex flex-wrap gap-4">
+          <div
+            className="flex flex-1 flex-col gap-2.5 rounded-xl border border-black/12 p-4"
+            style={{backgroundColor: `var(${colors.bg})`}}
+          >
+            <span className="text-base font-medium tracking-tight" style={contrastStyle(colors.bg)}>
+              Bg
+            </span>
+            <ColorBlock hasBorder bgVariable={colors.bg} cssValue={colors.bgHover} label="Hover" />
+            <ColorBlock hasBorder bgVariable={colors.bg} label="Focus" />
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex-1">
+              <div
+                className="flex h-full items-center rounded-xl border border-border px-4 py-5"
+                style={{backgroundColor: `var(${colors.placeholder})`}}
+              >
+                <span
+                  className="text-lg font-medium tracking-tight"
+                  style={contrastStyle(colors.placeholder)}
+                >
+                  Placeholder
+                </span>
+              </div>
+            </div>
+            <div className="flex-1">
+              <div
+                className="flex h-full items-center rounded-xl px-4 py-5"
+                style={{backgroundColor: `var(${colors.foreground})`}}
+              >
+                <span
+                  className="text-lg font-medium tracking-tight"
+                  style={contrastStyle(colors.foreground)}
+                >
+                  Foreground
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ColorSectionFormField({colors}: {colors: FormFieldColors}) {
+  return (
+    <div className="not-prose flex flex-col gap-4">
+      <FormFieldThemeBlock colors={colors} theme="light" />
+      <FormFieldThemeBlock colors={colors} theme="dark" />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 Description

Redesigns the colors documentation page to match the Figma design. The page now organizes colors into semantic sections (Accent, Default, Success, Warning, Danger, Foreground, Background, Surface, Form field, Separator, Other) with side-by-side light and dark theme previews, descriptive copy from Figma, and CSS variable names displayed below each color label.

## ⛳️ Current behavior (updates)

- Colors page uses simple circular swatches grouped into flat categories
- No light/dark theme split — colors display based on the user's current theme only
- No descriptions explaining the purpose of each color group
- No CSS variable names shown

## 🚀 New behavior

- Colors organized into 11 semantic sections matching the Figma design
- Two layout patterns: side-by-side columns (Accent, Default, Success, Warning, Danger) and stacked with chip labels (Foreground, Background, Surface, Form field, Separator, Other)
- Light and dark variants shown simultaneously using `data-theme` scoping
- Each section includes a descriptive paragraph explaining the color's purpose
- CSS variable names displayed as small monospace text below each color label
- Auto-contrast text using `background-clip: text` with `filter: invert(1) grayscale(1) contrast(100)` for clean black/white readability on any background
- Computed `@theme inline` variables replaced with inline `color-mix()` expressions to ensure correct resolution inside `data-theme` containers
- Uses HeroUI `Chip` component for Light/Dark theme indicators
- Applied to both React and Native docs

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

New component created: `apps/docs/src/components/color-section.tsx` with `ColorSectionSideBySide`, `ColorSectionStacked`, and `ColorSectionFormField` exports.