### PR TITLE
fix(docs): move mobile design theme selector to header

### DIFF
--- a/apps/docs/src/app/(home)/layout.tsx
+++ b/apps/docs/src/app/(home)/layout.tsx
@@ -4,6 +4,7 @@ import {HomeLayout} from "fumadocs-ui/layouts/home";
 
 import {baseOptions, homeLayoutLinks} from "@/app/layout.config";
 import {DesignThemeSelector} from "@/components/design-theme-selector";
+import {SearchToggle} from "@/components/fumadocs/ui/search-toggle";
 import {GitHubLinkSmall} from "@/components/github-link";
 
 export default function Layout({children}: {children: ReactNode}) {
@@ -19,11 +20,27 @@ export default function Layout({children}: {children: ReactNode}) {
               <GitHubLinkSmall />
             </div>
           ),
-          on: "all" as const,
+          on: "nav" as const,
+          secondary: true,
+          type: "custom" as const,
+        },
+        {
+          children: <GitHubLinkSmall />,
+          on: "menu" as const,
           secondary: true,
           type: "custom" as const,
         },
       ]}
+      searchToggle={{
+        components: {
+          sm: (
+            <>
+              <DesignThemeSelector />
+              <SearchToggle hideIfDisabled className="p-2" />
+            </>
+          ),
+        },
+      }}
       themeSwitch={{
         mode: "light-dark-system",
       }}

--- a/apps/docs/src/app/(home)/layout.tsx
+++ b/apps/docs/src/app/(home)/layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({children}: {children: ReactNode}) {
         {
           children: (
             <div className="flex items-center gap-1.5">
-              <DesignThemeSelector />
+              <DesignThemeSelector triggerVariant="ghost" />
               <GitHubLinkSmall />
             </div>
           ),
@@ -35,7 +35,7 @@ export default function Layout({children}: {children: ReactNode}) {
         components: {
           sm: (
             <>
-              <DesignThemeSelector />
+              <DesignThemeSelector triggerVariant="ghost" />
               <SearchToggle hideIfDisabled className="p-2" />
             </>
           ),

--- a/apps/docs/src/components/design-theme-selector.tsx
+++ b/apps/docs/src/components/design-theme-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type {ThemeId} from "@/app/themes/constants";
+import type {ButtonProps} from "@heroui/react";
 import type {StaticImageData} from "next/image";
 
 import {BucketPaint, Palette} from "@gravity-ui/icons";
@@ -62,7 +63,11 @@ function applyTheme(themeId: string) {
   removeThemeCssLink();
 }
 
-export function DesignThemeSelector() {
+export function DesignThemeSelector({
+  triggerVariant = "tertiary",
+}: {
+  triggerVariant?: ButtonProps["variant"];
+}) {
   const [active, setActive] = useState("default");
   const [mounted, setMounted] = useState(false);
 
@@ -130,7 +135,7 @@ export function DesignThemeSelector() {
           <Button
             aria-label="Design theme"
             size="sm"
-            variant="tertiary"
+            variant={triggerVariant}
             className={cn(
               "text-xs text-muted",
               showAvatar &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Moves the landing page design theme selector out of the mobile menu and into the mobile header controls next to search. The landing page now renders that selector trigger with the ghost button variant.

## ⛳️ Current behavior (updates)

On mobile, the design theme selector is rendered inside the landing page menu, so opening its popover can close the menu instead. Its trigger also used the default tertiary styling on the landing page.

## 🚀 New behavior

The design theme selector is rendered beside the search button in the mobile header. The mobile menu keeps the GitHub action but no longer includes the design theme selector. Landing page selector instances opt into the ghost trigger variant while other pages keep the default selector styling.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Merge conflict review:
- Fetched latest `origin/v3` before merging.
- Simple conflict resolved in `apps/docs/src/components/design-theme-selector.tsx` by combining `v3`'s typed/shared design-theme utility changes with this branch's configurable trigger variant.
- No complicated or conflicting-intent conflicts found.

Verification:
- `pnpm --filter @heroui/docs lint`
- `pnpm --filter @heroui/docs typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ba900b5-2d31-4484-826d-91e1c0bb8916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ba900b5-2d31-4484-826d-91e1c0bb8916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

