### PR TITLE
fix(styles): add field border width to checkbox control

### DIFF
--- a/packages/styles/components/checkbox.css
+++ b/packages/styles/components/checkbox.css
@@ -83,7 +83,7 @@
    ========================================================================== */
 
 .checkbox__control {
-  @apply relative inline-flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-md bg-field shadow-field outline-none no-highlight;
+  @apply relative inline-flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-md border [border-width:var(--border-width-field)] border-field-border bg-field shadow-field outline-none no-highlight;
 
   /**
    * Transitions
@@ -91,6 +91,7 @@
    */
   transition:
     background-color 200ms var(--ease-out),
+    border-color 200ms var(--ease-out),
     transform 100ms var(--ease-out);
   @apply motion-reduce:transition-none;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Add base field border styling to `.checkbox__control`, aligning it with the existing `radio__control` pattern. Both primary and secondary checkbox variants now inherit the same base field border unless a state override (selected, indeterminate, invalid) applies.

## ⛳️ Current behavior (updates)

`.checkbox__control` had no explicit border or border-width, relying solely on `shadow-field` for its visual boundary. This was inconsistent with `.radio__control`, which already used `border border-field-border [border-width:var(--border-width-field)]`.

## 🚀 New behavior

- `.checkbox__control` base styles now include `border`, `border-field-border`, and `[border-width:var(--border-width-field)]`
- `border-color` is added to the transition list for smooth color changes on hover/selection
- All existing overrides are preserved:
  - **Hover**: `border-field-border-hover`
  - **Selected**: `border-transparent` (border hidden behind accent fill)
  - **Invalid (unselected)**: `status-invalid-field`
  - **Invalid + Selected**: `border-transparent bg-danger`
  - **Secondary variant**: inherits the same base border; hover override unchanged

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

### Validation

```
$ pnpm --filter @heroui/styles build
✨ Build completed successfully!

$ pnpm --filter @heroui/styles typecheck
tsc --noEmit  (exit 0)

$ pnpm lint
Tasks: 3 successful, 3 total
```

All validation commands passed with zero errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f52c296-bf42-4717-a106-b551657e5445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f52c296-bf42-4717-a106-b551657e5445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

