### PR TITLE
fix(styles): use field-border for radio default border color

### DIFF
--- a/packages/styles/components/radio.css
+++ b/packages/styles/components/radio.css
@@ -28,7 +28,7 @@
    ========================================================================== */
 
 .radio__control {
-  @apply relative mt-[3px] inline-flex size-4 shrink-0 items-center justify-center rounded-lg border [border-width:var(--border-width-field)] bg-field shadow-field outline-none no-highlight;
+  @apply relative mt-[3px] inline-flex size-4 shrink-0 items-center justify-center rounded-lg border [border-width:var(--border-width-field)] border-field-border bg-field shadow-field outline-none no-highlight;
 
   /**
    * Transitions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #7336

## 📝 Description

Updates the radio component's `.radio__control` to use `border-field-border` for its default/unselected border color instead of the generic `border` color. This aligns the radio with other field components (`input`, `select`, `textarea`, `number-field`) that already use `field-border` for their default border.

## ⛳️ Current behavior (updates)

The `.radio__control` uses the generic Tailwind `border` utility, which applies the default border color (`currentColor` / configured border color). This is inconsistent with other field components that use the field-specific border color.

## 🚀 New behavior

The `.radio__control` now uses `border-field-border` which resolves to `--color-field-border: var(--field-border, var(--border))`. This:

- Sets the default/unselected border to the field-specific border color
- Keeps `var(--border-width-field)` for border width (unchanged)
- Preserves hover state: `border-field-border-hover` (line 55)
- Preserves selected state: `border-transparent bg-accent` (line 76)
- Preserves focus state: `status-focused` (line 49)
- Preserves invalid state: `status-invalid-field` (line 89)

## 💣 Is this a breaking change (Yes/No):

No. The border color change uses the existing `--field-border` design token which falls back to `var(--border)` when not explicitly set.

## 📝 Additional Information

### Validation

```
$ pnpm --filter @heroui/styles build
✨ Build completed successfully!

$ pnpm lint
Tasks: 3 successful, 3 total
```

Both the `@heroui/styles` build and full repository lint pass with no errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2879abe3-5a5e-4088-8d6a-c5689af9ee43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2879abe3-5a5e-4088-8d6a-c5689af9ee43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

