### PR TITLE
fix(styles): use accent soft foreground for default hover

### DIFF
--- a/apps/docs/content/docs/react/migration/styling.mdx
+++ b/apps/docs/content/docs/react/migration/styling.mdx
@@ -414,7 +414,7 @@ v2 provided a `secondary` semantic color (purple). This has been removed in v3. 
 | `bg-secondary-50` | `bg-default` | Use default color |
 | `border-secondary` | `border-accent` | Use accent border |
 
-**Note:** In v3, "secondary" refers to a component variant style (like `button--secondary`), not a color token. The secondary variant typically uses `bg-default` and `text-accent`.
+**Note:** In v3, "secondary" refers to a component variant style (like `button--secondary`), not a color token. The secondary variant typically uses `bg-default` and `text-accent-soft-foreground`.
 
 ### Numbered Color Scales Removed
 

--- a/apps/docs/src/components/search-dialog.tsx
+++ b/apps/docs/src/components/search-dialog.tsx
@@ -105,7 +105,7 @@ function useProSearch(query: string, tag: "web" | "native") {
 }
 
 const tagStyles = tv({
-  base: "bg-default/80 px-2 data-[selected=true]:bg-accent-soft data-[selected=true]:text-accent",
+  base: "bg-default/80 px-2 data-[selected=true]:bg-accent-soft data-[selected=true]:text-accent-soft-foreground",
 });
 
 export default function CustomSearchDialog(props: SharedProps) {

--- a/packages/styles/components/calendar-year-picker.css
+++ b/packages/styles/components/calendar-year-picker.css
@@ -75,7 +75,7 @@
 }
 
 .calendar-year-picker__trigger-indicator {
-  @apply text-xs text-accent;
+  @apply text-xs text-accent-soft-foreground;
 
   transition: transform 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
@@ -87,7 +87,7 @@
 }
 
 .calendar-year-picker__trigger[data-open="true"] .calendar-year-picker__trigger-heading {
-  @apply text-accent;
+  @apply text-accent-soft-foreground;
 }
 
 /* -----------------------------------------------------------------------------

--- a/packages/styles/components/calendar.css
+++ b/packages/styles/components/calendar.css
@@ -32,7 +32,7 @@
 }
 
 .calendar__nav-button {
-  @apply flex size-6 items-center justify-center rounded-2xl text-accent;
+  @apply flex size-6 items-center justify-center rounded-2xl text-accent-soft-foreground;
 
   will-change: scale;
 
@@ -53,7 +53,7 @@
   @media (hover: hover) {
     &:hover,
     &[data-hovered="true"] {
-      @apply bg-default text-accent;
+      @apply bg-default text-accent-soft-foreground;
     }
   }
 
@@ -157,7 +157,7 @@
 
   /* Today indicator */
   &[data-today="true"] {
-    @apply text-accent;
+    @apply text-accent-soft-foreground;
   }
 
   /* Selected state */

--- a/packages/styles/components/range-calendar.css
+++ b/packages/styles/components/range-calendar.css
@@ -32,7 +32,7 @@
 }
 
 .range-calendar__nav-button {
-  @apply flex size-6 items-center justify-center rounded-xl text-accent;
+  @apply flex size-6 items-center justify-center rounded-xl text-accent-soft-foreground;
 
   will-change: scale;
 
@@ -53,7 +53,7 @@
   @media (hover: hover) {
     &:hover,
     &[data-hovered="true"] {
-      @apply bg-default text-accent;
+      @apply bg-default text-accent-soft-foreground;
     }
   }
 
@@ -169,7 +169,7 @@
   /* Today indicator */
   &[data-today="true"] {
     .range-calendar__cell-button {
-      @apply text-accent;
+      @apply text-accent-soft-foreground;
     }
   }
 


### PR DESCRIPTION
## Summary\n- replace default hover accent text with accent soft foreground in calendar and range calendar\n- align the docs search tag selected state with accent-soft foreground\n- update migration docs to mention text-accent-soft-foreground\n\n## Verification\n- scanned repo for raw bg-default + text-accent combos; none remain