### PR TITLE
fix(checkbox): add field border width to checkbox control

### DIFF
--- a/packages/styles/components/checkbox.css
+++ b/packages/styles/components/checkbox.css
@@ -83,7 +83,7 @@
    ========================================================================== */
 
 .checkbox__control {
-  @apply relative inline-flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-md bg-field shadow-field outline-none no-highlight;
+  @apply relative inline-flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-md border [border-width:var(--border-width-field)] border-field-border bg-field shadow-field outline-none no-highlight;
 
   /**
    * Transitions
@@ -91,6 +91,7 @@
    */
   transition:
     background-color 200ms var(--ease-out),
+    border-color 200ms var(--ease-out),
     transform 100ms var(--ease-out);
   @apply motion-reduce:transition-none;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Add field border width support to the checkbox control (`.checkbox__control`), matching the existing pattern used by the radio control (`.radio__control`). This ensures checkboxes respect the `--border-width-field` CSS variable for consistent field border styling across form components.

## ⛳️ Current behavior (updates)

The `.checkbox__control` has no explicit border or border-width set, so it does not honor the `--border-width-field` theme variable that other field components (radio, input, textarea, select, etc.) already use.

## 🚀 New behavior

- `.checkbox__control` now includes `border border-field-border [border-width:var(--border-width-field)]` in its base styles
- `border-color` added to the transition list for smooth state changes
- All existing state overrides are preserved:
  - **Selected**: `border-transparent` hides the border
  - **Indeterminate**: `bg-accent` fills the control
  - **Invalid (unselected)**: `status-invalid-field` applies
  - **Invalid + Selected**: `border-transparent` + `bg-danger`
  - **Secondary variant**: hover still applies `border-field-border-hover`
- Both primary and secondary checkboxes inherit the same base field border unless state overrides apply

## 💣 Is this a breaking change (Yes/No):

No. The default theme sets `--field-border-width: 0px` and `--field-border: transparent`, so visual output is unchanged unless the consumer customizes these variables.

## 📝 Additional Information

### Validation commands and results

```
$ pnpm --filter @heroui/styles build
✨ Build completed successfully!

$ pnpm --filter @heroui/react typecheck
(exit code 0, no errors)
```

### Pattern reference

This change mirrors the existing `radio__control` implementation:

```css
/* radio.css */
.radio__control {
  @apply ... border [border-width:var(--border-width-field)] ...;
  transition:
    background-color 200ms var(--ease-out),
    border-color 200ms var(--ease-out),
    transform 100ms var(--ease-out);
}
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dfd5358-dbab-46a2-bc78-075d4380c304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dfd5358-dbab-46a2-bc78-075d4380c304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

