### PR TITLE
fix(pagination): improve active state contrast on surfaces

### DIFF
--- a/packages/react/src/components/pagination/pagination.stories.tsx
+++ b/packages/react/src/components/pagination/pagination.stories.tsx
@@ -400,3 +400,71 @@ export const Disabled = {
   args: defaultArgs,
   render: DisabledTemplate,
 };
+
+/* -------------------------------------------------------------------------------------------------
+ * On Surface (demonstrates contrast on gray backgrounds)
+ * -----------------------------------------------------------------------------------------------*/
+const OnSurfaceTemplate = (props: PaginationProps) => {
+  const [page, setPage] = React.useState(1);
+  const pages = [1, 2, 3, 4, 5];
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-semibold text-muted">On white background (default)</span>
+        <div className="rounded-xl bg-surface p-4">
+          <Pagination {...props}>
+            <Pagination.Content>
+              {pages.map((p) => (
+                <Pagination.Item key={p}>
+                  <Pagination.Link isActive={p === page} onPress={() => setPage(p)}>
+                    {p}
+                  </Pagination.Link>
+                </Pagination.Item>
+              ))}
+            </Pagination.Content>
+          </Pagination>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-semibold text-muted">
+          On surface-secondary (e.g. table footer)
+        </span>
+        <div className="rounded-xl bg-surface-secondary p-4">
+          <Pagination {...props}>
+            <Pagination.Content>
+              {pages.map((p) => (
+                <Pagination.Item key={p}>
+                  <Pagination.Link isActive={p === page} onPress={() => setPage(p)}>
+                    {p}
+                  </Pagination.Link>
+                </Pagination.Item>
+              ))}
+            </Pagination.Content>
+          </Pagination>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-semibold text-muted">On surface-tertiary</span>
+        <div className="rounded-xl bg-surface-tertiary p-4">
+          <Pagination {...props}>
+            <Pagination.Content>
+              {pages.map((p) => (
+                <Pagination.Item key={p}>
+                  <Pagination.Link isActive={p === page} onPress={() => setPage(p)}>
+                    {p}
+                  </Pagination.Link>
+                </Pagination.Item>
+              ))}
+            </Pagination.Content>
+          </Pagination>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const OnSurface = {
+  args: defaultArgs,
+  render: OnSurfaceTemplate,
+};

--- a/packages/styles/components/pagination.css
+++ b/packages/styles/components/pagination.css
@@ -74,11 +74,20 @@
     transform: scale(0.97);
   }
 
-  /* Active page - tertiary button style */
+  /* Active page - high-contrast inverted style for visibility on all surfaces */
   &[data-active="true"] {
-    --pagination-link-bg: var(--color-default);
-    --pagination-link-bg-hover: var(--color-default-hover);
-    --pagination-link-bg-pressed: var(--color-default-hover);
+    --pagination-link-bg: var(--color-foreground);
+    --pagination-link-bg-hover: color-mix(
+      in oklab,
+      var(--color-foreground) 85%,
+      var(--color-background) 15%
+    );
+    --pagination-link-bg-pressed: color-mix(
+      in oklab,
+      var(--color-foreground) 80%,
+      var(--color-background) 20%
+    );
+    --pagination-link-fg: var(--color-background);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6488

## 📝 Description

The Pagination component's active page indicator was barely visible when placed on gray surfaces (e.g. table footers). This was because the active state used `--color-default` (oklch 94% lightness) which is nearly identical to `--surface-secondary` (oklch 95.24% lightness) — a difference of only ~1.24% in lightness.

This PR switches the active page style to a high-contrast inverted approach using foreground/background color tokens, ensuring clear visibility on any surface in both light and dark modes.

## ⛳️ Current behavior (updates)

- Active pagination page uses `--color-default` as background (a very light gray, ~94% lightness)
- On white backgrounds this was acceptable but still subtle
- On `surface-secondary` backgrounds (e.g., table footer with ~95% lightness), the active page was nearly invisible — only 1.24% contrast difference

## 🚀 New behavior

- Active pagination page now uses `--color-foreground` as background with `--color-background` as text color
- This provides high contrast on **any** surface in both light and dark modes:
  - Light mode: dark (~21% lightness) pill on any light surface
  - Dark mode: light (~99% lightness) pill on any dark surface
- Hover and pressed states use `color-mix()` to provide subtle interactive feedback while maintaining contrast
- Added an "On Surface" Storybook story demonstrating pagination on different surface backgrounds

## 💣 Is this a breaking change (Yes/No):

No. The change only affects the visual appearance of the active page indicator. No API changes.

## 📝 Additional Information

### Validation

```
$ pnpm --filter @heroui/styles build
✨ Build completed successfully!

$ pnpm --filter @heroui/react build
✨ Build completed successfully!

$ pnpm --filter @heroui/react typecheck
tsc --noEmit (exit code 0)

$ pnpm lint
Tasks: 3 successful, 3 total (0 errors)
```

### Files Changed

- `packages/styles/components/pagination.css` — Updated active state tokens from low-contrast `--color-default` to high-contrast `foreground`/`background` inversion
- `packages/react/src/components/pagination/pagination.stories.tsx` — Added "On Surface" story demonstrating pagination on white, `surface-secondary`, and `surface-tertiary` backgrounds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24a9ecb1-01f1-4532-9ddd-8763837a7dfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24a9ecb1-01f1-4532-9ddd-8763837a7dfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

