### PR TITLE
fix(styles): disable twMerge for textVariants

### DIFF
--- a/packages/styles/src/components/text/text.styles.ts
+++ b/packages/styles/src/components/text/text.styles.ts
@@ -2,49 +2,56 @@ import type {VariantProps} from "tailwind-variants";
 
 import {tv} from "tailwind-variants";
 
-export const textVariants = tv({
-  defaultVariants: {
-    align: "start",
-    color: "default",
-    type: "body",
+export const textVariants = tv(
+  {
+    defaultVariants: {
+      align: "start",
+      color: "default",
+      type: "body",
+    },
+    slots: {
+      base: "text",
+      prose: "text-prose",
+    },
+    variants: {
+      align: {
+        center: "text--align-center",
+        end: "text--align-end",
+        justify: "text--align-justify",
+        start: "text--align-start",
+      },
+      color: {
+        default: "text--color-default",
+        muted: "text--color-muted",
+      },
+      truncate: {
+        true: "text--truncate",
+      },
+      type: {
+        body: "text--body",
+        "body-sm": "text--body-sm",
+        "body-xs": "text--body-xs",
+        code: "text--code",
+        h1: "text--h1",
+        h2: "text--h2",
+        h3: "text--h3",
+        h4: "text--h4",
+        h5: "text--h5",
+        h6: "text--h6",
+      },
+      weight: {
+        bold: "text--weight-bold",
+        medium: "text--weight-medium",
+        normal: "text--weight-normal",
+        semibold: "text--weight-semibold",
+      },
+    },
   },
-  slots: {
-    base: "text",
-    prose: "text-prose",
+  {
+    // `text--*` BEM modifiers are mistaken for Tailwind `text-*` utilities by tailwind-merge,
+    // which would drop `text--color-muted` when combined with e.g. `text--body-sm`.
+    twMerge: false,
   },
-  variants: {
-    align: {
-      center: "text--align-center",
-      end: "text--align-end",
-      justify: "text--align-justify",
-      start: "text--align-start",
-    },
-    color: {
-      default: "text--color-default",
-      muted: "text--color-muted",
-    },
-    truncate: {
-      true: "text--truncate",
-    },
-    type: {
-      body: "text--body",
-      "body-sm": "text--body-sm",
-      "body-xs": "text--body-xs",
-      code: "text--code",
-      h1: "text--h1",
-      h2: "text--h2",
-      h3: "text--h3",
-      h4: "text--h4",
-      h5: "text--h5",
-      h6: "text--h6",
-    },
-    weight: {
-      bold: "text--weight-bold",
-      medium: "text--weight-medium",
-      normal: "text--weight-normal",
-      semibold: "text--weight-semibold",
-    },
-  },
-});
+);
 
 export type TextVariants = VariantProps<typeof textVariants>;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6497

## 📝 Description

<!--- Add a brief description -->

tailwind-merge treats BEM classes like `text--body-sm` and `text--color-muted` as conflicting `text-*` utilities, so the last one won and color="muted" was dropped. Disable `twMerge` for textVariants so modifiers stack correctly.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Taking [this story] as an example, you can see the class names from the second paragraph:

`text text--body-sm`

<img width="731" height="174" alt="image" src="https://github.com/user-attachments/assets/5089047b-c069-45a3-b699-690180ec7764" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

`text text--align-start text--color-muted text--body-sm`

<img width="698" height="170" alt="image" src="https://github.com/user-attachments/assets/d507947f-13c9-4af6-9df3-539e41c6d45a" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
