### PR TITLE
fix(styles): cover scrollbar gutter in modal and alert-dialog backdrops

### DIFF
--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -45,7 +45,17 @@
 .alert-dialog__backdrop {
   @apply fixed inset-0 z-50;
   @apply flex flex-row items-center justify-center;
-  @apply h-(--visual-viewport-height) w-full;
+  @apply h-(--visual-viewport-height);
+
+  /**
+   * Use 100vw instead of w-full (100%) to cover the scrollbar gutter.
+   * React Aria's usePreventScroll sets scrollbar-gutter: stable on <html>,
+   * which shrinks the 100% containing block by the gutter width — leaving
+   * a strip at the right edge uncovered. 100vw resolves against the full
+   * viewport. max-width: 100% prevents overflow in scoped portal containers.
+   */
+  width: 100vw;
+  max-width: 100%;
 
   /* Entering animation */
   &[data-entering="true"] {

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -44,7 +44,17 @@
 .modal__backdrop {
   @apply fixed inset-0 z-50;
   @apply flex flex-row items-center justify-center;
-  @apply h-(--visual-viewport-height) w-full;
+  @apply h-(--visual-viewport-height);
+
+  /**
+   * Use 100vw instead of w-full (100%) to cover the scrollbar gutter.
+   * React Aria's usePreventScroll sets scrollbar-gutter: stable on <html>,
+   * which shrinks the 100% containing block by the gutter width — leaving
+   * a strip at the right edge uncovered. 100vw resolves against the full
+   * viewport. max-width: 100% prevents overflow in scoped portal containers.
+   */
+  width: 100vw;
+  max-width: 100%;
 
   /* Entering animation */
   &[data-entering="true"] {


### PR DESCRIPTION
Closes #6562

## 📝 Description

Fixes the modal and alert-dialog backdrops not covering the scrollbar gutter when React Aria's `usePreventScroll` is active.

## ⛳️ Current behavior (updates)

When a Modal or AlertDialog opens, React Aria sets `scrollbar-gutter: stable` on `<html>` to prevent layout shift. The backdrop uses `w-full` (`width: 100%`), which on a `position: fixed` element resolves against the viewport's content area — excluding the gutter. This leaves a visible strip at the right edge of the viewport where the backdrop doesn't cover.

## 🚀 New behavior

Replace `w-full` with explicit `width: 100vw; max-width: 100%`:

- `100vw` resolves against the full viewport including the scrollbar gutter
- `max-width: 100%` prevents overflow when the backdrop is rendered inside a scoped portal container (`UNSTABLE_portalContainer`) that is narrower than the viewport

The fix is applied to both `.modal__backdrop` and `.alert-dialog__backdrop`.

## 💣 Is this a breaking change (Yes/No):

No. Pure CSS fix with no API or behavioural changes.

## 📝 Additional Information

Validated by inspecting the computed styles. The `inset: 0` already on the backdrop handles positioning; the width change only affects the explicit `width` property that was previously set via `w-full`.