### PR TITLE
chore(docs): add missing init cmd options & add agents-md content

### DIFF
--- a/apps/docs/content/docs/react/getting-started/(overview)/cli.mdx
+++ b/apps/docs/content/docs/react/getting-started/(overview)/cli.mdx
@@ -4,7 +4,7 @@ description: Use the CLI to manage HeroUI dependencies and initialize projects.
 icon: terminal
 ---
 
-The CLI offers a comprehensive suite of commands to initialize, manage, and improve your HeroUI projects. It enables you to `install`, `uninstall`, or `upgrade` individual components, assess the health of your project, and more.
+The CLI offers a comprehensive suite of commands to initialize, manage, and improve your HeroUI projects. It enables you to `install`, `uninstall`, or `upgrade` individual components, assess the health of your project, download documentation for AI coding agents, and more.
 
 ## Installation
 
@@ -76,6 +76,7 @@ Commands:
   list [options]                 Lists installed HeroUI packages (@heroui/react, @heroui/styles)
   env [options]                  Displays debugging information for the local environment
   doctor [options]               Checks for issues in the project
+  agents-md [options]            Downloads HeroUI documentation for AI coding agents
   help [command]                 Display help for command
 ```
 
@@ -84,8 +85,14 @@ Commands:
 Initialize a new HeroUI project using the `init` command. This sets up your project with the necessary configurations.
 
 ```bash
-heroui init
+heroui init [options]
 ```
+
+**Options:**
+
+- `-t --template [string]` The template to use for the new project e.g. app, pages, vite
+- `-p --package [string]` The package manager to use for the new project
+
 output:
 
 ```bash
@@ -350,6 +357,58 @@ Environment Info:
   Binaries:
     Node: v25.8.1
 ```
+
+### agents-md
+
+Download HeroUI documentation for AI coding agents (Claude, Cursor, etc.). The command clones the latest docs from the HeroUI repository and injects a compact index into `AGENTS.md` or `CLAUDE.md` so assistants can reference your project's HeroUI setup.
+
+```bash
+heroui agents-md [options]
+```
+
+**Options:**
+
+- `--react` [boolean] Include React docs only (one library at a time)
+- `--native` [boolean] Include Native docs only
+- `--migration` [boolean] Include HeroUI v2 to v3 migration docs only
+- `--output <file>` [string] Target file path (e.g., `AGENTS.md`, `CLAUDE.md`)
+- `--ssh` [boolean] Use SSH instead of HTTPS for git clone
+
+**Examples:**
+
+Run without flags to enter interactive mode:
+
+```bash
+heroui agents-md
+```
+
+Download React docs to a specific file:
+
+```bash
+heroui agents-md --react --output AGENTS.md
+```
+
+Download Native or migration docs:
+
+```bash
+heroui agents-md --native --output CLAUDE.md
+heroui agents-md --migration --output AGENTS.md
+```
+
+**How it works:**
+
+1. Clones documentation from the `v3` branch using git sparse-checkout
+2. Generates a compact index of doc and demo files
+3. Injects the index into your markdown file between markers (`<!-- HEROUI-REACT-AGENTS-MD-START -->` / `<!-- HEROUI-REACT-AGENTS-MD-END -->`, and similar for Native and Migration)
+4. Adds `.heroui-docs/` to `.gitignore`
+
+Only one of `--react`, `--native`, or `--migration` can be selected at a time.
+
+For more details, see [AGENTS.md](/docs/react/getting-started/agents-md).
+
+<Callout>
+  The `agents-md` command collects anonymous usage data (selection, output file names, duration, success or error). Set `HEROUI_ANALYTICS_DISABLED=1` to opt out.
+</Callout>
 
 ## Reporting issues
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

This pull request updates the HeroUI CLI documentation to introduce the new `agents-md` command, which helps users download and inject HeroUI documentation for AI coding agents into their projects. It also enhances the documentation for the `init` command by detailing its options. The most important changes are grouped below:

**New CLI Command Documentation:**

* Added documentation for the new `agents-md` command, which downloads HeroUI documentation for AI coding agents (e.g., Claude, Cursor) and injects a compact index into markdown files such as `AGENTS.md` or `CLAUDE.md`. The documentation covers usage, options, examples, and how the command works.
* Included the `agents-md` command in the CLI commands list, making it visible alongside existing commands.
* Updated the CLI overview to mention that users can now download documentation for AI coding agents using the CLI.

**Enhancements to Existing Command Documentation:**

* Expanded the documentation for the `init` command to describe available options, such as specifying a template or package manager when initializing a new project.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
