### PR TITLE
fix(hooks): resolve useTheme SSR crash and circular dependency

### DIFF
--- a/packages/react/src/hooks/use-theme.ts
+++ b/packages/react/src/hooks/use-theme.ts
@@ -1,11 +1,35 @@
 "use client";
 
-import {useCallback, useEffect, useState} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 
 const THEME_STORAGE_KEY = "heroui-theme";
 const PREFERS_DARK_MEDIA = "(prefers-color-scheme: dark)";
 
 export type Theme = string;
+
+/**
+ * Resolves a theme value to its applied class name.
+ * "system" resolves to "dark" or "light" based on OS preference.
+ */
+function resolveTheme(theme: Theme): string {
+  if (theme === "system") {
+    return window.matchMedia?.(PREFERS_DARK_MEDIA).matches ? "dark" : "light";
+  }
+
+  return theme;
+}
+
+/**
+ * Applies the resolved theme to the document element (classList + data-theme attribute).
+ */
+function applyThemeToDOM(resolved: string, previous?: string) {
+  if (previous && previous !== resolved) {
+    document.documentElement.classList.remove(previous);
+  }
+
+  document.documentElement.classList.add(resolved);
+  document.documentElement.setAttribute("data-theme", resolved);
+}
 
 /**
  * React hook to switch between themes.
@@ -16,65 +40,64 @@ export type Theme = string;
  * @param defaultTheme - the initial theme name (defaults to "system")
  */
 export function useTheme(defaultTheme: Theme = "system") {
+  // The stored theme value (may be "system" or a concrete theme name)
   const [theme, setThemeState] = useState<Theme>(() => {
+    // SSR guard — browser APIs are not available on the server
+    if (typeof window === "undefined") return defaultTheme;
+
     const stored = localStorage.getItem(THEME_STORAGE_KEY);
 
     if (stored) return stored;
 
-    if (defaultTheme === "system") {
-      return window.matchMedia?.(PREFERS_DARK_MEDIA).matches ? "dark" : "light";
-    }
-
     return defaultTheme;
   });
 
-  const setTheme = useCallback(
-    (newTheme: Theme) => {
-      const resolved =
-        newTheme === "system"
-          ? window.matchMedia?.(PREFERS_DARK_MEDIA).matches
-            ? "dark"
-            : "light"
-          : newTheme;
+  // Track the currently-applied resolved class to remove it on change
+  const appliedRef = useRef<string | undefined>(undefined);
 
-      localStorage.setItem(THEME_STORAGE_KEY, newTheme);
+  const setTheme = useCallback((newTheme: Theme) => {
+    // SSR guard
+    if (typeof window === "undefined") return;
 
-      const previous = theme;
+    const resolved = resolveTheme(newTheme);
 
-      if (previous && previous !== resolved) {
-        document.documentElement.classList.remove(previous);
-      }
+    // Store the user's intent (e.g. "system"), not the resolved value
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme);
 
-      document.documentElement.classList.add(resolved);
-      document.documentElement.setAttribute("data-theme", resolved);
+    applyThemeToDOM(resolved, appliedRef.current);
+    appliedRef.current = resolved;
 
-      setThemeState(newTheme);
-    },
-    [theme],
-  );
+    setThemeState(newTheme);
+  }, []);
 
-  const handleMediaQuery = useCallback(
-    (e: MediaQueryListEvent | MediaQueryList) => {
-      if (defaultTheme === "system") {
-        setTheme(e.matches ? "dark" : "light");
-      }
-    },
-    [defaultTheme, setTheme],
-  );
-
+  // Apply theme to DOM on mount and when theme changes
   useEffect(() => {
-    queueMicrotask(() => {
-      setTheme(theme);
-    });
-  }, [theme, setTheme]);
+    const resolved = resolveTheme(theme);
 
+    applyThemeToDOM(resolved, appliedRef.current);
+    appliedRef.current = resolved;
+  }, [theme]);
+
+  // Listen for OS color scheme changes when tracking "system"
   useEffect(() => {
+    // Only respond to media query changes if the current theme is "system"
+    if (theme !== "system") return;
+
     const media = window.matchMedia(PREFERS_DARK_MEDIA);
 
-    media.addEventListener("change", handleMediaQuery);
+    const handleChange = (e: MediaQueryListEvent) => {
+      const resolved = e.matches ? "dark" : "light";
 
-    return () => media.removeEventListener("change", handleMediaQuery);
-  }, [handleMediaQuery]);
+      applyThemeToDOM(resolved, appliedRef.current);
+      appliedRef.current = resolved;
+      // Keep state as "system" — don't overwrite with the resolved value
+      setThemeState("system");
+    };
+
+    media.addEventListener("change", handleChange);
+
+    return () => media.removeEventListener("change", handleChange);
+  }, [theme]);
 
   return {theme, setTheme};
 }

