### PR TITLE
fix(docs): sync home iframe demo themes

### DIFF
--- a/apps/docs/src/app/(home)/components/demo-showcase.tsx
+++ b/apps/docs/src/app/(home)/components/demo-showcase.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type {ThemeId} from "../../themes/constants";
 import type {CSSProperties} from "react";
 import type {Color} from "react-aria-components";
 
@@ -12,8 +13,16 @@ import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 
 import {DemoComponents} from "@/components/demo";
 import {cn} from "@/utils/cn";
+import {
+  DEFAULT_DESIGN_THEME,
+  DESIGN_THEME_CHANGE_EVENT,
+  DESIGN_THEME_STORAGE_KEY,
+  getStoredDesignTheme,
+  isDesignThemeId,
+} from "@/utils/design-theme";
 
-import {HEROUI_PRO_URL, iframeTabs} from "../../themes/constants";
+import {HEROUI_PRO_URL, iframeTabs, themeValuesById} from "../../themes/constants";
+import {computeThemeVars} from "../../themes/hooks";
 import {
   calculateAccentForeground,
   getAccentDerivedVariables,
@@ -76,6 +85,7 @@ const LOADER_DURATION_MS = 250;
 export function DemoShowcase() {
   const [selectedTab, setSelectedTab] = useState("components");
   const [selectedColor, setSelectedColor] = useState<Color | null>(null);
+  const [activeDesignTheme, setActiveDesignTheme] = useState<ThemeId>(getStoredDesignTheme);
   const [iframeLoading, setIframeLoading] = useState(true);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const {resolvedTheme} = useTheme();
@@ -84,6 +94,20 @@ export function DemoShowcase() {
     () => (selectedColor ? getAccentStyleVars(selectedColor) : {}),
     [selectedColor],
   );
+
+  const computedDesignThemeVars = useMemo(
+    () => computeThemeVars(themeValuesById[activeDesignTheme]),
+    [activeDesignTheme],
+  );
+
+  const iframeThemeVars = useMemo(() => {
+    const modeVars =
+      resolvedTheme === "light"
+        ? computedDesignThemeVars.fullLightVars
+        : computedDesignThemeVars.fullDarkVars;
+
+    return Object.keys(accentVars).length > 0 ? {...modeVars, ...accentVars} : modeVars;
+  }, [accentVars, computedDesignThemeVars, resolvedTheme]);
 
   const themeBuilderHref = useMemo(() => {
     const params = new URLSearchParams();
@@ -114,15 +138,51 @@ export function DemoShowcase() {
     }
   }
 
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setActiveDesignTheme(getStoredDesignTheme());
+    });
+
+    function handleDesignThemeChange(event: Event) {
+      const themeId = (event as CustomEvent<{themeId?: string}>).detail?.themeId;
+
+      if (isDesignThemeId(themeId)) {
+        setActiveDesignTheme(themeId);
+      }
+    }
+
+    function handleStorage(event: StorageEvent) {
+      if (event.key !== DESIGN_THEME_STORAGE_KEY) return;
+
+      setActiveDesignTheme(isDesignThemeId(event.newValue) ? event.newValue : DEFAULT_DESIGN_THEME);
+    }
+
+    window.addEventListener(DESIGN_THEME_CHANGE_EVENT, handleDesignThemeChange);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener(DESIGN_THEME_CHANGE_EVENT, handleDesignThemeChange);
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
   const sendMessageToIframe = useCallback(() => {
     const iframe = iframeRef.current;
 
     if (!iframe?.contentWindow) return;
     iframe.contentWindow.postMessage({theme: resolvedTheme ?? "dark", type: "heroui-theme"}, "*");
-    if (Object.keys(accentVars).length > 0) {
-      iframe.contentWindow.postMessage({type: "heroui-accent", vars: accentVars}, "*");
-    }
-  }, [accentVars, resolvedTheme]);
+    iframe.contentWindow.postMessage({type: "heroui-accent", vars: iframeThemeVars}, "*");
+    iframe.contentWindow.postMessage(
+      {
+        cdnUrl: computedDesignThemeVars.fontMeta.cdnUrl,
+        family: computedDesignThemeVars.fontMeta.family,
+        type: "heroui-font",
+        variable: computedDesignThemeVars.fontMeta.variable,
+      },
+      "*",
+    );
+  }, [computedDesignThemeVars.fontMeta, iframeThemeVars, resolvedTheme]);
 
   // Re-send whenever theme or accent changes
   useEffect(() => {

--- a/apps/docs/src/app/themes/hooks/index.ts
+++ b/apps/docs/src/app/themes/hooks/index.ts
@@ -1,5 +1,5 @@
-export {useComputedThemeVars} from "./use-computed-theme-vars";
-export type {FontMeta} from "./use-computed-theme-vars";
+export {computeThemeVars, useComputedThemeVars} from "./use-computed-theme-vars";
+export type {ComputedThemeVars, FontMeta} from "./use-computed-theme-vars";
 export {useCssSync} from "./use-css-sync";
 export {useCustomFonts} from "./use-custom-fonts";
 export type {CustomFont} from "./use-custom-fonts";

--- a/apps/docs/src/app/themes/hooks/use-computed-theme-vars.ts
+++ b/apps/docs/src/app/themes/hooks/use-computed-theme-vars.ts
@@ -27,7 +27,7 @@ export interface FontMeta {
   family: string;
 }
 
-interface ComputedThemeVars {
+export interface ComputedThemeVars {
   fullLightVars: Record<string, string>;
   fullDarkVars: Record<string, string>;
   fontMeta: FontMeta;
@@ -46,7 +46,9 @@ function getCommonVars(
   };
 }
 
-function computeThemeVars(variables: ReturnType<typeof useVariablesState>[0]): ComputedThemeVars {
+export function computeThemeVars(
+  variables: ReturnType<typeof useVariablesState>[0],
+): ComputedThemeVars {
   const {base, chroma, hue, lightness} = variables;
   const accentColor = `oklch(${lightness} ${chroma} ${hue})`;
   const isAdaptive = accentColor in adaptiveColors;

--- a/apps/docs/src/app/themes/hooks/use-computed-theme-vars.ts
+++ b/apps/docs/src/app/themes/hooks/use-computed-theme-vars.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import type {ThemeValues} from "../constants";
+
 import {useMemo} from "react";
 
 import {
@@ -46,9 +48,7 @@ function getCommonVars(
   };
 }
 
-export function computeThemeVars(
-  variables: ReturnType<typeof useVariablesState>[0],
-): ComputedThemeVars {
+export function computeThemeVars(variables: ThemeValues): ComputedThemeVars {
   const {base, chroma, hue, lightness} = variables;
   const accentColor = `oklch(${lightness} ${chroma} ${hue})`;
   const isAdaptive = accentColor in adaptiveColors;

--- a/apps/docs/src/components/design-theme-selector.tsx
+++ b/apps/docs/src/components/design-theme-selector.tsx
@@ -22,11 +22,15 @@ import rabbitTheme from "@/assets/themes/rabbit.png";
 import skyTheme from "@/assets/themes/sky.png";
 import spotifyTheme from "@/assets/themes/spotify.png";
 import {cn} from "@/utils/cn";
-
-const STORAGE_KEY = "heroui-docs-design-theme";
+import {
+  DESIGN_THEME_STORAGE_KEY,
+  getStoredDesignTheme,
+  isDesignThemeId,
+  notifyDesignThemeChange,
+} from "@/utils/design-theme";
 
 interface ThemeOption {
-  id: string;
+  id: ThemeId;
   label: string;
   image: StaticImageData;
 }
@@ -49,7 +53,7 @@ function removeThemeCssLink() {
   document.getElementById("design-theme-css-link")?.remove();
 }
 
-function applyTheme(themeId: string) {
+function applyTheme(themeId: ThemeId) {
   const root = document.documentElement;
   const isDefault = themeId === "default";
 
@@ -63,16 +67,16 @@ function applyTheme(themeId: string) {
 }
 
 export function DesignThemeSelector() {
-  const [active, setActive] = useState("default");
+  const [active, setActive] = useState<ThemeId>("default");
   const [mounted, setMounted] = useState(false);
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => setMounted(true), []);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = getStoredDesignTheme();
 
-    if (stored && THEMES.some((t) => t.id === stored)) {
+    if (stored !== "default") {
       setActive(stored);
       applyTheme(stored);
     }
@@ -83,18 +87,18 @@ export function DesignThemeSelector() {
     if (keys === "all") return;
     const selected = [...keys][0];
 
-    if (typeof selected !== "string") return;
+    if (typeof selected !== "string" || !isDesignThemeId(selected)) return;
     setActive(selected);
-    localStorage.setItem(STORAGE_KEY, selected);
+    localStorage.setItem(DESIGN_THEME_STORAGE_KEY, selected);
     applyTheme(selected);
+    notifyDesignThemeChange(selected);
   }, []);
 
   const current = THEMES.find((t) => t.id === active);
   const showAvatar = mounted && active !== "default" && current;
 
   const themeBuilderHref = useMemo(() => {
-    const themeId = active as ThemeId;
-    const values = themeValuesById[themeId];
+    const values = themeValuesById[active];
 
     if (!values) {
       return "/themes";

--- a/apps/docs/src/utils/design-theme.ts
+++ b/apps/docs/src/utils/design-theme.ts
@@ -1,0 +1,29 @@
+import type {ThemeId} from "@/app/themes/constants";
+
+import {themeIds} from "@/app/themes/constants";
+
+export const DEFAULT_DESIGN_THEME: ThemeId = "default";
+export const DESIGN_THEME_STORAGE_KEY = "heroui-docs-design-theme";
+export const DESIGN_THEME_CHANGE_EVENT = "heroui-docs-design-theme-change";
+
+export function isDesignThemeId(value: string | null | undefined): value is ThemeId {
+  return themeIds.includes(value as ThemeId);
+}
+
+export function getStoredDesignTheme(): ThemeId {
+  if (typeof window === "undefined") {
+    return DEFAULT_DESIGN_THEME;
+  }
+
+  const stored = window.localStorage.getItem(DESIGN_THEME_STORAGE_KEY);
+
+  return isDesignThemeId(stored) ? stored : DEFAULT_DESIGN_THEME;
+}
+
+export function notifyDesignThemeChange(themeId: ThemeId) {
+  window.dispatchEvent(
+    new CustomEvent(DESIGN_THEME_CHANGE_EVENT, {
+      detail: {themeId},
+    }),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Fixes the desktop home page iframe demos so they receive the active design theme preset, matching the behavior of the `/themes` preview.

## ⛳️ Current behavior (updates)

The home page components demo inherited design theme CSS from the parent document, but iframe-based demos only received light/dark mode and optional accent swatch variables.

## 🚀 New behavior

The design theme selector now broadcasts preset changes, and the home page iframe demos send the full computed theme variables and font metadata to embedded Pro templates.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Validation:
- `pnpm lint:docs`
- `pnpm typecheck:docs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904bfa13-fc2f-4e1a-bce9-02c244b6e05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904bfa13-fc2f-4e1a-bce9-02c244b6e05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

