### PR TITLE
refactor(styles): use unprefixed source tokens across components and theme builder

### DIFF
--- a/apps/docs/src/app/themes/hooks/use-computed-theme-vars.ts
+++ b/apps/docs/src/app/themes/hooks/use-computed-theme-vars.ts
@@ -13,10 +13,8 @@ import {getCustomFontInfoFromUrl, isCustomFontUrl} from "../utils/font-utils";
 import {
   calculateAccentForeground,
   generateThemeColors,
-  getAccentDerivedVariables,
   getColorVariablesForElement,
-  getFieldDerivedVariables,
-  getSemanticDerivedVariables,
+  getDerivedColorVariables,
   parseOklch,
   radiusDerivedVariables,
 } from "../utils/generate-theme-colors";
@@ -45,44 +43,6 @@ function getCommonVars(
     "--font-sans": `var(${fontVariable})`,
     "--radius": radius,
     ...radiusDerivedVariables,
-  };
-}
-
-function getDerivedColorVars(
-  baseVars: Record<string, string>,
-  accentDerived: Record<string, string>,
-) {
-  const successDerived = getSemanticDerivedVariables(
-    "success",
-    baseVars["--success"] ?? "",
-    baseVars["--success-foreground"] ?? "",
-  );
-  const warningDerived = getSemanticDerivedVariables(
-    "warning",
-    baseVars["--warning"] ?? "",
-    baseVars["--warning-foreground"] ?? "",
-  );
-  const dangerDerived = getSemanticDerivedVariables(
-    "danger",
-    baseVars["--danger"] ?? "",
-    baseVars["--danger-foreground"] ?? "",
-  );
-  const fieldDerived = getFieldDerivedVariables(
-    baseVars["--field-background"] ?? "",
-    baseVars["--field-foreground"] ?? "",
-    baseVars["--field-placeholder"] ?? "",
-    baseVars["--border"] ?? "",
-  );
-  const defaultHover = `color-mix(in oklab, ${baseVars["--default"]} 90%, ${baseVars["--foreground"]} 10%)`;
-
-  return {
-    ...baseVars,
-    ...accentDerived,
-    ...successDerived,
-    ...warningDerived,
-    ...dangerDerived,
-    ...fieldDerived,
-    "--color-default-hover": defaultHover,
   };
 }
 
@@ -154,17 +114,23 @@ function computeThemeVars(variables: ReturnType<typeof useVariablesState>[0]): C
       "--accent": adaptiveConfig.light,
       "--accent-foreground": lightFg,
       "--focus": adaptiveConfig.light,
-      ...getAccentDerivedVariables(adaptiveConfig.light, lightFg),
     };
     const darkAccentVars = {
       "--accent": adaptiveConfig.dark,
       "--accent-foreground": darkFg,
       "--focus": adaptiveConfig.dark,
-      ...getAccentDerivedVariables(adaptiveConfig.dark, darkFg),
     };
 
