### PR TITLE
fix(docs): use white accent for uber dark theme

### DIFF
--- a/apps/docs/scripts/build-theme-presets.mjs
+++ b/apps/docs/scripts/build-theme-presets.mjs
@@ -306,6 +306,7 @@ const PRESETS = [
   {
     accentHex: "#000000",
     base: 0.005,
+    darkAccent: {c: 0, h: 0, l: 0.9848},
     formRadius: "small",
     id: "uber",
     radius: "small",
@@ -430,7 +431,13 @@ function generatePresetCss(preset) {
   const so = preset.semanticOverrides;
 
   function modeVars(mode) {
-    const accentVars = genAccent(accent.l, accent.c, hue, so?.[mode]?.accentForeground);
+    const modeAccent = preset[`${mode}Accent`] ?? accent;
+    const accentVars = genAccent(
+      modeAccent.l,
+      modeAccent.c,
+      modeAccent.h,
+      so?.[mode]?.accentForeground,
+    );
     const neutrals = genNeutrals(hue, grayChroma, mode);
 
     let semantics = {};

--- a/apps/docs/src/styles/theme-presets.css
+++ b/apps/docs/src/styles/theme-presets.css
@@ -796,13 +796,13 @@
     --surface-secondary-foreground: oklch(99.11% 0.005 0);
     --surface-tertiary: oklch(27.21% 0.0075 0);
     --surface-tertiary-foreground: oklch(99.11% 0.005 0);
-    --accent: oklch(0% 0 0);
-    --accent-foreground: oklch(99.11% 0 0);
-    --accent-hover: color-mix(in oklab, oklch(0% 0 0) 90%, oklch(99.11% 0 0) 10%);
-    --accent-soft: color-mix(in oklab, oklch(0% 0 0) 15%, transparent);
-    --accent-soft-foreground: oklch(0% 0 0);
-    --accent-soft-hover: color-mix(in oklab, oklch(0% 0 0) 20%, transparent);
-    --focus: oklch(0% 0 0);
+    --accent: oklch(98.48% 0 0);
+    --accent-foreground: oklch(15% 0 0);
+    --accent-hover: color-mix(in oklab, oklch(98.48% 0 0) 90%, oklch(15% 0 0) 10%);
+    --accent-soft: color-mix(in oklab, oklch(98.48% 0 0) 15%, transparent);
+    --accent-soft-foreground: oklch(63.48% 0 0);
+    --accent-soft-hover: color-mix(in oklab, oklch(98.48% 0 0) 20%, transparent);
+    --focus: oklch(98.48% 0 0);
     --success: oklch(0.6514 0.1321 156.22);
     --success-foreground: oklch(15% 0.0396 156.22);
     --success-hover: color-mix(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #

## 📝 Description

Updates the static docs Uber theme preset so dark mode uses a white accent/focus color, matching the adaptive behavior in the `/themes` builder.

## ⛳️ Current behavior (updates)

The generated static Uber dark preset emitted a black accent, so the home page Components tab could show dark-mode accent UI incorrectly.

## 🚀 New behavior

The preset generator supports a mode-specific accent override, and Uber dark mode now emits a white accent with matching derived accent variables.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Validation:
- `pnpm lint:docs`
- `pnpm typecheck:docs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-904bfa13-fc2f-4e1a-bce9-02c244b6e05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-904bfa13-fc2f-4e1a-bce9-02c244b6e05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