--- a/packages/react/src/hooks/use-theme.ts
+++ b/packages/react/src/hooks/use-theme.ts
@@ -1,6 +1,8 @@
 "use client";
 
-import {useCallback, useEffect, useRef, useState} from "react";
+import {useCallback, useRef, useState, useSyncExternalStore} from "react";
+
+import {useIsomorphicLayoutEffect} from "./use-isomorphic-layout-effect";
 
 const THEME_STORAGE_KEY = "heroui-theme";
 const PREFERS_DARK_MEDIA = "(prefers-color-scheme: dark)";
@@ -8,22 +10,41 @@ const PREFERS_DARK_MEDIA = "(prefers-color-scheme: dark)";
 export type Theme = string;
 
 /**
- * Resolves a theme value to its applied class name.
- * "system" resolves to "dark" or "light" based on OS preference.
+ * Subscribes to OS color-scheme changes. No-op on the server.
  */
-function resolveTheme(theme: Theme): string {
-  if (theme === "system") {
-    return window.matchMedia?.(PREFERS_DARK_MEDIA).matches ? "dark" : "light";
-  }
+function subscribeSystemPreference(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
 
-  return theme;
+  const media = window.matchMedia(PREFERS_DARK_MEDIA);
+
+  media.addEventListener("change", callback);
+
+  return () => media.removeEventListener("change", callback);
+}
+
+/**
+ * Reads the current OS color-scheme preference. Client-only.
+ */
+function getSystemPreference(): "dark" | "light" {
+  return window.matchMedia?.(PREFERS_DARK_MEDIA).matches ? "dark" : "light";
+}
+
+/**
+ * Server snapshot for the system preference — unknown without `window.matchMedia`.
+ */
+function getServerSystemPreference(): undefined {
+  return undefined;
 }
 
 /**
  * Applies the resolved theme to the document element (classList + data-theme attribute).
+ * No-op when the resolved value matches the previously-applied class to avoid
+ * redundant DOM writes (which can trigger MutationObservers and view transitions).
  */
 function applyThemeToDOM(resolved: string, previous?: string) {
-  if (previous && previous !== resolved) {
+  if (previous === resolved) return;
+
+  if (previous) {
     document.documentElement.classList.remove(previous);
   }
 
@@ -38,66 +59,52 @@ function applyThemeToDOM(resolved: string, previous?: string) {
  * Pass "system" to follow the OS preference (resolves to "light" or "dark").
  *
  * @param defaultTheme - the initial theme name (defaults to "system")
+ * @returns `theme` (the stored intent, e.g. "system"), `resolvedTheme` (the
+ *          concrete class applied to the DOM — undefined during SSR), and `setTheme`.
  */
 export function useTheme(defaultTheme: Theme = "system") {
-  // The stored theme value (may be "system" or a concrete theme name)
+  // The stored theme value — the user's intent (may be "system" or a concrete name).
   const [theme, setThemeState] = useState<Theme>(() => {
-    // SSR guard — browser APIs are not available on the server
+    // SSR guard — browser APIs are not available on the server.
     if (typeof window === "undefined") return defaultTheme;
 
-    const stored = localStorage.getItem(THEME_STORAGE_KEY);
-
-    if (stored) return stored;
-
-    return defaultTheme;
+    return localStorage.getItem(THEME_STORAGE_KEY) ?? defaultTheme;
   });
 
-  // Track the currently-applied resolved class to remove it on change
+  // Reactive snapshot of the OS color-scheme preference.
+  // Returns `undefined` on the server (no `matchMedia`).
+  const systemTheme = useSyncExternalStore(
+    subscribeSystemPreference,
+    getSystemPreference,
+    getServerSystemPreference,
+  );
+
+  // Derived during render — no extra state, no setState-in-effect.
+  // When `theme === "system"`, follows the OS; otherwise echoes `theme`.
+  const resolvedTheme: string | undefined = theme === "system" ? systemTheme : theme;
+
+  // Track the last class written to the DOM so we can remove it on change.
   const appliedRef = useRef<string | undefined>(undefined);
 
+  // Sync the document with the resolved theme.
+  // Uses a layout effect so the DOM is updated before paint (no FOUC).
+  useIsomorphicLayoutEffect(() => {
+    if (!resolvedTheme) return;
+
+    applyThemeToDOM(resolvedTheme, appliedRef.current);
+    appliedRef.current = resolvedTheme;
+  }, [resolvedTheme]);
+
+  // Stable callback — empty deps, reads nothing from the render closure.
   const setTheme = useCallback((newTheme: Theme) => {
     // SSR guard
     if (typeof window === "undefined") return;
 
-    const resolved = resolveTheme(newTheme);
-
-    // Store the user's intent (e.g. "system"), not the resolved value
+    // Persist the user's intent (e.g. "system"), not the resolved value.
     localStorage.setItem(THEME_STORAGE_KEY, newTheme);
-
-    applyThemeToDOM(resolved, appliedRef.current);
-    appliedRef.current = resolved;
-
     setThemeState(newTheme);
+    // The DOM is updated in the layout effect above when `resolvedTheme` changes.
   }, []);
 
-  // Apply theme to DOM on mount and when theme changes
-  useEffect(() => {
-    const resolved = resolveTheme(theme);
-
-    applyThemeToDOM(resolved, appliedRef.current);
-    appliedRef.current = resolved;
-  }, [theme]);
-
-  // Listen for OS color scheme changes when tracking "system"
-  useEffect(() => {
-    // Only respond to media query changes if the current theme is "system"
-    if (theme !== "system") return;
-
-    const media = window.matchMedia(PREFERS_DARK_MEDIA);
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      const resolved = e.matches ? "dark" : "light";
-
-      applyThemeToDOM(resolved, appliedRef.current);
-      appliedRef.current = resolved;
-      // Keep state as "system" — don't overwrite with the resolved value
-      setThemeState("system");
-    };
-
-    media.addEventListener("change", handleChange);
-
-    return () => media.removeEventListener("change", handleChange);
-  }, [theme]);
-
-  return {theme, setTheme};
+  return {resolvedTheme, setTheme, theme};
 }


### PR DESCRIPTION
Closes #6559, #6560

## 📝 Description

The `useTheme` hook has two critical bugs:

1. **SSR crash** — `localStorage` and `window.matchMedia` are accessed directly in the `useState` initializer without any environment guard. This throws `ReferenceError: localStorage is not defined` in any SSR framework (Next.js, Remix, Astro, etc.).

2. **Circular dependency / infinite re-render risk** — `setTheme` depends on `theme` in its `useCallback` deps, and a `useEffect` depends on both `theme` and `setTheme`. The effect calls `setTheme(theme)`, creating a circular chain. Additionally, the media query handler stores the resolved value ("dark"/"light") instead of "system", permanently breaking system preference tracking.

## ⛳️ Current behavior (updates)

- `useTheme()` crashes during SSR with `ReferenceError: localStorage is not defined`
- `setTheme` is recreated on every theme change (unstable reference)
- The `useEffect` that applies theme to DOM re-runs unnecessarily due to `setTheme` instability
- When OS preference changes while using "system" theme, localStorage stores "dark"/"light" instead of "system", breaking future preference tracking

## 🚀 New behavior

- **SSR-safe**: `typeof window === "undefined"` guard in `useState` initializer returns `defaultTheme` on server
- **Stable `setTheme`**: Uses a ref (`appliedRef`) to track the previously-applied class instead of reading from the `theme` closure. `useCallback` has empty deps → stable reference.
- **No circular dependency**: The DOM-application effect depends only on `theme`, not on `setTheme`
- **System preference preserved**: Media query handler applies the resolved class to DOM but keeps state as "system", so localStorage correctly stores "system" and future OS changes continue to be tracked
- **Extracted helpers**: `resolveTheme()` and `applyThemeToDOM()` are pure functions extracted for clarity and testability

## 💣 Is this a breaking change (Yes/No):

No — the public API (`useTheme(defaultTheme?) → {theme, setTheme}`) is unchanged.

## 📝 Additional Information

The fix addresses both issues in a single rewrite because they share the same root cause (the `setTheme` callback depending on `theme` state). Fixing one without the other would leave the hook in an inconsistent state.