-    const colorLightVars = getDerivedColorVars(lightVars, lightAccentVars);
-    const colorDarkVars = getDerivedColorVars(darkVars, darkAccentVars);
+    const colorLightVars = {
+      ...lightVars,
+      ...lightAccentVars,
+      ...getDerivedColorVariables({...lightVars, ...lightAccentVars}),
+    };
+    const colorDarkVars = {
+      ...darkVars,
+      ...darkAccentVars,
+      ...getDerivedColorVariables({...darkVars, ...darkAccentVars}),
+    };
 
     return {
       fontMeta,
@@ -184,17 +150,8 @@ function computeThemeVars(variables: ReturnType<typeof useVariablesState>[0]): C
   const lightVars = getColorVariablesForElement(colors, "light");
   const darkVars = getColorVariablesForElement(colors, "dark");
 
-  const accentDerivedLight = getAccentDerivedVariables(
-    colors.accent.oklchLight,
-    colors.accentForeground.oklchLight,
-  );
-  const accentDerivedDark = getAccentDerivedVariables(
-    colors.accent.oklchDark,
-    colors.accentForeground.oklchDark,
-  );
-
-  const colorLightVars = getDerivedColorVars(lightVars, accentDerivedLight);
-  const colorDarkVars = getDerivedColorVars(darkVars, accentDerivedDark);
+  const colorLightVars = {...lightVars, ...getDerivedColorVariables(lightVars)};
+  const colorDarkVars = {...darkVars, ...getDerivedColorVariables(darkVars)};
 
   return {
     fontMeta,

--- a/apps/docs/src/app/themes/hooks/use-css-sync.ts
+++ b/apps/docs/src/app/themes/hooks/use-css-sync.ts
@@ -18,10 +18,8 @@ import {getCustomFontInfoFromUrl, injectFontLink, isCustomFontUrl} from "../util
 import {
   calculateAccentForeground,
   generateThemeColors,
-  getAccentDerivedVariables,
   getColorVariablesForElement,
-  getFieldDerivedVariables,
-  getSemanticDerivedVariables,
+  getDerivedColorVariables,
   radiusDerivedVariables,
 } from "../utils/generate-theme-colors";
 
@@ -78,7 +76,9 @@ function buildVarsCSS(vars: Record<string, string>): string {
 }
 
 /**
- * Get common variables (radius, font) that apply to both light and dark modes
+ * Get common variables (radius, font) that apply to both light and dark modes.
+ * Derived radius values must be re-declared on scoped elements because
+ * CSS custom properties resolve var() at the level they are defined.
  */
 function getCommonVariables(
   radius: string,
@@ -131,91 +131,33 @@ function getAdaptiveColorCSS(
   const lightVars = getColorVariablesForElement(lightColors, "light");
   const darkVars = getColorVariablesForElement(darkColors, "dark");
 
-  // Get derived variables for accent
-  const accentDerivedLight = getAccentDerivedVariables(adaptiveConfig.light, lightFg);
-  const accentDerivedDark = getAccentDerivedVariables(adaptiveConfig.dark, darkFg);
-
-  // Get semantic derived variables
-  const successDerivedLight = getSemanticDerivedVariables(
-    "success",
-    lightVars["--success"] ?? "",
-    lightVars["--success-foreground"] ?? "",
-  );
-  const warningDerivedLight = getSemanticDerivedVariables(
-    "warning",
-    lightVars["--warning"] ?? "",
-    lightVars["--warning-foreground"] ?? "",
-  );
-  const dangerDerivedLight = getSemanticDerivedVariables(
-    "danger",
-    lightVars["--danger"] ?? "",
-    lightVars["--danger-foreground"] ?? "",
-  );
-
-  const successDerivedDark = getSemanticDerivedVariables(
-    "success",
-    darkVars["--success"] ?? "",
-    darkVars["--success-foreground"] ?? "",
-  );
-  const warningDerivedDark = getSemanticDerivedVariables(
-    "warning",
-    darkVars["--warning"] ?? "",
-    darkVars["--warning-foreground"] ?? "",
-  );
-  const dangerDerivedDark = getSemanticDerivedVariables(
-    "danger",
-    darkVars["--danger"] ?? "",
-    darkVars["--danger-foreground"] ?? "",
-  );
-
   const lightAccentVars = {
     "--accent": adaptiveConfig.light,
     "--accent-foreground": lightFg,
     "--focus": adaptiveConfig.light,
-    ...accentDerivedLight,
   };
 
   const darkAccentVars = {
     "--accent": adaptiveConfig.dark,
     "--accent-foreground": darkFg,
     "--focus": adaptiveConfig.dark,
-    ...accentDerivedDark,
   };
 
-  // Get field derived variables
-  const fieldDerivedLight = getFieldDerivedVariables(
-    lightVars["--field-background"] ?? "",
-    lightVars["--field-foreground"] ?? "",
-    lightVars["--field-placeholder"] ?? "",
-    lightVars["--border"] ?? "",
-  );
-  const fieldDerivedDark = getFieldDerivedVariables(
-    darkVars["--field-background"] ?? "",
-    darkVars["--field-foreground"] ?? "",
-    darkVars["--field-placeholder"] ?? "",
-    darkVars["--border"] ?? "",
-  );
-
-  // Colors only (for page level)
+  // Derived vars must be re-declared on scoped elements because
+  // CSS custom properties resolve var() at the level they are defined,
+  // not where they are inherited.
   const colorLightVars = {
     ...lightVars,
     ...lightAccentVars,
-    ...successDerivedLight,
-    ...warningDerivedLight,
-    ...dangerDerivedLight,
-    ...fieldDerivedLight,
+    ...getDerivedColorVariables({...lightVars, ...lightAccentVars}),
   };
-
   const colorDarkVars = {
     ...darkVars,
     ...darkAccentVars,
-    ...successDerivedDark,
-    ...warningDerivedDark,
-    ...dangerDerivedDark,
-    ...fieldDerivedDark,
+    ...getDerivedColorVariables({...darkVars, ...darkAccentVars}),
   };
 
-  // Full theme vars (colors + radius + fonts for content level)
+  // Content level: colors + radius + fonts
   const fullLightVars = {...commonVars, ...colorLightVars};
   const fullDarkVars = {...commonVars, ...colorDarkVars};
 
@@ -244,7 +186,8 @@ function getAdaptiveColorCSS(
 
 /**
  * Generates CSS for theme-aware colors (light/dark mode support).
- * This handles all generated theme colors including semantic colors.
+ * Derived vars must be re-declared on scoped elements because
+ * CSS custom properties resolve var() at the level they are defined.
  */
 function getThemeColorsCSS(
   chroma: number,
@@ -254,96 +197,15 @@ function getThemeColorsCSS(
   commonVars: Record<string, string>,
   semanticOverrides?: SemanticOverrides,
 ): string {
-  // Generate full theme colors
   const colors = generateThemeColors({chroma, grayChroma, hue, lightness, semanticOverrides});
 
-  // Get color variables for both modes
   const lightVars = getColorVariablesForElement(colors, "light");
   const darkVars = getColorVariablesForElement(colors, "dark");
 
-  // Get accent derived variables
-  const accentLight = colors.accent.oklchLight;
-  const accentFgLight = colors.accentForeground.oklchLight;
-  const accentDerivedLight = getAccentDerivedVariables(accentLight, accentFgLight);
+  const colorLightVars = {...lightVars, ...getDerivedColorVariables(lightVars)};
+  const colorDarkVars = {...darkVars, ...getDerivedColorVariables(darkVars)};
 
-  const accentDark = colors.accent.oklchDark;
-  const accentFgDark = colors.accentForeground.oklchDark;
-  const accentDerivedDark = getAccentDerivedVariables(accentDark, accentFgDark);
-
-  // Get semantic derived variables for light mode
-  const successDerivedLight = getSemanticDerivedVariables(
-    "success",
-    lightVars["--success"] ?? "",
-    lightVars["--success-foreground"] ?? "",
-  );
-  const warningDerivedLight = getSemanticDerivedVariables(
-    "warning",
-    lightVars["--warning"] ?? "",
-    lightVars["--warning-foreground"] ?? "",
-  );
-  const dangerDerivedLight = getSemanticDerivedVariables(
-    "danger",
-    lightVars["--danger"] ?? "",
-    lightVars["--danger-foreground"] ?? "",
-  );
-
-  // Get semantic derived variables for dark mode
-  const successDerivedDark = getSemanticDerivedVariables(
-    "success",
-    darkVars["--success"] ?? "",
-    darkVars["--success-foreground"] ?? "",
-  );
-  const warningDerivedDark = getSemanticDerivedVariables(
-    "warning",
-    darkVars["--warning"] ?? "",
-    darkVars["--warning-foreground"] ?? "",
-  );
-  const dangerDerivedDark = getSemanticDerivedVariables(
-    "danger",
-    darkVars["--danger"] ?? "",
-    darkVars["--danger-foreground"] ?? "",
-  );
-
-  // Default hover
-  const defaultHoverLight = `color-mix(in oklab, ${lightVars["--default"]} 90%, ${lightVars["--foreground"]} 10%)`;
-  const defaultHoverDark = `color-mix(in oklab, ${darkVars["--default"]} 90%, ${darkVars["--foreground"]} 10%)`;
-
-  // Get field derived variables
-  const fieldDerivedLight = getFieldDerivedVariables(
-    lightVars["--field-background"] ?? "",
-    lightVars["--field-foreground"] ?? "",
-    lightVars["--field-placeholder"] ?? "",
-    lightVars["--border"] ?? "",
-  );
-  const fieldDerivedDark = getFieldDerivedVariables(
-    darkVars["--field-background"] ?? "",
-    darkVars["--field-foreground"] ?? "",
-    darkVars["--field-placeholder"] ?? "",
-    darkVars["--border"] ?? "",
-  );
-
-  // Colors only (for page level)
-  const colorLightVars = {
-    ...lightVars,
-    ...accentDerivedLight,
-    ...successDerivedLight,
-    ...warningDerivedLight,
-    ...dangerDerivedLight,
-    ...fieldDerivedLight,
-    "--color-default-hover": defaultHoverLight,
-  };
-
-  const colorDarkVars = {
-    ...darkVars,
-    ...accentDerivedDark,
-    ...successDerivedDark,
-    ...warningDerivedDark,
-    ...dangerDerivedDark,
-    ...fieldDerivedDark,
-    "--color-default-hover": defaultHoverDark,
-  };
-
-  // Full theme vars (colors + radius + fonts for content level)
+  // Content level: colors + radius + fonts
   const fullLightVars = {...commonVars, ...colorLightVars};
   const fullDarkVars = {...commonVars, ...colorDarkVars};
 

--- a/apps/docs/src/app/themes/utils/generate-css-variables.ts
+++ b/apps/docs/src/app/themes/utils/generate-css-variables.ts
@@ -21,16 +21,14 @@ export interface CustomFontInfo {
 import {
   calculateAccentForeground,
   generateThemeColors,
-  getAccentDerivedVariables,
   getColorVariablesForElement,
-  getFieldDerivedVariables,
-  getSemanticDerivedVariables,
+  getDerivedColorVariables,
   parseOklch,
 } from "./generate-theme-colors";
 
 /**
- * Get only the base CSS variables (those defined in variables.css)
- * Excludes derived variables like --color-accent-hover, --color-accent-soft, etc.
+ * Get only the authored CSS variables that users need to customize.
+ * Derived variables are provided by the default theme stylesheet.
  */
 function getBaseColorVariables(
   colors: GeneratedThemeColors,
@@ -49,6 +47,7 @@ function getBaseColorVariables(
     "--default": getValue(colors.default),
     "--default-foreground": getValue(colors.defaultForeground),
     "--field-background": getValue(colors.fieldBackground),
+    "--field-border": "transparent",
     "--field-foreground": getValue(colors.fieldForeground),
     "--field-placeholder": getValue(colors.fieldPlaceholder),
     "--focus": getValue(colors.focus),
@@ -82,50 +81,12 @@ function buildColorVarsCSS(
   indentation = "  ",
 ): string {
   const vars = getColorVariablesForElement(colors, theme);
-
-  // Get accent derived variables
-  const accentValue = theme === "light" ? colors.accent.oklchLight : colors.accent.oklchDark;
-  const accentFgValue =
-    theme === "light" ? colors.accentForeground.oklchLight : colors.accentForeground.oklchDark;
-  const accentDerived = getAccentDerivedVariables(accentValue, accentFgValue);
-
-  // Get semantic derived variables
-  const successDerived = getSemanticDerivedVariables(
-    "success",
-    vars["--success"] ?? "",
-    vars["--success-foreground"] ?? "",
-  );
-  const warningDerived = getSemanticDerivedVariables(
-    "warning",
-    vars["--warning"] ?? "",
-    vars["--warning-foreground"] ?? "",
-  );
-  const dangerDerived = getSemanticDerivedVariables(
-    "danger",
-    vars["--danger"] ?? "",
-    vars["--danger-foreground"] ?? "",
-  );
-
-  // Default hover
-  const defaultHover = `color-mix(in oklab, ${vars["--default"]} 90%, ${vars["--foreground"]} 10%)`;
-
-  // Get field derived variables
-  const fieldDerived = getFieldDerivedVariables(
-    vars["--field-background"] ?? "",
-    vars["--field-foreground"] ?? "",
-    vars["--field-placeholder"] ?? "",
-    vars["--border"] ?? "",
-  );
+  const derivedVars = getDerivedColorVariables(vars);
 
   // Merge all vars
   const allVars = {
     ...vars,
-    ...accentDerived,
-    ...successDerived,
-    ...warningDerived,
-    ...dangerDerived,
-    ...fieldDerived,
-    "--color-default-hover": defaultHover,
+    ...derivedVars,
   };
 
   return Object.entries(allVars)
@@ -205,61 +166,6 @@ export function generateCssVariables(
     const lightVars = getColorVariablesForElement(colors, "light");
     const darkVars = getColorVariablesForElement(colors, "dark");
 
-    // Get accent derived for both modes
-    const accentDerivedLight = getAccentDerivedVariables(adaptiveConfig.light, lightFg);
-    const accentDerivedDark = getAccentDerivedVariables(adaptiveConfig.dark, darkFg);
-
-    // Get semantic derived for both modes
-    const successDerivedLight = getSemanticDerivedVariables(
-      "success",
-      lightVars["--success"] ?? "",
-      lightVars["--success-foreground"] ?? "",
-    );
-    const warningDerivedLight = getSemanticDerivedVariables(
-      "warning",
-      lightVars["--warning"] ?? "",
-      lightVars["--warning-foreground"] ?? "",
-    );
-    const dangerDerivedLight = getSemanticDerivedVariables(
-      "danger",
-      lightVars["--danger"] ?? "",
-      lightVars["--danger-foreground"] ?? "",
-    );
-
-    const successDerivedDark = getSemanticDerivedVariables(
-      "success",
-      darkVars["--success"] ?? "",
-      darkVars["--success-foreground"] ?? "",
-    );
-    const warningDerivedDark = getSemanticDerivedVariables(
-      "warning",
-      darkVars["--warning"] ?? "",
-      darkVars["--warning-foreground"] ?? "",
-    );
-    const dangerDerivedDark = getSemanticDerivedVariables(
-      "danger",
-      darkVars["--danger"] ?? "",
-      darkVars["--danger-foreground"] ?? "",
-    );
-
-    // Default hover
-    const defaultHoverLight = `color-mix(in oklab, ${lightVars["--default"]} 90%, ${lightVars["--foreground"]} 10%)`;
-    const defaultHoverDark = `color-mix(in oklab, ${darkVars["--default"]} 90%, ${darkVars["--foreground"]} 10%)`;
-
-    // Get field derived for both modes
-    const fieldDerivedLight = getFieldDerivedVariables(
-      lightVars["--field-background"] ?? "",
-      lightVars["--field-foreground"] ?? "",
-      lightVars["--field-placeholder"] ?? "",
-      lightVars["--border"] ?? "",
-    );
-    const fieldDerivedDark = getFieldDerivedVariables(
-      darkVars["--field-background"] ?? "",
-      darkVars["--field-foreground"] ?? "",
-      darkVars["--field-placeholder"] ?? "",
-      darkVars["--border"] ?? "",
-    );
-
     // Build light mode vars string
     const lightAccentVars = {
       "--accent": adaptiveConfig.light,
@@ -269,12 +175,7 @@ export function generateCssVariables(
     const allLightVars = {
       ...lightVars,
       ...lightAccentVars,
-      ...accentDerivedLight,
-      ...successDerivedLight,
-      ...warningDerivedLight,
-      ...dangerDerivedLight,
-      ...fieldDerivedLight,
-      "--color-default-hover": defaultHoverLight,
+      ...getDerivedColorVariables({...lightVars, ...lightAccentVars}),
     };
     const lightVarsCSS = Object.entries(allLightVars)
       .map(([prop, val]) => `  ${prop}: ${val};`)
@@ -289,12 +190,7 @@ export function generateCssVariables(
     const allDarkVars = {
       ...darkVars,
       ...darkAccentVars,
-      ...accentDerivedDark,
-      ...successDerivedDark,
-      ...warningDerivedDark,
-      ...dangerDerivedDark,
-      ...fieldDerivedDark,
-      "--color-default-hover": defaultHoverDark,
+      ...getDerivedColorVariables({...darkVars, ...darkAccentVars}),
     };
     const darkVarsCSS = Object.entries(allDarkVars)
       .map(([prop, val]) => `  ${prop}: ${val};`)
@@ -355,9 +251,8 @@ ${darkVarsCSS}
 }
 
 /**
- * Generates CSS output with only the base variables found in variables.css.
- * Does not include derived variables like --color-accent-hover, --color-accent-soft, etc.
- * These derived variables are automatically computed by theme.css.
+ * Generates CSS output with only the variables users need to customize.
+ * Derived variables are automatically computed by the default theme stylesheet.
  *
  * @param variables - Theme variables from the builder
  * @param customFont - Optional custom font info when using a CDN font
@@ -437,7 +332,7 @@ export function generateMinimalCssVariables(
   return `/*
  * HeroUI Theme Customization
  * Add this to your global.css after importing @heroui/styles
- * Only includes base variables from variables.css
+ * Only includes variables users need to customize
  * @see https://heroui.com/docs/react/getting-started/theming
  */
 

--- a/apps/docs/src/app/themes/utils/generate-theme-colors.ts
+++ b/apps/docs/src/app/themes/utils/generate-theme-colors.ts
@@ -709,7 +709,7 @@ function darkenForSoftForeground(oklchValue: string): string {
 }
 
 /**
- * Accent-derived CSS variables that use color-mix for hover/soft variants
+ * Accent-derived source variables used by @theme color aliases.
  */
 export function getAccentDerivedVariables(
   accentValue: string,
@@ -718,19 +718,16 @@ export function getAccentDerivedVariables(
   const softFg = darkenForSoftForeground(accentValue);
 
   return {
-    "--color-accent": "var(--accent)",
-    "--color-accent-foreground": "var(--accent-foreground)",
-    "--color-accent-hover": `color-mix(in oklab, ${accentValue} 90%, ${accentFgValue} 10%)`,
-    "--color-accent-soft": `color-mix(in oklab, ${accentValue} 15%, transparent)`,
-    "--color-accent-soft-foreground": softFg,
-    "--color-accent-soft-hover": `color-mix(in oklab, ${accentValue} 20%, transparent)`,
-    "--color-focus": "var(--focus)",
+    "--accent-hover": `color-mix(in oklab, ${accentValue} 90%, ${accentFgValue} 10%)`,
+    "--accent-soft": `color-mix(in oklab, ${accentValue} 15%, transparent)`,
+    "--accent-soft-foreground": softFg,
+    "--accent-soft-hover": `color-mix(in oklab, ${accentValue} 20%, transparent)`,
     "--tw-ring-color": "var(--focus)",
   };
 }
 
 /**
- * Semantic color derived variables (hover, soft variants)
+ * Semantic color derived source variables (hover, soft variants).
  */
 export function getSemanticDerivedVariables(
   colorName: string,
@@ -740,35 +737,71 @@ export function getSemanticDerivedVariables(
   const softFg = darkenForSoftForeground(colorValue);
 
   return {
-    [`--color-${colorName}`]: `var(--${colorName})`,
-    [`--color-${colorName}-foreground`]: `var(--${colorName}-foreground)`,
-    [`--color-${colorName}-hover`]: `color-mix(in oklab, ${colorValue} 90%, ${foregroundValue} 10%)`,
-    [`--color-${colorName}-soft`]: `color-mix(in oklab, ${colorValue} 15%, transparent)`,
-    [`--color-${colorName}-soft-foreground`]: softFg,
-    [`--color-${colorName}-soft-hover`]: `color-mix(in oklab, ${colorValue} 20%, transparent)`,
+    [`--${colorName}-hover`]: `color-mix(in oklab, ${colorValue} 90%, ${foregroundValue} 10%)`,
+    [`--${colorName}-soft`]: `color-mix(in oklab, ${colorValue} 15%, transparent)`,
+    [`--${colorName}-soft-foreground`]: softFg,
+    [`--${colorName}-soft-hover`]: `color-mix(in oklab, ${colorValue} 20%, transparent)`,
   };
 }
 
 /**
- * Field-derived CSS variables (from theme.css)
- * These are the computed field tokens based on base field variables
+ * Field-derived source variables based on base field variables.
  */
 export function getFieldDerivedVariables(
   fieldBgValue: string,
   fieldFgValue: string,
-  fieldPlaceholderValue: string,
-  borderValue: string,
+  fieldBorderValue: string,
 ): Record<string, string> {
   return {
-    // Base field color tokens (sorted alphabetically)
-    "--color-field": fieldBgValue,
-    "--color-field-border": borderValue,
-    "--color-field-border-focus": `color-mix(in oklab, ${borderValue} 74%, ${fieldFgValue} 22%)`,
-    "--color-field-border-hover": `color-mix(in oklab, ${borderValue} 88%, ${fieldFgValue} 10%)`,
-    "--color-field-focus": fieldBgValue,
-    "--color-field-foreground": fieldFgValue,
-    "--color-field-hover": `color-mix(in oklab, ${fieldBgValue} 90%, ${fieldFgValue} 2%)`,
-    "--color-field-placeholder": fieldPlaceholderValue,
+    "--field-border-focus": `color-mix(in oklab, ${fieldBorderValue} 74%, ${fieldFgValue} 22%)`,
+    "--field-border-hover": `color-mix(in oklab, ${fieldBorderValue} 88%, ${fieldFgValue} 10%)`,
+    "--field-focus": fieldBgValue,
+    "--field-hover": `color-mix(in oklab, ${fieldBgValue} 90%, ${fieldFgValue} 2%)`,
+  };
+}
+
+/**
+ * Derived source variables that mirror packages/styles/themes/default/variables.css.
+ */
+export function getDerivedColorVariables(vars: Record<string, string>): Record<string, string> {
+  const background = vars["--background"] ?? "";
+  const border = vars["--border"] ?? "";
+  const defaultColor = vars["--default"] ?? "";
+  const defaultForeground = vars["--default-foreground"] ?? "";
+  const fieldBackground = vars["--field-background"] ?? "";
+  const fieldBorder = vars["--field-border"] ?? border;
+  const fieldForeground = vars["--field-foreground"] ?? "";
+  const foreground = vars["--foreground"] ?? "";
+  const surface = vars["--surface"] ?? "";
+  const surfaceForeground = vars["--surface-foreground"] ?? "";
+
+  return {
+    "--background-inverse": foreground,
+    "--background-secondary": `color-mix(in oklab, ${background} 96%, ${foreground} 4%)`,
+    "--background-tertiary": `color-mix(in oklab, ${background} 92%, ${foreground} 8%)`,
+    "--border-secondary": `color-mix(in oklab, ${surface} 78%, ${surfaceForeground} 22%)`,
+    "--border-tertiary": `color-mix(in oklab, ${surface} 66%, ${surfaceForeground} 34%)`,
+    "--default-hover": `color-mix(in oklab, ${defaultColor} 96%, ${defaultForeground} 4%)`,
+    "--separator-secondary": `color-mix(in oklab, ${surface} 85%, ${surfaceForeground} 15%)`,
+    "--separator-tertiary": `color-mix(in oklab, ${surface} 81%, ${surfaceForeground} 19%)`,
+    "--surface-hover": `color-mix(in oklab, ${surface} 92%, ${surfaceForeground} 8%)`,
+    ...getAccentDerivedVariables(vars["--accent"] ?? "", vars["--accent-foreground"] ?? ""),
+    ...getSemanticDerivedVariables(
+      "success",
+      vars["--success"] ?? "",
+      vars["--success-foreground"] ?? "",
+    ),
+    ...getSemanticDerivedVariables(
+      "warning",
+      vars["--warning"] ?? "",
+      vars["--warning-foreground"] ?? "",
+    ),
+    ...getSemanticDerivedVariables(
+      "danger",
+      vars["--danger"] ?? "",
+      vars["--danger-foreground"] ?? "",
+    ),
+    ...getFieldDerivedVariables(fieldBackground, fieldForeground, fieldBorder),
   };
 }
 
@@ -801,9 +834,7 @@ export function getColorVariablesForElement(
 
   // Core colors
   vars["--background"] = getValue(colors.background);
-  vars["--color-background"] = getValue(colors.background);
   vars["--foreground"] = getValue(colors.foreground);
-  vars["--color-foreground"] = getValue(colors.foreground);
 
   // Accent
   vars["--accent"] = getValue(colors.accent);
@@ -812,49 +843,34 @@ export function getColorVariablesForElement(
 
   // UI colors
   vars["--muted"] = getValue(colors.muted);
-  vars["--color-muted"] = getValue(colors.muted);
 
   vars["--default"] = getValue(colors.default);
-  vars["--color-default"] = getValue(colors.default);
   vars["--default-foreground"] = getValue(colors.defaultForeground);
-  vars["--color-default-foreground"] = getValue(colors.defaultForeground);
 
   vars["--surface"] = getValue(colors.surface);
-  vars["--color-surface"] = getValue(colors.surface);
   vars["--surface-foreground"] = getValue(colors.surfaceForeground);
-  vars["--color-surface-foreground"] = getValue(colors.surfaceForeground);
 
   vars["--surface-secondary"] = getValue(colors.surfaceSecondary);
-  vars["--color-surface-secondary"] = getValue(colors.surfaceSecondary);
   vars["--surface-secondary-foreground"] = getValue(colors.surfaceSecondaryForeground);
-  vars["--color-surface-secondary-foreground"] = getValue(colors.surfaceSecondaryForeground);
 
   vars["--surface-tertiary"] = getValue(colors.surfaceTertiary);
-  vars["--color-surface-tertiary"] = getValue(colors.surfaceTertiary);
   vars["--surface-tertiary-foreground"] = getValue(colors.surfaceTertiaryForeground);
-  vars["--color-surface-tertiary-foreground"] = getValue(colors.surfaceTertiaryForeground);
 
   vars["--overlay"] = getValue(colors.overlay);
-  vars["--color-overlay"] = getValue(colors.overlay);
   vars["--overlay-foreground"] = getValue(colors.overlayForeground);
-  vars["--color-overlay-foreground"] = getValue(colors.overlayForeground);
 
   vars["--scrollbar"] = getValue(colors.scrollbar);
-  vars["--color-scrollbar"] = getValue(colors.scrollbar);
 
   vars["--segment"] = getValue(colors.segment);
-  vars["--color-segment"] = getValue(colors.segment);
   vars["--segment-foreground"] = getValue(colors.segmentForeground);
-  vars["--color-segment-foreground"] = getValue(colors.segmentForeground);
 
   vars["--border"] = getValue(colors.border);
-  vars["--color-border"] = getValue(colors.border);
 
   vars["--separator"] = getValue(colors.separator);
-  vars["--color-separator"] = getValue(colors.separator);
 
   // Field colors
   vars["--field-background"] = getValue(colors.fieldBackground);
+  vars["--field-border"] = "transparent";
   vars["--field-foreground"] = getValue(colors.fieldForeground);
   vars["--field-placeholder"] = getValue(colors.fieldPlaceholder);
 

--- a/packages/styles/components/accordion.css
+++ b/packages/styles/components/accordion.css
@@ -72,7 +72,7 @@
   @media (hover: hover) {
     &:hover:not([aria-expanded="true"]),
     &[data-hovered="true"]:not([aria-expanded="true"]) {
-      background-color: color-mix(in oklab, var(--color-foreground) 3%, transparent 90%);
+      background-color: color-mix(in oklab, var(--foreground) 3%, transparent 90%);
     }
   }
 

--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -20,7 +20,7 @@
   cursor: var(--cursor-interactive);
 
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /* Add padding-right when indicator is present */
   &:has(.autocomplete__indicator) {
@@ -32,7 +32,7 @@
     &:hover:not(:has(.autocomplete__clear-button:hover)),
     &[data-hovered="true"]:not(:has(.autocomplete__clear-button:hover)) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -40,8 +40,8 @@
   &:focus-visible:not(:focus),
   &[data-focus-visible="true"] {
     @apply status-focused;
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-focus);
+    border-color: var(--field-border-focus);
+    background-color: var(--field-focus);
   }
 
   /* Focus state */
@@ -53,7 +53,7 @@
   .autocomplete[data-invalid="true"] &,
   .autocomplete[aria-invalid="true"] & {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
   }
 
   /* Disabled state */
@@ -73,9 +73,9 @@
   @apply shadow-none;
   background-color: var(--autocomplete-trigger-bg);
 
-  --autocomplete-trigger-bg: var(--color-default);
-  --autocomplete-trigger-bg-hover: var(--color-default-hover);
-  --autocomplete-trigger-bg-focus: var(--color-default);
+  --autocomplete-trigger-bg: var(--default);
+  --autocomplete-trigger-bg-hover: var(--default-hover);
+  --autocomplete-trigger-bg-focus: var(--default);
 
   /* Exclude when clear button is hovered to prevent double hover effect */
   @media (hover: hover) {

--- a/packages/styles/components/badge.css
+++ b/packages/styles/components/badge.css
@@ -10,9 +10,9 @@
   @apply min-h-7 min-w-7 rounded-3xl text-xs leading-[1.34];
 
   /* Default tokens */
-  --badge-bg: var(--color-default);
-  --badge-fg: var(--color-default-foreground);
-  --badge-border: var(--color-background);
+  --badge-bg: var(--default);
+  --badge-fg: var(--default-foreground);
+  --badge-border: var(--background);
 
   background-color: var(--badge-bg);
   color: var(--badge-fg);
@@ -48,23 +48,23 @@
    ========================================================================== */
 
 .badge--accent {
-  --badge-fg: var(--color-accent-soft-foreground);
+  --badge-fg: var(--accent-soft-foreground);
 }
 
 .badge--default {
-  --badge-fg: var(--color-default-foreground);
+  --badge-fg: var(--default-foreground);
 }
 
 .badge--success {
-  --badge-fg: var(--color-success);
+  --badge-fg: var(--success);
 }
 
 .badge--warning {
-  --badge-fg: var(--color-warning);
+  --badge-fg: var(--warning);
 }
 
 .badge--danger {
-  --badge-fg: var(--color-danger);
+  --badge-fg: var(--danger);
 }
 
 /* ==========================================================================
@@ -112,28 +112,28 @@
    ========================================================================== */
 
 .badge--primary.badge--accent {
-  --badge-bg: var(--color-accent);
-  --badge-fg: var(--color-accent-foreground);
+  --badge-bg: var(--accent);
+  --badge-fg: var(--accent-foreground);
 }
 
 .badge--primary.badge--default {
-  --badge-bg: var(--color-default);
-  --badge-fg: var(--color-default-foreground);
+  --badge-bg: var(--default);
+  --badge-fg: var(--default-foreground);
 }
 
 .badge--primary.badge--success {
-  --badge-bg: var(--color-success);
-  --badge-fg: var(--color-success-foreground);
+  --badge-bg: var(--success);
+  --badge-fg: var(--success-foreground);
 }
 
 .badge--primary.badge--warning {
-  --badge-bg: var(--color-warning);
-  --badge-fg: var(--color-warning-foreground);
+  --badge-bg: var(--warning);
+  --badge-fg: var(--warning-foreground);
 }
 
 .badge--primary.badge--danger {
-  --badge-bg: var(--color-danger);
-  --badge-fg: var(--color-danger-foreground);
+  --badge-bg: var(--danger);
+  --badge-fg: var(--danger-foreground);
 }
 
 /* ==========================================================================
@@ -141,26 +141,26 @@
    ========================================================================== */
 
 .badge--soft.badge--accent {
-  --badge-bg: var(--color-accent-soft);
-  --badge-fg: var(--color-accent-soft-foreground);
+  --badge-bg: var(--accent-soft);
+  --badge-fg: var(--accent-soft-foreground);
 }
 
 .badge--soft.badge--default {
-  --badge-bg: var(--color-default);
-  --badge-fg: var(--color-default-foreground);
+  --badge-bg: var(--default);
+  --badge-fg: var(--default-foreground);
 }
 
 .badge--soft.badge--success {
-  --badge-bg: var(--color-success-soft);
-  --badge-fg: var(--color-success-soft-foreground);
+  --badge-bg: var(--success-soft);
+  --badge-fg: var(--success-soft-foreground);
 }
 
 .badge--soft.badge--warning {
-  --badge-bg: var(--color-warning-soft);
-  --badge-fg: var(--color-warning-soft-foreground);
+  --badge-bg: var(--warning-soft);
+  --badge-fg: var(--warning-soft-foreground);
 }
 
 .badge--soft.badge--danger {
-  --badge-bg: var(--color-danger-soft);
-  --badge-fg: var(--color-danger-soft-foreground);
+  --badge-bg: var(--danger-soft);
+  --badge-fg: var(--danger-soft-foreground);
 }

--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -93,50 +93,50 @@
 
 /* Color variants - only set custom property values */
 .button--primary {
-  --button-bg: var(--color-accent);
-  --button-bg-hover: var(--color-accent-hover);
-  --button-bg-pressed: var(--color-accent-hover);
-  --button-fg: var(--color-accent-foreground);
+  --button-bg: var(--accent);
+  --button-bg-hover: var(--accent-hover);
+  --button-bg-pressed: var(--accent-hover);
+  --button-fg: var(--accent-foreground);
 }
 
 .button--secondary {
-  --button-bg: var(--color-default);
-  --button-bg-hover: var(--color-default-hover);
-  --button-bg-pressed: var(--color-default-hover);
-  --button-fg: var(--color-accent-soft-foreground);
+  --button-bg: var(--default);
+  --button-bg-hover: var(--default-hover);
+  --button-bg-pressed: var(--default-hover);
+  --button-fg: var(--accent-soft-foreground);
 }
 
 .button--tertiary {
-  --button-bg: var(--color-default);
-  --button-bg-hover: var(--color-default-hover);
-  --button-bg-pressed: var(--color-default-hover);
+  --button-bg: var(--default);
+  --button-bg-hover: var(--default-hover);
+  --button-bg-pressed: var(--default-hover);
 }
 
 .button--ghost,
 .button--outline {
   --button-bg: transparent;
-  --button-bg-hover: var(--color-default);
-  --button-bg-pressed: var(--color-default);
-  --button-fg: var(--color-default-foreground);
+  --button-bg-hover: var(--default);
+  --button-bg-pressed: var(--default);
+  --button-fg: var(--default-foreground);
 }
 
 .button--outline {
   @apply border border-border;
-  --button-bg-hover: color-mix(in srgb, var(--color-default) 60%, transparent);
+  --button-bg-hover: color-mix(in srgb, var(--default) 60%, transparent);
 }
 
 .button--danger {
-  --button-bg: var(--color-danger);
-  --button-bg-hover: var(--color-danger-hover);
-  --button-bg-pressed: var(--color-danger-hover);
-  --button-fg: var(--color-danger-foreground);
+  --button-bg: var(--danger);
+  --button-bg-hover: var(--danger-hover);
+  --button-bg-pressed: var(--danger-hover);
+  --button-fg: var(--danger-foreground);
 }
 
 .button--danger-soft {
-  --button-bg: var(--color-danger-soft);
-  --button-bg-hover: var(--color-danger-soft-hover);
-  --button-bg-pressed: var(--color-danger-soft-hover);
-  --button-fg: var(--color-danger-soft-foreground);
+  --button-bg: var(--danger-soft);
+  --button-bg-hover: var(--danger-soft-hover);
+  --button-bg-pressed: var(--danger-soft-hover);
+  --button-fg: var(--danger-soft-foreground);
 }
 
 /* Icon-only modifier */

--- a/packages/styles/components/checkbox.css
+++ b/packages/styles/components/checkbox.css
@@ -232,7 +232,7 @@
   @apply shadow-none;
   background-color: var(--checkbox-control-bg);
 
-  --checkbox-control-bg: var(--color-default);
+  --checkbox-control-bg: var(--default);
 
   /* Hover state */
   .checkbox:hover &,

--- a/packages/styles/components/chip.css
+++ b/packages/styles/components/chip.css
@@ -3,7 +3,7 @@
   @apply inline-flex shrink-0 items-center gap-0.5 rounded-2xl px-2 py-0.5 text-xs leading-5 font-medium;
 
   /* Default tokens */
-  --chip-bg: var(--color-default);
+  --chip-bg: var(--default);
   --chip-fg: currentColor;
 
   background-color: var(--chip-bg);
@@ -16,23 +16,23 @@
 
 /* Color variants - set foreground color */
 .chip--accent {
-  --chip-fg: var(--color-accent-soft-foreground);
+  --chip-fg: var(--accent-soft-foreground);
 }
 
 .chip--danger {
-  --chip-fg: var(--color-danger);
+  --chip-fg: var(--danger);
 }
 
 .chip--default {
-  --chip-fg: var(--color-default-foreground);
+  --chip-fg: var(--default-foreground);
 }
 
 .chip--success {
-  --chip-fg: var(--color-success);
+  --chip-fg: var(--success);
 }
 
 .chip--warning {
-  --chip-fg: var(--color-warning);
+  --chip-fg: var(--warning);
 }
 
 /* Variant styles */
@@ -66,42 +66,42 @@
 
 /* Primary variants - solid backgrounds */
 .chip--primary.chip--accent {
-  --chip-bg: var(--color-accent);
-  --chip-fg: var(--color-accent-foreground);
+  --chip-bg: var(--accent);
+  --chip-fg: var(--accent-foreground);
 }
 
 .chip--primary.chip--success {
-  --chip-bg: var(--color-success);
-  --chip-fg: var(--color-success-foreground);
+  --chip-bg: var(--success);
+  --chip-fg: var(--success-foreground);
 }
 
 .chip--primary.chip--warning {
-  --chip-bg: var(--color-warning);
-  --chip-fg: var(--color-warning-foreground);
+  --chip-bg: var(--warning);
+  --chip-fg: var(--warning-foreground);
 }
 
 .chip--primary.chip--danger {
-  --chip-bg: var(--color-danger);
-  --chip-fg: var(--color-danger-foreground);
+  --chip-bg: var(--danger);
+  --chip-fg: var(--danger-foreground);
 }
 
 /* Soft variants - muted backgrounds */
 .chip--accent.chip--soft {
-  --chip-bg: var(--color-accent-soft);
-  --chip-fg: var(--color-accent-soft-foreground);
+  --chip-bg: var(--accent-soft);
+  --chip-fg: var(--accent-soft-foreground);
 }
 
 .chip--success.chip--soft {
-  --chip-bg: var(--color-success-soft);
-  --chip-fg: var(--color-success-soft-foreground);
+  --chip-bg: var(--success-soft);
+  --chip-fg: var(--success-soft-foreground);
 }
 
 .chip--warning.chip--soft {
-  --chip-bg: var(--color-warning-soft);
-  --chip-fg: var(--color-warning-soft-foreground);
+  --chip-bg: var(--warning-soft);
+  --chip-fg: var(--warning-soft-foreground);
 }
 
 .chip--danger.chip--soft {
-  --chip-bg: var(--color-danger-soft);
-  --chip-fg: var(--color-danger-soft-foreground);
+  --chip-bg: var(--danger-soft);
+  --chip-fg: var(--danger-soft-foreground);
 }

--- a/packages/styles/components/color-input-group.css
+++ b/packages/styles/components/color-input-group.css
@@ -6,7 +6,7 @@
 .color-input-group {
   @apply inline-flex h-9 items-center overflow-hidden rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /**
    * Transitions
@@ -23,7 +23,7 @@
     &:hover:not(:focus-within),
     &[data-hovered="true"]:not([data-focus-within="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -36,7 +36,7 @@
   /* Invalid state */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
     border-color: var(--color-field-border-invalid);
   }
 
@@ -98,9 +98,9 @@
   @apply shadow-none;
   background-color: var(--color-input-group-bg);
 
-  --color-input-group-bg: var(--color-default);
-  --color-input-group-bg-hover: var(--color-default-hover);
-  --color-input-group-bg-focus: var(--color-default);
+  --color-input-group-bg: var(--default);
+  --color-input-group-bg-hover: var(--default-hover);
+  --color-input-group-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus-within),

--- a/packages/styles/components/combo-box.css
+++ b/packages/styles/components/combo-box.css
@@ -25,8 +25,8 @@
     &:focus,
     &[data-focus] {
       @apply status-focused-field;
-      border-color: var(--color-field-border-focus);
-      background-color: var(--color-field-focus);
+      border-color: var(--field-border-focus);
+      background-color: var(--field-focus);
     }
 
     /* Disabled state */

--- a/packages/styles/components/date-input-group.css
+++ b/packages/styles/components/date-input-group.css
@@ -2,7 +2,7 @@
 .date-input-group {
   @apply inline-flex h-9 items-center overflow-hidden rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /**
    * Transitions
@@ -19,7 +19,7 @@
     &:hover:not(:focus-within),
     &[data-hovered="true"]:not([data-focus-within="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -46,7 +46,7 @@
   /* Invalid state */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
     border-color: var(--color-field-border-invalid);
   }
 
@@ -153,9 +153,9 @@
   @apply shadow-none;
   background-color: var(--date-input-group-bg);
 
-  --date-input-group-bg: var(--color-default);
-  --date-input-group-bg-hover: var(--color-default-hover);
-  --date-input-group-bg-focus: var(--color-default);
+  --date-input-group-bg: var(--default);
+  --date-input-group-bg-hover: var(--default-hover);
+  --date-input-group-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus-within),

--- a/packages/styles/components/input-group.css
+++ b/packages/styles/components/input-group.css
@@ -2,7 +2,7 @@
 .input-group {
   @apply inline-flex min-h-9 items-center rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /* When textarea is present, align items to start and allow height to grow */
   &:has([data-slot="input-group-textarea"]) {
@@ -25,7 +25,7 @@
     &:hover:not(:focus-within),
     &[data-hovered="true"]:not([data-focus-within="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -33,14 +33,14 @@
   &:has([data-slot="input-group-input"]:focus),
   &:has([data-slot="input-group-textarea"]:focus) {
     @apply status-focused-field;
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-focus);
+    border-color: var(--field-border-focus);
+    background-color: var(--field-focus);
   }
 
   /* Invalid state */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
     border-color: var(--color-field-border-invalid);
   }
 
@@ -80,9 +80,9 @@
 .input-group__prefix {
   @apply flex h-full items-center justify-center rounded-l-field rounded-r-none bg-transparent px-3 text-field-placeholder;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
   border-style: solid;
-  border-right-color: var(--color-field-border);
+  border-right-color: var(--field-border);
   border-left: none;
   border-top: none;
   border-bottom: none;
@@ -106,9 +106,9 @@
 .input-group__suffix {
   @apply flex h-full items-center justify-center rounded-l-none rounded-r-field bg-transparent px-3 text-field-placeholder;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
   border-style: solid;
-  border-left-color: var(--color-field-border);
+  border-left-color: var(--field-border);
   border-right: none;
   border-top: none;
   border-bottom: none;
@@ -138,9 +138,9 @@
   @apply shadow-none;
   background-color: var(--input-group-bg);
 
-  --input-group-bg: var(--color-default);
-  --input-group-bg-hover: var(--color-default-hover);
-  --input-group-bg-focus: var(--color-default);
+  --input-group-bg: var(--default);
+  --input-group-bg-hover: var(--default-hover);
+  --input-group-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus-within),

--- a/packages/styles/components/input-otp.css
+++ b/packages/styles/components/input-otp.css
@@ -19,7 +19,7 @@
   @apply rounded-field text-sm font-semibold outline-none;
 
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /**
    * Transitions
@@ -36,7 +36,7 @@
     &:hover,
     &[data-hovered="true"] {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -58,7 +58,7 @@
   /* Invalid */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
   }
 }
 
@@ -94,9 +94,9 @@
   @apply shadow-none;
   background-color: var(--input-otp-slot-bg);
 
-  --input-otp-slot-bg: var(--color-default);
-  --input-otp-slot-bg-hover: var(--color-default-hover);
-  --input-otp-slot-bg-focus: var(--color-default);
+  --input-otp-slot-bg: var(--default);
+  --input-otp-slot-bg-hover: var(--default-hover);
+  --input-otp-slot-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover,

--- a/packages/styles/components/input.css
+++ b/packages/styles/components/input.css
@@ -2,7 +2,7 @@
   @apply rounded-field border bg-field px-3 py-2 text-base text-field-foreground shadow-field outline-none placeholder:text-field-placeholder sm:text-sm;
 
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /**
    * Transitions
@@ -18,7 +18,7 @@
     &:hover:not(:focus):not(:focus-visible),
     &[data-hovered="true"]:not([data-focused="true"]):not([data-focus-visible="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -26,8 +26,8 @@
   &:focus,
   &[data-focused="true"] {
     @apply status-focused-field;
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-focus);
+    border-color: var(--field-border-focus);
+    background-color: var(--field-focus);
   }
 
   /* Focus visible state */
@@ -38,7 +38,7 @@
   /* Invalid state */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
   }
 
   /* Disabled state */
@@ -57,9 +57,9 @@
   @apply shadow-none;
   background-color: var(--input-bg);
 
-  --input-bg: var(--color-default);
-  --input-bg-hover: var(--color-default-hover);
-  --input-bg-focus: var(--color-default);
+  --input-bg: var(--default);
+  --input-bg-hover: var(--default-hover);
+  --input-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus):not(:focus-visible),

--- a/packages/styles/components/meter.css
+++ b/packages/styles/components/meter.css
@@ -11,7 +11,7 @@
   grid-template-columns: 1fr auto;
 
   /* Default color tokens (accent) */
-  --meter-fill: var(--color-accent);
+  --meter-fill: var(--accent);
 
   [data-slot="label"] {
     @apply w-fit text-sm font-medium;
@@ -92,21 +92,21 @@
    ========================================================================== */
 
 .meter--default {
-  --meter-fill: var(--color-default-foreground);
+  --meter-fill: var(--default-foreground);
 }
 
 .meter--accent {
-  --meter-fill: var(--color-accent);
+  --meter-fill: var(--accent);
 }
 
 .meter--success {
-  --meter-fill: var(--color-success);
+  --meter-fill: var(--success);
 }
 
 .meter--warning {
-  --meter-fill: var(--color-warning);
+  --meter-fill: var(--warning);
 }
 
 .meter--danger {
-  --meter-fill: var(--color-danger);
+  --meter-fill: var(--danger);
 }

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -17,7 +17,7 @@
 .number-field__group {
   @apply grid h-9 items-center overflow-hidden rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
   grid-template-columns: 40px 1fr 40px;
 
   /**
@@ -35,7 +35,7 @@
     &:hover:not(:focus-within),
     &[data-hovered="true"]:not([data-focus-within="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -43,14 +43,14 @@
   &[data-focus-within="true"],
   &:focus-within {
     @apply status-focused-field;
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-focus);
+    border-color: var(--field-border-focus);
+    background-color: var(--field-focus);
   }
 
   /* Invalid state */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
     border-color: var(--color-field-border-invalid);
   }
 
@@ -85,7 +85,7 @@
 .number-field__decrement-button {
   @apply flex h-full w-10 items-center justify-center rounded-none bg-transparent text-field-foreground outline-none;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
   border-style: solid;
 
   /**
@@ -148,9 +148,9 @@
   @apply shadow-none;
   background-color: var(--number-field-group-bg);
 
-  --number-field-group-bg: var(--color-default);
-  --number-field-group-bg-hover: var(--color-default-hover);
-  --number-field-group-bg-focus: var(--color-default);
+  --number-field-group-bg: var(--default);
+  --number-field-group-bg-hover: var(--default-hover);
+  --number-field-group-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus-within),

--- a/packages/styles/components/pagination.css
+++ b/packages/styles/components/pagination.css
@@ -40,9 +40,9 @@
 
   /* Ghost button tokens */
   --pagination-link-bg: transparent;
-  --pagination-link-bg-hover: var(--color-default-hover);
-  --pagination-link-bg-pressed: var(--color-default-hover);
-  --pagination-link-fg: var(--color-default-foreground);
+  --pagination-link-bg-hover: var(--default-hover);
+  --pagination-link-bg-pressed: var(--default-hover);
+  --pagination-link-fg: var(--default-foreground);
 
   background-color: var(--pagination-link-bg);
   color: var(--pagination-link-fg);
@@ -76,9 +76,9 @@
 
   /* Active page - tertiary button style */
   &[data-active="true"] {
-    --pagination-link-bg: var(--color-default);
-    --pagination-link-bg-hover: var(--color-default-hover);
-    --pagination-link-bg-pressed: var(--color-default-hover);
+    --pagination-link-bg: var(--default);
+    --pagination-link-bg-hover: var(--default-hover);
+    --pagination-link-bg-pressed: var(--default-hover);
   }
 }
 

--- a/packages/styles/components/progress-bar.css
+++ b/packages/styles/components/progress-bar.css
@@ -11,7 +11,7 @@
   grid-template-columns: 1fr auto;
 
   /* Default color token (accent) */
-  --progress-bar-fill: var(--color-accent);
+  --progress-bar-fill: var(--accent);
 
   [data-slot="label"] {
     @apply w-fit text-sm font-medium;
@@ -116,21 +116,21 @@
    ========================================================================== */
 
 .progress-bar--default {
-  --progress-bar-fill: var(--color-default-foreground);
+  --progress-bar-fill: var(--default-foreground);
 }
 
 .progress-bar--accent {
-  --progress-bar-fill: var(--color-accent);
+  --progress-bar-fill: var(--accent);
 }
 
 .progress-bar--success {
-  --progress-bar-fill: var(--color-success);
+  --progress-bar-fill: var(--success);
 }
 
 .progress-bar--warning {
-  --progress-bar-fill: var(--color-warning);
+  --progress-bar-fill: var(--warning);
 }
 
 .progress-bar--danger {
-  --progress-bar-fill: var(--color-danger);
+  --progress-bar-fill: var(--danger);
 }

--- a/packages/styles/components/progress-circle.css
+++ b/packages/styles/components/progress-circle.css
@@ -7,8 +7,8 @@
   @apply inline-flex items-center justify-center;
 
   /* Default color token (accent) */
-  --progress-circle-stroke: var(--color-accent);
-  --progress-circle-track-stroke: var(--color-default);
+  --progress-circle-stroke: var(--accent);
+  --progress-circle-track-stroke: var(--default);
 
   .progress-circle__track {
     /* Default size (matches --md) */
@@ -85,21 +85,21 @@
    ========================================================================== */
 
 .progress-circle--default {
-  --progress-circle-stroke: var(--color-default-foreground);
+  --progress-circle-stroke: var(--default-foreground);
 }
 
 .progress-circle--accent {
-  --progress-circle-stroke: var(--color-accent);
+  --progress-circle-stroke: var(--accent);
 }
 
 .progress-circle--success {
-  --progress-circle-stroke: var(--color-success);
+  --progress-circle-stroke: var(--success);
 }
 
 .progress-circle--warning {
-  --progress-circle-stroke: var(--color-warning);
+  --progress-circle-stroke: var(--warning);
 }
 
 .progress-circle--danger {
-  --progress-circle-stroke: var(--color-danger);
+  --progress-circle-stroke: var(--danger);
 }

--- a/packages/styles/components/radio-group.css
+++ b/packages/styles/components/radio-group.css
@@ -23,8 +23,8 @@
   @apply shadow-none;
   background-color: var(--radio-control-bg);
 
-  --radio-control-bg: var(--color-default);
-  --radio-control-bg-hover: var(--color-default-hover);
+  --radio-control-bg: var(--default);
+  --radio-control-bg-hover: var(--default-hover);
 
   /* Hover state */
   .radio:hover &,

--- a/packages/styles/components/search-field.css
+++ b/packages/styles/components/search-field.css
@@ -23,7 +23,7 @@
 .search-field__group {
   @apply relative inline-flex h-9 items-center overflow-hidden rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /**
    * Transitions
@@ -40,7 +40,7 @@
     &:hover:not(:focus-within),
     &[data-hovered="true"]:not([data-focus-within="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -53,7 +53,7 @@
   /* Invalid state */
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
     border-color: var(--color-field-border-invalid);
   }
 
@@ -114,9 +114,9 @@
   @apply shadow-none;
   background-color: var(--search-field-group-bg);
 
-  --search-field-group-bg: var(--color-default);
-  --search-field-group-bg-hover: var(--color-default-hover);
-  --search-field-group-bg-focus: var(--color-default);
+  --search-field-group-bg: var(--default);
+  --search-field-group-bg-hover: var(--default-hover);
+  --search-field-group-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus-within),

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -31,7 +31,7 @@
   cursor: var(--cursor-interactive);
 
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /* Add padding-right when indicator is present */
   &:has(.select__indicator) {
@@ -43,7 +43,7 @@
     &:hover,
     &[data-hovered="true"] {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -51,8 +51,8 @@
   &:focus-visible:not(:focus),
   &[data-focus-visible="true"] {
     @apply status-focused;
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-focus);
+    border-color: var(--field-border-focus);
+    background-color: var(--field-focus);
   }
 
   /* Focus state */
@@ -64,7 +64,7 @@
   .select[data-invalid="true"] &,
   .select[aria-invalid="true"] & {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
   }
 
   /* Disabled state */
@@ -84,9 +84,9 @@
   @apply shadow-none;
   background-color: var(--select-trigger-bg);
 
-  --select-trigger-bg: var(--color-default);
-  --select-trigger-bg-hover: var(--color-default-hover);
-  --select-trigger-bg-focus: var(--color-default);
+  --select-trigger-bg: var(--default);
+  --select-trigger-bg-hover: var(--default-hover);
+  --select-trigger-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover,

--- a/packages/styles/components/switch.css
+++ b/packages/styles/components/switch.css
@@ -6,11 +6,11 @@
   cursor: var(--cursor-interactive);
 
   /* Default tokens for switch control states */
-  --switch-control-bg: var(--color-default);
+  --switch-control-bg: var(--default);
   --switch-control-bg-hover: color-mix(in oklab, var(--switch-control-bg), transparent 20%);
   --switch-control-bg-pressed: var(--switch-control-bg-hover);
-  --switch-control-bg-checked: var(--color-accent);
-  --switch-control-bg-checked-hover: var(--color-accent-hover);
+  --switch-control-bg-checked: var(--accent);
+  --switch-control-bg-checked-hover: var(--accent-hover);
 
   /* Disabled state */
   &:disabled,

--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -166,7 +166,7 @@
   &:focus-visible,
   &[data-focus-visible="true"] {
     @apply rounded-lg outline-none;
-    box-shadow: inset 0 0 0 2px var(--color-focus);
+    box-shadow: inset 0 0 0 2px var(--focus);
   }
 }
 
@@ -260,7 +260,7 @@
   &:focus-visible,
   &[data-focus-visible="true"] {
     @apply rounded-lg outline-none;
-    box-shadow: inset 0 0 0 2px var(--color-focus);
+    box-shadow: inset 0 0 0 2px var(--focus);
   }
 }
 
@@ -279,7 +279,7 @@
 .table__row:is(:focus-visible, [data-focus-visible="true"])
   > *:only-child
   :is(.table__cell, .table__column) {
-  @apply rounded-lg shadow-[inset_0_0_0_2px_var(--color-focus)] outline-none;
+  @apply rounded-lg shadow-[inset_0_0_0_2px_var(--focus)] outline-none;
 }
 
 .table__row:is(:focus-visible, [data-focus-visible="true"])
@@ -287,7 +287,7 @@
 .table__row:is(:focus-visible, [data-focus-visible="true"])
   > *:first-child:not(:only-child)
   :is(.table__cell, .table__column) {
-  @apply rounded-l-lg shadow-[inset_2px_0_0_0_var(--color-focus),inset_0_2px_0_0_var(--color-focus),inset_0_-2px_0_0_var(--color-focus)] outline-none;
+  @apply rounded-l-lg shadow-[inset_2px_0_0_0_var(--focus),inset_0_2px_0_0_var(--focus),inset_0_-2px_0_0_var(--focus)] outline-none;
 }
 
 .table__row:is(:focus-visible, [data-focus-visible="true"])
@@ -295,7 +295,7 @@
 .table__row:is(:focus-visible, [data-focus-visible="true"])
   > *:last-child:not(:only-child)
   :is(.table__cell, .table__column) {
-  @apply rounded-r-lg shadow-[inset_-2px_0_0_0_var(--color-focus),inset_0_2px_0_0_var(--color-focus),inset_0_-2px_0_0_var(--color-focus)] outline-none;
+  @apply rounded-r-lg shadow-[inset_-2px_0_0_0_var(--focus),inset_0_2px_0_0_var(--focus),inset_0_-2px_0_0_var(--focus)] outline-none;
 }
 
 .table__row:is(:focus-visible, [data-focus-visible="true"])
@@ -303,7 +303,7 @@
 .table__row:is(:focus-visible, [data-focus-visible="true"])
   > *:not(:first-child):not(:last-child):not(:only-child)
   :is(.table__cell, .table__column) {
-  @apply shadow-[inset_0_2px_0_0_var(--color-focus),inset_0_-2px_0_0_var(--color-focus)] outline-none;
+  @apply shadow-[inset_0_2px_0_0_var(--focus),inset_0_-2px_0_0_var(--focus)] outline-none;
 }
 
 /* --------------------------------------------------------------------------

--- a/packages/styles/components/textarea.css
+++ b/packages/styles/components/textarea.css
@@ -5,7 +5,7 @@
   min-height: 38px;
 
   border-width: var(--border-width-field);
-  border-color: var(--color-field-border);
+  border-color: var(--field-border);
 
   /**
    * Transitions
@@ -21,7 +21,7 @@
     &:hover:not(:focus):not(:focus-visible),
     &[data-hovered="true"]:not([data-focused="true"]):not([data-focus-visible="true"]) {
       @apply bg-field-hover;
-      border-color: var(--color-field-border-hover);
+      border-color: var(--field-border-hover);
     }
   }
 
@@ -29,8 +29,8 @@
   &:focus,
   &[data-focused="true"] {
     @apply status-focused-field;
-    border-color: var(--color-field-border-focus);
-    background-color: var(--color-field-focus);
+    border-color: var(--field-border-focus);
+    background-color: var(--field-focus);
   }
 
   /* Focus visible state */
@@ -40,7 +40,7 @@
 
   &[data-invalid="true"] {
     @apply status-invalid-field;
-    background-color: var(--color-field-focus);
+    background-color: var(--field-focus);
   }
 
   /* Disabled state */
@@ -59,9 +59,9 @@
   @apply shadow-none;
   background-color: var(--textarea-bg);
 
-  --textarea-bg: var(--color-default);
-  --textarea-bg-hover: var(--color-default-hover);
-  --textarea-bg-focus: var(--color-default);
+  --textarea-bg: var(--default);
+  --textarea-bg-hover: var(--default-hover);
+  --textarea-bg-focus: var(--default);
 
   @media (hover: hover) {
     &:hover:not(:focus):not(:focus-visible),

--- a/packages/styles/components/toggle-button.css
+++ b/packages/styles/components/toggle-button.css
@@ -20,16 +20,16 @@
   cursor: var(--cursor-interactive);
 
   /* Default tokens (unselected state) */
-  --toggle-button-bg: var(--color-default);
-  --toggle-button-bg-hover: var(--color-default-hover);
-  --toggle-button-bg-pressed: var(--color-default-hover);
+  --toggle-button-bg: var(--default);
+  --toggle-button-bg-hover: var(--default-hover);
+  --toggle-button-bg-pressed: var(--default-hover);
   --toggle-button-fg: currentColor;
 
   /* Selected state tokens */
-  --toggle-button-bg-selected: var(--color-accent-soft);
-  --toggle-button-bg-selected-hover: var(--color-accent-soft-hover);
-  --toggle-button-bg-selected-pressed: var(--color-accent-soft-hover);
-  --toggle-button-fg-selected: var(--color-accent-soft-foreground);
+  --toggle-button-bg-selected: var(--accent-soft);
+  --toggle-button-bg-selected-hover: var(--accent-soft-hover);
+  --toggle-button-bg-selected-pressed: var(--accent-soft-hover);
+  --toggle-button-fg-selected: var(--accent-soft-foreground);
 
   background-color: var(--toggle-button-bg);
   color: var(--toggle-button-fg);
@@ -120,16 +120,16 @@
    ========================================================================== */
 
 .toggle-button--default {
-  --toggle-button-bg: var(--color-default);
-  --toggle-button-bg-hover: var(--color-default-hover);
-  --toggle-button-bg-pressed: var(--color-default-hover);
+  --toggle-button-bg: var(--default);
+  --toggle-button-bg-hover: var(--default-hover);
+  --toggle-button-bg-pressed: var(--default-hover);
 }
 
 .toggle-button--ghost {
   --toggle-button-bg: transparent;
-  --toggle-button-bg-hover: var(--color-default);
-  --toggle-button-bg-pressed: var(--color-default);
-  --toggle-button-fg: var(--color-default-foreground);
+  --toggle-button-bg-hover: var(--default);
+  --toggle-button-bg-pressed: var(--default);
+  --toggle-button-fg: var(--default-foreground);
 }
 
 /* ==========================================================================

--- a/packages/styles/themes/default/variables.css
+++ b/packages/styles/themes/default/variables.css
@@ -93,6 +93,58 @@
     /* Backdrop */
     --backdrop: rgba(0, 0, 0, 0.5);
 
+    /* Calculated Colors */
+    --surface-hover: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
+
+    --background-secondary: color-mix(in oklab, var(--background) 96%, var(--foreground) 4%);
+    --background-tertiary: color-mix(in oklab, var(--background) 92%, var(--foreground) 8%);
+    --background-inverse: var(--foreground);
+
+    --default-hover: color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%);
+    --accent-hover: color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%);
+    --success-hover: color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%);
+    --warning-hover: color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%);
+    --danger-hover: color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%);
+
+    --field-hover: color-mix(
+      in oklab,
+      var(--field-background, var(--default)) 90%,
+      var(--field-foreground, var(--foreground)) 2%
+    );
+    --field-focus: var(--field-background, var(--default));
+    --field-border-hover: color-mix(
+      in oklab,
+      var(--field-border, var(--border)) 88%,
+      var(--field-foreground, var(--foreground)) 10%
+    );
+    --field-border-focus: color-mix(
+      in oklab,
+      var(--field-border, var(--border)) 74%,
+      var(--field-foreground, var(--foreground)) 22%
+    );
+
+    --accent-soft: color-mix(in oklab, var(--accent) 15%, transparent);
+    --accent-soft-foreground: var(--accent);
+    --accent-soft-hover: color-mix(in oklab, var(--accent) 20%, transparent);
+
+    --danger-soft: color-mix(in oklab, var(--danger) 15%, transparent);
+    --danger-soft-foreground: var(--danger);
+    --danger-soft-hover: color-mix(in oklab, var(--danger) 20%, transparent);
+
+    --warning-soft: color-mix(in oklab, var(--warning) 15%, transparent);
+    --warning-soft-foreground: var(--warning);
+    --warning-soft-hover: color-mix(in oklab, var(--warning) 20%, transparent);
+
+    --success-soft: color-mix(in oklab, var(--success) 15%, transparent);
+    --success-soft-foreground: var(--success);
+    --success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
+
+    --separator-secondary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
+    --separator-tertiary: color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%);
+
+    --border-secondary: color-mix(in oklab, var(--surface) 78%, var(--surface-foreground) 22%);
+    --border-tertiary: color-mix(in oklab, var(--surface) 66%, var(--surface-foreground) 34%);
+
     /* Shadows */
     /* --surface-shadow: 0 0px 0px 0 rgba(24, 24, 27, 0.03), 0 2px 10px 0 rgba(24, 24, 27, 0.08); */
     --surface-shadow:

--- a/packages/styles/themes/shared/theme.css
+++ b/packages/styles/themes/shared/theme.css
@@ -4,7 +4,7 @@
 
   --color-surface: var(--surface);
   --color-surface-foreground: var(--surface-foreground);
-  --color-surface-hover: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
+  --color-surface-hover: var(--surface-hover);
 
   --color-surface-secondary: var(--surface-secondary);
   --color-surface-secondary-foreground: var(--surface-secondary-foreground);
@@ -48,96 +48,53 @@
 
   /* Form Field Tokens */
   --color-field: var(--field-background, var(--default));
-  --color-field-hover: color-mix(
-    in oklab,
-    var(--field-background, var(--default)) 90%,
-    var(--field-foreground, var(--default-foreground)) 10%
-  );
+  --color-field-hover: var(--field-hover);
   --color-field-foreground: var(--field-foreground, var(--foreground));
   --color-field-placeholder: var(--field-placeholder, var(--muted));
   --color-field-border: var(--field-border, var(--border));
   --radius-field: var(--field-radius, calc(var(--radius) * 1.5));
   --border-width-field: var(--field-border-width, var(--border-width));
 
-  /* Calculated Variables */
+  /* Color Tokens */
+  --color-background-secondary: var(--background-secondary);
+  --color-background-tertiary: var(--background-tertiary);
+  --color-background-inverse: var(--background-inverse);
 
-  /* Colors */
-
-  /* --- background shades --- */
-  --color-background-secondary: color-mix(in oklab, var(--background) 96%, var(--foreground) 4%);
-  --color-background-tertiary: color-mix(in oklab, var(--background) 92%, var(--foreground) 8%);
-  --color-background-inverse: var(--foreground);
-
-  /* ------------------------- */
-  --color-default-hover: color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%);
-  --color-accent-hover: color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%);
-  --color-success-hover: color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%);
-  --color-warning-hover: color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%);
-  --color-danger-hover: color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%);
+  --color-default-hover: var(--default-hover);
+  --color-accent-hover: var(--accent-hover);
+  --color-success-hover: var(--success-hover);
+  --color-warning-hover: var(--warning-hover);
+  --color-danger-hover: var(--danger-hover);
 
   /* Form Field Colors */
-  --color-field-hover: color-mix(
-    in oklab,
-    var(--field-background, var(--default)) 90%,
-    var(--field-foreground, var(--foreground)) 2%
-  );
-  --color-field-focus: var(--field-background, var(--default));
-  --color-field-border-hover: color-mix(
-    in oklab,
-    var(--field-border, var(--border)) 88%,
-    var(--field-foreground, var(--foreground)) 10%
-  );
-  --color-field-border-focus: color-mix(
-    in oklab,
-    var(--field-border, var(--border)) 74%,
-    var(--field-foreground, var(--foreground)) 22%
-  );
+  --color-field-focus: var(--field-focus);
+  --color-field-border-hover: var(--field-border-hover);
+  --color-field-border-focus: var(--field-border-focus);
 
   /* Soft Colors */
-  --color-accent-soft: var(--accent-soft, color-mix(in oklab, var(--accent) 15%, transparent));
-  --color-accent-soft-foreground: var(--accent-soft-foreground, var(--accent));
-  --color-accent-soft-hover: var(
-    --accent-soft-hover,
-    color-mix(in oklab, var(--accent) 20%, transparent)
-  );
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-soft-foreground: var(--accent-soft-foreground);
+  --color-accent-soft-hover: var(--accent-soft-hover);
 
-  --color-danger-soft: var(--danger-soft, color-mix(in oklab, var(--danger) 15%, transparent));
-  --color-danger-soft-foreground: var(--danger-soft-foreground, var(--danger));
-  --color-danger-soft-hover: var(
-    --danger-soft-hover,
-    color-mix(in oklab, var(--danger) 20%, transparent)
-  );
+  --color-danger-soft: var(--danger-soft);
+  --color-danger-soft-foreground: var(--danger-soft-foreground);
+  --color-danger-soft-hover: var(--danger-soft-hover);
 
-  --color-warning-soft: var(--warning-soft, color-mix(in oklab, var(--warning) 15%, transparent));
-  --color-warning-soft-foreground: var(--warning-soft-foreground, var(--warning));
-  --color-warning-soft-hover: var(
-    --warning-soft-hover,
-    color-mix(in oklab, var(--warning) 20%, transparent)
-  );
+  --color-warning-soft: var(--warning-soft);
+  --color-warning-soft-foreground: var(--warning-soft-foreground);
+  --color-warning-soft-hover: var(--warning-soft-hover);
 
-  --color-success-soft: var(--success-soft, color-mix(in oklab, var(--success) 15%, transparent));
-  --color-success-soft-foreground: var(--success-soft-foreground, var(--success));
-  --color-success-soft-hover: var(
-    --success-soft-hover,
-    color-mix(in oklab, var(--success) 20%, transparent)
-  );
+  --color-success-soft: var(--success-soft);
+  --color-success-soft-foreground: var(--success-soft-foreground);
+  --color-success-soft-hover: var(--success-soft-hover);
 
   /* Separator Colors - Levels */
-  --color-separator-secondary: color-mix(
-    in oklab,
-    var(--surface) 85%,
-    var(--surface-foreground) 15%
-  );
-  --color-separator-tertiary: color-mix(
-    in oklab,
-    var(--surface) 81%,
-    var(--surface-foreground) 19%
-  );
+  --color-separator-secondary: var(--separator-secondary);
+  --color-separator-tertiary: var(--separator-tertiary);
 
-  /* Border Colors - Levels (progressive contrast: default → secondary → tertiary) */
-  /* Light mode: lighter → darker | Dark mode: darker → lighter */
-  --color-border-secondary: color-mix(in oklab, var(--surface) 78%, var(--surface-foreground) 22%);
-  --color-border-tertiary: color-mix(in oklab, var(--surface) 66%, var(--surface-foreground) 34%);
+  /* Border Colors - Levels */
+  --color-border-secondary: var(--border-secondary);
+  --color-border-tertiary: var(--border-tertiary);
 
   /* Radius and default sizes - defaults can change by just changing the --radius */
   --radius-xs: calc(var(--radius) * 0.25); /* 0.125rem (2px) */


### PR DESCRIPTION
## 📝 Description

Moves calculated color tokens (hover, soft, border-secondary, etc.) from `@theme inline` in `theme.css` into `variables.css` as unprefixed source variables. Updates all 24 component CSS files to reference source tokens directly (e.g. `var(--default)` instead of `var(--color-default)`), and consolidates the theme builder's derived-token generation into a single `getDerivedColorVariables()` helper emitting unprefixed vars.

## ⛳️ Current behavior (updates)

- `theme.css` (`@theme inline`) contained inline `color-mix()` / `calc()` calculations for derived tokens like `--color-accent-hover`, `--color-default-hover`, soft variants, border levels, etc.
- Component CSS files referenced Tailwind-namespaced `var(--color-*)` tokens in raw CSS property values.
- Theme builder had three separate derived-token helpers (`getAccentDerivedVariables`, `getSemanticDerivedVariables`, `getFieldDerivedVariables`) each emitting `--color-*` prefixed vars.

## 🚀 New behavior

- `variables.css` now owns all derived color formulas as unprefixed source tokens (e.g. `--accent-hover`, `--default-hover`, `--background-secondary`).
- `theme.css` is pure aliases only: `--color-accent-hover: var(--accent-hover)`, etc.
- 24 component CSS files use source tokens directly: `var(--default)`, `var(--accent-soft-foreground)`, etc.
- Theme builder uses a single `getDerivedColorVariables()` that emits all unprefixed derived vars, including the `darkenForSoftForeground` logic for readable soft foreground colors.
- Iframe (Pro templates) payload is unchanged — still sends the full set of vars via `postMessage` for backwards compatibility until Pro updates to the latest styles.

## 💣 Is this a breaking change (Yes/No):

No — `@theme inline` still exposes all `--color-*` Tailwind utilities as aliases to the source tokens, so Tailwind class usage (`bg-default`, `text-accent`, etc.) is unaffected. Only raw `var(--color-*)` references in component CSS were updated.

## 📝 Additional Information

- Pro iframe templates will need to update to latest `@heroui/styles` to pick up derived var overrides from the theme builder. Base color overrides (`--accent`, `--default`, etc.) continue working immediately.
- CSS custom properties resolve `var()` at the level they are defined, so derived vars must still be re-declared on scoped elements (theme builder preview). This is handled by the `getDerivedColorVariables()` helper in `useCssSync()`.