### PR TITLE
fix(styles): use field-border color for radio control border

### DIFF
--- a/packages/styles/components/radio.css
+++ b/packages/styles/components/radio.css
@@ -28,7 +28,7 @@
    ========================================================================== */
 
 .radio__control {
-  @apply relative mt-[3px] inline-flex size-4 shrink-0 items-center justify-center rounded-lg border [border-width:var(--border-width-field)] bg-field shadow-field outline-none no-highlight;
+  @apply relative mt-[3px] inline-flex size-4 shrink-0 items-center justify-center rounded-lg border [border-width:var(--border-width-field)] border-field-border bg-field shadow-field outline-none no-highlight;
 
   /**
    * Transitions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes # <!-- Related to: Change border color to radio component -->

## 📝 Description

Changes the `.radio__control` default border color from the generic `border` token to `border-field-border`, aligning the radio component with other form field components (input, checkbox, number-field, etc.) that already use the field-specific border color.

## ⛳️ Current behavior (updates)

The `.radio__control` uses the generic `border` utility class, which applies `border-color: var(--color-border)` — the global border color. This is inconsistent with other form field components that use the field-specific border color token.

## 🚀 New behavior

The `.radio__control` now uses `border border-field-border`, which applies `border-color: var(--color-field-border)` (resolves to `var(--field-border, var(--border))`). This means:

- **Default/unselected**: uses `field-border` color instead of generic `border`
- **Hover**: still uses `border-field-border-hover` (unchanged)
- **Selected**: still overrides to `border-transparent bg-accent` (unchanged)
- **Invalid**: still uses `status-invalid-field` (unchanged)
- **`var(--border-width-field)`**: preserved (unchanged)

Only the default/unselected radio border color changes.

## 💣 Is this a breaking change (Yes/No):

No. The `--color-field-border` variable defaults to `var(--field-border, var(--border))`, which falls back to the same generic border color if no field-specific override is set. Themes that customize `--field-border` will now correctly affect the radio component.

## 📝 Additional Information

### Validation Results

All validation commands passed successfully:

```
$ pnpm --filter @heroui/styles build   → ✅ Build completed successfully
$ pnpm --filter @heroui/react build    → ✅ Build completed successfully
$ pnpm lint                            → ✅ 3/3 tasks successful
$ pnpm typecheck                       → ✅ 4/4 tasks successful
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6988a40-e6d1-40a8-a313-80d1d98220e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6988a40-e6d1-40a8-a313-80d1d98220e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

