### PR TITLE
fix(fieldset): forward disabled state to descendant fields

### DIFF
--- a/packages/react/src/components/fieldset/fieldset.tsx
+++ b/packages/react/src/components/fieldset/fieldset.tsx
@@ -5,6 +5,7 @@ import type {ReactNode} from "react";
 
 import {fieldsetVariants} from "@heroui/styles";
 import React, {createContext, useContext} from "react";
+import {Provider, RadioGroupContext, SliderContext} from "react-aria-components";
 
 import {composeSlotClassName} from "../../utils/compose";
 import {dom} from "../../utils/dom";
@@ -29,14 +30,43 @@ interface FieldsetRootProps<
 }
 
 const FieldsetRoot = <E extends keyof React.JSX.IntrinsicElements = "fieldset">({
+  children,
   className,
   ...props
 }: FieldsetRootProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof FieldsetRootProps<E>>) => {
   const slots = React.useMemo(() => fieldsetVariants({}), []);
 
+  // Mirror native `<fieldset disabled>` as `data-disabled="true"` so the
+  // existing `[data-disabled="true"] .label` (and similar) ancestor selectors
+  // cascade disabled styling to descendant fields, just like a direct
+  // `isDisabled` prop on TextField/Checkbox/etc. would.
+  const isDisabled = "disabled" in props && props.disabled === true;
+
   return (
     <FieldsetContext value={{slots}}>
-      <dom.fieldset className={slots?.base({className})} data-slot="fieldset" {...(props as any)} />
+      <dom.fieldset
+        className={slots?.base({className})}
+        data-disabled={isDisabled || undefined}
+        data-slot="fieldset"
+        {...(props as any)}
+      >
+        {isDisabled ? (
+          // Slider and RadioGroup render as <div> (no native form controls),
+          // so the browser doesn't propagate <fieldset disabled> to them.
+          // Forward `isDisabled` explicitly via React Aria's context so their
+          // wrapper elements receive `data-disabled` and behave as disabled.
+          <Provider
+            values={[
+              [RadioGroupContext, {isDisabled: true}],
+              [SliderContext, {isDisabled: true}],
+            ]}
+          >
+            {children}
+          </Provider>
+        ) : (
+          children
+        )}
+      </dom.fieldset>
     </FieldsetContext>
   );
 };

--- a/packages/styles/components/input.css
+++ b/packages/styles/components/input.css
@@ -42,6 +42,7 @@
   }
 
   /* Disabled state */
+  &:disabled,
   &[data-disabled="true"],
   &[aria-disabled="true"] {
     @apply status-disabled;

--- a/packages/styles/components/textarea.css
+++ b/packages/styles/components/textarea.css
@@ -44,6 +44,7 @@
   }
 
   /* Disabled state */
+  &:disabled,
   &[data-disabled="true"],
   &[aria-disabled="true"] {
     @apply status-disabled;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #6517
- Closes #6518

## 📝 Description

<!--- Add a brief description -->

A `<TextField>` inside `<Fieldset disabled>` did not render the same disabled styling as `<TextField isDisabled>`, because React Aria components don't observe ancestor `<fieldset disabled>` state and the Input/TextArea CSS only matched data-disabled, not native `:disabled`.
- Set `data-disabled="true"` on the `<fieldset>` when disabled, so existing  ancestor selectors (e.g. `[data-disabled="true"] .label`) cascade.
- Forward isDisabled via React Aria's `<Provider>` for SliderContext and  RadioGroupContext, since those components render as plain <div>s and  aren't reached by the browser's native fieldset propagation.
- Add `:disabled` to input.css and textarea.css so the input element  itself picks up native fieldset-inherited disabled styling.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="280" height="849" alt="image" src="https://github.com/user-attachments/assets/fe6d998f-8fca-49f3-9372-c1afa29b2b4f" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="295" height="863" alt="image" src="https://github.com/user-attachments/assets/d1d2dbf1-ad36-4c79-911d-d138fa7b05e2" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
