### PR TITLE
feat(components): add StackedMeter component

### DIFF
--- a/apps/docs/content/docs/react/components/(feedback)/stacked-meter.mdx
+++ b/apps/docs/content/docs/react/components/(feedback)/stacked-meter.mdx
@@ -1,0 +1,195 @@
+---
+title: StackedMeter
+description: A segmented quantity indicator that visualises a breakdown of a known capacity.
+
+links:
+  source: stacked-meter/stacked-meter.tsx
+  styles: stacked-meter.css
+  storybook: Components/Feedback/StackedMeter
+---
+
+## Import
+
+```tsx
+import { StackedMeter, Label } from '@heroui/react';
+```
+
+### Usage
+
+<ComponentPreview
+  name="stacked-meter-basic"
+/>
+
+### Anatomy
+
+```tsx
+import { StackedMeter, Label } from '@heroui/react';
+
+const segments = [
+  { id: 'photos', value: 45, label: 'Photos', color: 'accent' },
+  { id: 'videos', value: 20, label: 'Videos', color: 'success' },
+  { id: 'docs', value: 10, label: 'Documents', color: 'warning' },
+  { id: 'other', value: 5, label: 'Other', color: 'default' },
+];
+
+export default () => (
+  <StackedMeter segments={segments} maxValue={128} aria-label="Storage usage">
+    <Label>Storage</Label>
+    <StackedMeter.Output>
+      {({ total, maxValue, format }) => `${format(total)} / ${format(maxValue)} GB`}
+    </StackedMeter.Output>
+    <StackedMeter.Track />
+    <StackedMeter.Legend />
+  </StackedMeter>
+);
+```
+
+### Sizes
+
+The `size` prop controls the track thickness, matching the Meter component's size scale.
+
+<ComponentPreview
+  name="stacked-meter-sizes"
+/>
+
+### With Legend
+
+The `StackedMeter.Legend` slot renders colour swatches with labels below the track. It is `aria-hidden` since each segment already carries its own ARIA label.
+
+<ComponentPreview
+  name="stacked-meter-with-legend"
+/>
+
+### Custom Value Format
+
+Use `formatOptions` (passed to `Intl.NumberFormat`) to customise how values display in the Output and tooltips.
+
+<ComponentPreview
+  name="stacked-meter-custom-format"
+/>
+
+### Without Label
+
+When no visible label is needed, use `aria-label` for accessibility.
+
+<ComponentPreview
+  name="stacked-meter-without-label"
+/>
+
+<RelatedComponents component="stacked-meter" />
+
+## Accessibility
+
+- The root element uses `role="group"` with an `aria-label`.
+- Each segment uses `role="meter"` with `aria-valuenow`, `aria-valuemin`, and `aria-valuemax`.
+- Screen readers can step through segments individually to hear each breakdown line.
+- The Legend is `aria-hidden="true"` (decorative — the meter roles carry the semantic information).
+- Fill animation respects `prefers-reduced-motion: reduce`.
+
+## Styling
+
+### Passing Tailwind CSS classes
+
+You can customize individual StackedMeter parts:
+
+```tsx
+import { StackedMeter, Label } from '@heroui/react';
+
+function CustomStackedMeter() {
+  return (
+    <StackedMeter segments={segments} maxValue={100} aria-label="Usage">
+      <Label>Usage</Label>
+      <StackedMeter.Output />
+      <StackedMeter.Track className="bg-purple-100 dark:bg-purple-900" />
+      <StackedMeter.Legend />
+    </StackedMeter>
+  );
+}
+```
+
+### Customizing the component classes
+
+To customize the StackedMeter component classes, you can use the `@layer components` directive.
+<br/>[Learn more](https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes).
+
+```css
+@layer components {
+  .stacked-meter {
+    @apply w-full gap-2;
+  }
+
+  .stacked-meter__track {
+    @apply h-3 rounded-full;
+  }
+
+  .stacked-meter__segment {
+    @apply rounded-none;
+  }
+}
+```
+
+HeroUI follows the [BEM](https://getbem.com/) methodology to ensure component variants and states are reusable and easy to customize.
+
+### CSS Classes
+
+The StackedMeter component uses these CSS classes ([View source styles](https://github.com/heroui-inc/heroui/blob/v3/packages/styles/components/stacked-meter.css)):
+
+#### Base & Element Classes
+- `.stacked-meter` - Base container (grid layout)
+- `.stacked-meter__output` - Value text display
+- `.stacked-meter__track` - Track background (flex container for segments)
+- `.stacked-meter__segment` - Individual coloured segment
+- `.stacked-meter__legend` - Legend container
+- `.stacked-meter__legend-item` - Legend row (swatch + label)
+- `.stacked-meter__legend-swatch` - Colour dot in legend
+- `.stacked-meter__legend-label` - Text label in legend
+
+#### Size Classes
+- `.stacked-meter--sm` - Small size variant (thinner track)
+- `.stacked-meter--md` - Medium size variant (default)
+- `.stacked-meter--lg` - Large size variant (thicker track)
+
+#### Segment Color Classes
+- `.stacked-meter__segment--default` - Default color
+- `.stacked-meter__segment--accent` - Accent color
+- `.stacked-meter__segment--success` - Success color
+- `.stacked-meter__segment--warning` - Warning color
+- `.stacked-meter__segment--danger` - Danger color
+
+## API Reference
+
+### StackedMeter Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `segments` | `StackedMeterSegment[]` | required | Segments to render in left-to-right order |
+| `maxValue` | `number` | `100` | Total capacity (denominator) |
+| `size` | `"sm" \| "md" \| "lg"` | `"md"` | Track thickness |
+| `formatOptions` | `Intl.NumberFormatOptions` | - | Number format for Output and tooltips |
+| `animate` | `boolean` | `true` | Fill-in animation on mount (respects prefers-reduced-motion) |
+| `aria-label` | `string` | - | Accessible label for the group |
+| `children` | `ReactNode` | - | Compound slots (Output, Track, Legend) |
+
+### StackedMeterSegment
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | required | Stable React key and ARIA id seed |
+| `value` | `number` | required | Numeric contribution toward maxValue |
+| `label` | `string` | required | Human-readable name for tooltip and legend |
+| `color` | `"default" \| "accent" \| "success" \| "warning" \| "danger"` | `"accent"` | Segment colour |
+| `tooltip` | `ReactNode` | - | Custom tooltip content (overrides default) |
+
+### StackedMeter.Output Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `(args: { total, maxValue, format }) => ReactNode` | - | Render prop for custom output |
+
+### StackedMeter.Track Props
+
+Standard `div` props (no additional props).
+
+### StackedMeter.Legend Props
+
+Standard `ul` props (no additional props). Rendered with `aria-hidden="true"`.

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -80,6 +80,7 @@ export * from "./number-field";
 export * from "./pagination";
 export * from "./select";
 export * from "./meter";
+export * from "./stacked-meter";
 export * from "./slider";
 export * from "./table";
 

--- a/packages/react/src/components/stacked-meter/index.ts
+++ b/packages/react/src/components/stacked-meter/index.ts
@@ -1,0 +1,49 @@
+import type {ComponentProps} from "react";
+
+import {
+  StackedMeterLegend,
+  StackedMeterOutput,
+  StackedMeterRoot,
+  StackedMeterTrack,
+} from "./stacked-meter";
+
+/* -------------------------------------------------------------------------------------------------
+ * Compound Component
+ * -----------------------------------------------------------------------------------------------*/
+export const StackedMeter = Object.assign(StackedMeterRoot, {
+  Root: StackedMeterRoot,
+  Output: StackedMeterOutput,
+  Track: StackedMeterTrack,
+  Legend: StackedMeterLegend,
+});
+
+export type StackedMeter = {
+  Props: ComponentProps<typeof StackedMeterRoot>;
+  RootProps: ComponentProps<typeof StackedMeterRoot>;
+  OutputProps: ComponentProps<typeof StackedMeterOutput>;
+  TrackProps: ComponentProps<typeof StackedMeterTrack>;
+  LegendProps: ComponentProps<typeof StackedMeterLegend>;
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * Named Component
+ * -----------------------------------------------------------------------------------------------*/
+export {StackedMeterRoot, StackedMeterOutput, StackedMeterTrack, StackedMeterLegend};
+
+export type {
+  StackedMeterRootProps,
+  StackedMeterRootProps as StackedMeterProps,
+  StackedMeterOutputProps,
+  StackedMeterTrackProps,
+  StackedMeterLegendProps,
+  StackedMeterSegment,
+  StackedMeterColor,
+  StackedMeterSize,
+} from "./stacked-meter";
+
+/* -------------------------------------------------------------------------------------------------
+ * Variants
+ * -----------------------------------------------------------------------------------------------*/
+export {stackedMeterVariants} from "@heroui/styles";
+
+export type {StackedMeterVariants} from "@heroui/styles";

--- a/packages/react/src/components/stacked-meter/stacked-meter.stories.tsx
+++ b/packages/react/src/components/stacked-meter/stacked-meter.stories.tsx
@@ -1,0 +1,160 @@
+import type {Meta, StoryObj} from "@storybook/react";
+
+import React from "react";
+
+import {Label} from "../label";
+
+import {StackedMeter} from "./index";
+
+const meta: Meta<typeof StackedMeter> = {
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+  },
+  component: StackedMeter,
+  decorators: [
+    (Story) => (
+      <div className="w-96 p-8">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  title: "Components/Feedback/StackedMeter",
+};
+
+export default meta;
+type Story = StoryObj<typeof StackedMeter>;
+
+const storageSegments = [
+  {id: "photos", value: 45, label: "Photos", color: "accent" as const},
+  {id: "videos", value: 20, label: "Videos", color: "success" as const},
+  {id: "docs", value: 10, label: "Documents", color: "warning" as const},
+  {id: "other", value: 5, label: "Other", color: "default" as const},
+];
+
+export const Default: Story = {
+  render: (args) => {
+    return (
+      <StackedMeter
+        aria-label="Storage usage"
+        maxValue={128}
+        segments={storageSegments}
+        {...args}
+      >
+        <Label>Storage</Label>
+        <StackedMeter.Output>
+          {({total, maxValue, format}) => `${format(total)} / ${format(maxValue)} GB`}
+        </StackedMeter.Output>
+        <StackedMeter.Track />
+        <StackedMeter.Legend />
+      </StackedMeter>
+    );
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => {
+    return (
+      <div className="flex w-full flex-col gap-6">
+        <StackedMeter
+          aria-label="Small"
+          maxValue={100}
+          segments={storageSegments}
+          size="sm"
+          {...args}
+        >
+          <Label>Small</Label>
+          <StackedMeter.Output />
+          <StackedMeter.Track />
+        </StackedMeter>
+        <StackedMeter
+          aria-label="Medium"
+          maxValue={100}
+          segments={storageSegments}
+          size="md"
+          {...args}
+        >
+          <Label>Medium</Label>
+          <StackedMeter.Output />
+          <StackedMeter.Track />
+        </StackedMeter>
+        <StackedMeter
+          aria-label="Large"
+          maxValue={100}
+          segments={storageSegments}
+          size="lg"
+          {...args}
+        >
+          <Label>Large</Label>
+          <StackedMeter.Output />
+          <StackedMeter.Track />
+        </StackedMeter>
+      </div>
+    );
+  },
+};
+
+export const WithLegend: Story = {
+  render: (args) => {
+    return (
+      <StackedMeter
+        aria-label="Team capacity"
+        maxValue={40}
+        segments={[
+          {id: "eng", value: 18, label: "Engineering", color: "accent"},
+          {id: "design", value: 8, label: "Design", color: "success"},
+          {id: "pm", value: 6, label: "Product", color: "warning"},
+          {id: "qa", value: 4, label: "QA", color: "danger"},
+        ]}
+        {...args}
+      >
+        <Label>Team Capacity</Label>
+        <StackedMeter.Output>
+          {({total, maxValue}) => `${total} / ${maxValue} people`}
+        </StackedMeter.Output>
+        <StackedMeter.Track />
+        <StackedMeter.Legend />
+      </StackedMeter>
+    );
+  },
+};
+
+export const CustomFormat: Story = {
+  render: (args) => {
+    return (
+      <StackedMeter
+        aria-label="Budget allocation"
+        formatOptions={{style: "currency", currency: "USD", maximumFractionDigits: 0}}
+        maxValue={50000}
+        segments={[
+          {id: "marketing", value: 20000, label: "Marketing", color: "accent"},
+          {id: "engineering", value: 15000, label: "Engineering", color: "success"},
+          {id: "operations", value: 8000, label: "Operations", color: "warning"},
+          {id: "misc", value: 3000, label: "Miscellaneous", color: "default"},
+        ]}
+        {...args}
+      >
+        <Label>Budget</Label>
+        <StackedMeter.Output />
+        <StackedMeter.Track />
+        <StackedMeter.Legend />
+      </StackedMeter>
+    );
+  },
+};
+
+export const WithoutLabel: Story = {
+  render: (args) => {
+    return (
+      <StackedMeter aria-label="Disk usage" maxValue={100} segments={storageSegments} {...args}>
+        <StackedMeter.Track />
+      </StackedMeter>
+    );
+  },
+};

--- a/packages/react/src/components/stacked-meter/stacked-meter.tsx
+++ b/packages/react/src/components/stacked-meter/stacked-meter.tsx
@@ -102,7 +102,7 @@ const StackedMeterRoot = ({
     return () => cancelAnimationFrame(frame);
   }, [animate]);
 
-  if (process.env.NODE_ENV !== "production") {
+  if (process.env["NODE_ENV"] !== "production") {
     const total = segments.reduce((sum, s) => sum + s.value, 0);
 
     if (total > maxValue) {

--- a/packages/react/src/components/stacked-meter/stacked-meter.tsx
+++ b/packages/react/src/components/stacked-meter/stacked-meter.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import type {StackedMeterVariants} from "@heroui/styles";
+import type {ComponentPropsWithoutRef, ReactNode} from "react";
+
+import {stackedMeterVariants} from "@heroui/styles";
+import React, {createContext, useContext, useEffect, useId, useMemo, useState} from "react";
+
+import {Tooltip} from "../tooltip";
+
+/* -------------------------------------------------------------------------------------------------
+ * Types
+ * -----------------------------------------------------------------------------------------------*/
+
+export type StackedMeterColor = "default" | "accent" | "success" | "warning" | "danger";
+
+export type StackedMeterSize = "sm" | "md" | "lg";
+
+export interface StackedMeterSegment {
+  /** Stable React key and ARIA id seed. */
+  id: string;
+  /** Numeric contribution; sums with siblings up to `maxValue`. */
+  value: number;
+  /** Human-readable name shown in the tooltip and legend. */
+  label: string;
+  /** One of HeroUI's status colours. Defaults to `accent`. */
+  color?: StackedMeterColor;
+  /** Override the tooltip content. Falls back to "{label}: {formatted value}". */
+  tooltip?: ReactNode;
+}
+
+export interface StackedMeterRootProps
+  extends Omit<ComponentPropsWithoutRef<"div">, "children">,
+    StackedMeterVariants {
+  /** Segments to render, in left-to-right order. */
+  segments: ReadonlyArray<StackedMeterSegment>;
+  /** Total capacity (denominator). Defaults to 100. */
+  maxValue?: number;
+  /** Intl.NumberFormat options for the Output and tooltip values. */
+  formatOptions?: Intl.NumberFormatOptions;
+  /** Track thickness. Matches HeroUI Meter's `size` scale. */
+  size?: StackedMeterSize;
+  /**
+   * Run the fill-in animation on mount. Defaults to true; ignored
+   * when the user prefers reduced motion.
+   */
+  animate?: boolean;
+  /** Compound slots: Output, Track, Legend (in any order). */
+  children?: ReactNode;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Context
+ * -----------------------------------------------------------------------------------------------*/
+
+interface StackedMeterContextValue {
+  segments: ReadonlyArray<StackedMeterSegment>;
+  maxValue: number;
+  formatOptions?: Intl.NumberFormatOptions;
+  size: StackedMeterSize;
+  mounted: boolean;
+  rootId: string;
+  slots: ReturnType<typeof stackedMeterVariants>;
+}
+
+const StackedMeterContext = createContext<StackedMeterContextValue | null>(null);
+
+function useStackedMeterContext(slot: string): StackedMeterContextValue {
+  const context = useContext(StackedMeterContext);
+
+  if (!context) {
+    throw new Error(`<StackedMeter.${slot}> must be rendered inside <StackedMeter>.`);
+  }
+
+  return context;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Root
+ * -----------------------------------------------------------------------------------------------*/
+
+const StackedMeterRoot = ({
+  segments,
+  maxValue = 100,
+  formatOptions,
+  size = "md",
+  animate = true,
+  className,
+  children,
+  ...rest
+}: StackedMeterRootProps) => {
+  const rootId = useId();
+  const slots = useMemo(() => stackedMeterVariants({size}), [size]);
+
+  // Skip the initial-render width=0 frame when animation is disabled.
+  const [mounted, setMounted] = useState(!animate);
+
+  useEffect(() => {
+    if (!animate) return;
+    const frame = requestAnimationFrame(() => setMounted(true));
+
+    return () => cancelAnimationFrame(frame);
+  }, [animate]);
+
+  if (process.env.NODE_ENV !== "production") {
+    const total = segments.reduce((sum, s) => sum + s.value, 0);
+
+    if (total > maxValue) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[StackedMeter] segment values total ${total}, which exceeds maxValue ${maxValue}. Segments will be clamped proportionally.`,
+      );
+    }
+  }
+
+  const context = useMemo<StackedMeterContextValue>(
+    () => ({segments, maxValue, formatOptions, size, mounted, rootId, slots}),
+    [segments, maxValue, formatOptions, size, mounted, rootId, slots],
+  );
+
+  return (
+    <StackedMeterContext value={context}>
+      <div
+        className={slots.base({className})}
+        data-size={size}
+        data-slot="stacked-meter"
+        role="group"
+        {...rest}
+      >
+        {children}
+      </div>
+    </StackedMeterContext>
+  );
+};
+
+StackedMeterRoot.displayName = "HeroUI.StackedMeter";
+
+/* -------------------------------------------------------------------------------------------------
+ * Output
+ * -----------------------------------------------------------------------------------------------*/
+
+export interface StackedMeterOutputProps
+  extends Omit<ComponentPropsWithoutRef<"span">, "children"> {
+  /** Custom render. Receives the sum, max, and formatter. */
+  children?: (args: {total: number; maxValue: number; format: (n: number) => string}) => ReactNode;
+}
+
+const StackedMeterOutput = ({className, children, ...rest}: StackedMeterOutputProps) => {
+  const {segments, maxValue, formatOptions, slots} = useStackedMeterContext("Output");
+  const total = segments.reduce((sum, s) => sum + s.value, 0);
+  const format = (n: number) => formatNumber(n, formatOptions);
+
+  return (
+    <span className={slots.output({className})} data-slot="stacked-meter-output" {...rest}>
+      {children ? children({total, maxValue, format}) : `${format(total)} / ${format(maxValue)}`}
+    </span>
+  );
+};
+
+StackedMeterOutput.displayName = "HeroUI.StackedMeter.Output";
+
+/* -------------------------------------------------------------------------------------------------
+ * Track
+ * -----------------------------------------------------------------------------------------------*/
+
+export type StackedMeterTrackProps = Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+const StackedMeterTrack = ({className, ...rest}: StackedMeterTrackProps) => {
+  const {segments, maxValue, formatOptions, mounted, rootId, slots} =
+    useStackedMeterContext("Track");
+
+  const totalRaw = segments.reduce((sum, s) => sum + s.value, 0);
+  // Clamp the denominator so we never exceed 100% width even on overflow.
+  const denom = Math.max(maxValue, totalRaw);
+
+  return (
+    <div className={slots.track({className})} data-slot="stacked-meter-track" {...rest}>
+      {segments.map((seg, index) => {
+        const pct = denom === 0 ? 0 : (seg.value / denom) * 100;
+        const tooltipNode = seg.tooltip ?? (
+          <span>
+            <strong>{seg.label}</strong>: {formatNumber(seg.value, formatOptions)}
+          </span>
+        );
+        const color = seg.color ?? "accent";
+
+        return (
+          <Tooltip delay={150} key={seg.id}>
+            <Tooltip.Trigger
+              aria-label={`${seg.label}: ${formatNumber(seg.value, formatOptions)}`}
+              aria-valuemax={maxValue}
+              aria-valuemin={0}
+              aria-valuenow={seg.value}
+              className={slots.segment({className: `stacked-meter__segment--${color}`})}
+              data-color={color}
+              data-index={index}
+              data-segment-id={`${rootId}-${seg.id}`}
+              role="meter"
+              style={{
+                width: mounted ? `${pct}%` : "0%",
+                ["--stacked-meter-segment-index" as string]: index,
+              }}
+            />
+            <Tooltip.Content>{tooltipNode}</Tooltip.Content>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};
+
+StackedMeterTrack.displayName = "HeroUI.StackedMeter.Track";
+
+/* -------------------------------------------------------------------------------------------------
+ * Legend
+ * -----------------------------------------------------------------------------------------------*/
+
+export type StackedMeterLegendProps = Omit<ComponentPropsWithoutRef<"ul">, "children">;
+
+const StackedMeterLegend = ({className, ...rest}: StackedMeterLegendProps) => {
+  const {segments, slots} = useStackedMeterContext("Legend");
+
+  return (
+    <ul
+      aria-hidden="true"
+      className={slots.legend({className})}
+      data-slot="stacked-meter-legend"
+      {...rest}
+    >
+      {segments.map((seg) => {
+        const color = seg.color ?? "accent";
+
+        return (
+          <li className={slots.legendItem()} data-color={color} key={seg.id}>
+            <span
+              aria-hidden="true"
+              className={slots.legendSwatch({className: `stacked-meter__legend-swatch--${color}`})}
+            />
+            <span className={slots.legendLabel()}>{seg.label}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+StackedMeterLegend.displayName = "HeroUI.StackedMeter.Legend";
+
+/* -------------------------------------------------------------------------------------------------
+ * Helpers
+ * -----------------------------------------------------------------------------------------------*/
+
+function formatNumber(value: number, options: Intl.NumberFormatOptions | undefined): string {
+  try {
+    return new Intl.NumberFormat(undefined, options).format(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Exports
+ * -----------------------------------------------------------------------------------------------*/
+export {StackedMeterRoot, StackedMeterOutput, StackedMeterTrack, StackedMeterLegend};

--- a/packages/styles/components/index.css
+++ b/packages/styles/components/index.css
@@ -86,6 +86,7 @@
 @import "./empty-state.css";
 @import "./skeleton.css";
 @import "./meter.css";
+@import "./stacked-meter.css";
 @import "./progress-bar.css";
 @import "./progress-circle.css";
 @import "./spinner.css";

--- a/packages/styles/components/stacked-meter.css
+++ b/packages/styles/components/stacked-meter.css
@@ -1,0 +1,163 @@
+/* ==========================================================================
+   StackedMeter - A segmented quantity indicator within a known range
+   ========================================================================== */
+
+/* Base styles */
+.stacked-meter {
+  @apply grid w-full gap-1;
+  grid-template-areas:
+    "label output"
+    "track track"
+    "legend legend";
+  grid-template-columns: 1fr auto;
+
+  [data-slot="label"] {
+    @apply w-fit text-sm font-medium;
+
+    grid-area: label;
+  }
+
+  .stacked-meter__output {
+    @apply text-sm font-medium tabular-nums;
+
+    grid-area: output;
+  }
+
+  .stacked-meter__track {
+    @apply relative flex overflow-hidden rounded-sm bg-default;
+
+    grid-area: track;
+
+    /* Default height (matches --md) */
+    @apply h-2;
+  }
+
+  .stacked-meter__segment {
+    @apply h-full shrink-0 cursor-default outline-none;
+
+    background-color: var(--stacked-meter-segment-fill, var(--accent));
+
+    /**
+     * Transitions
+     * CRITICAL: motion-reduce must be AFTER transition for correct override specificity
+     */
+    transition: width 300ms var(--ease-out);
+    transition-delay: calc(var(--stacked-meter-segment-index, 0) * 50ms);
+    @apply motion-reduce:transition-none;
+
+    /* First segment gets left radius */
+    &:first-child {
+      @apply rounded-l-sm;
+    }
+
+    /* Last segment gets right radius */
+    &:last-child {
+      @apply rounded-r-sm;
+    }
+  }
+
+  .stacked-meter__legend {
+    @apply flex flex-wrap gap-x-4 gap-y-1;
+
+    grid-area: legend;
+  }
+
+  .stacked-meter__legend-item {
+    @apply flex items-center gap-1.5 text-xs text-muted;
+  }
+
+  .stacked-meter__legend-swatch {
+    @apply inline-block size-2.5 shrink-0 rounded-full;
+
+    background-color: var(--stacked-meter-segment-fill, var(--accent));
+  }
+
+  .stacked-meter__legend-label {
+    @apply text-xs;
+  }
+}
+
+/* ==========================================================================
+   Size variants
+   ========================================================================== */
+
+.stacked-meter--sm {
+  .stacked-meter__track {
+    @apply h-1 rounded-xs;
+  }
+
+  .stacked-meter__segment {
+    &:first-child {
+      @apply rounded-l-xs;
+    }
+
+    &:last-child {
+      @apply rounded-r-xs;
+    }
+  }
+}
+
+.stacked-meter--md {
+  /* Default size — no overrides needed */
+}
+
+.stacked-meter--lg {
+  .stacked-meter__track {
+    @apply h-3 rounded-md;
+  }
+
+  .stacked-meter__segment {
+    &:first-child {
+      @apply rounded-l-md;
+    }
+
+    &:last-child {
+      @apply rounded-r-md;
+    }
+  }
+}
+
+/* ==========================================================================
+   Segment color variants
+   ========================================================================== */
+
+.stacked-meter__segment--default {
+  --stacked-meter-segment-fill: var(--default-foreground);
+}
+
+.stacked-meter__segment--accent {
+  --stacked-meter-segment-fill: var(--accent);
+}
+
+.stacked-meter__segment--success {
+  --stacked-meter-segment-fill: var(--success);
+}
+
+.stacked-meter__segment--warning {
+  --stacked-meter-segment-fill: var(--warning);
+}
+
+.stacked-meter__segment--danger {
+  --stacked-meter-segment-fill: var(--danger);
+}
+
+/* Legend swatch colors */
+.stacked-meter__legend-swatch--default {
+  --stacked-meter-segment-fill: var(--default-foreground);
+}
+
+.stacked-meter__legend-swatch--accent {
+  --stacked-meter-segment-fill: var(--accent);
+}
+
+.stacked-meter__legend-swatch--success {
+  --stacked-meter-segment-fill: var(--success);
+}
+
+.stacked-meter__legend-swatch--warning {
+  --stacked-meter-segment-fill: var(--warning);
+}
+
+.stacked-meter__legend-swatch--danger {
+  --stacked-meter-segment-fill: var(--danger);
+}

--- a/packages/styles/src/components/index.ts
+++ b/packages/styles/src/components/index.ts
@@ -49,6 +49,7 @@ export * from "./list-box-item";
 export * from "./list-box-section";
 export * from "./menu";
 export * from "./meter";
+export * from "./stacked-meter";
 export * from "./progress-bar";
 export * from "./progress-circle";
 export * from "./menu-item";

--- a/packages/styles/src/components/stacked-meter/index.ts
+++ b/packages/styles/src/components/stacked-meter/index.ts
@@ -1,0 +1,1 @@
+export * from "./stacked-meter.styles";

--- a/packages/styles/src/components/stacked-meter/stacked-meter.styles.ts
+++ b/packages/styles/src/components/stacked-meter/stacked-meter.styles.ts
@@ -1,0 +1,34 @@
+import type {VariantProps} from "tailwind-variants";
+
+import {tv} from "tailwind-variants";
+
+export const stackedMeterVariants = tv({
+  defaultVariants: {
+    size: "md",
+  },
+  slots: {
+    base: "stacked-meter",
+    legend: "stacked-meter__legend",
+    legendItem: "stacked-meter__legend-item",
+    legendLabel: "stacked-meter__legend-label",
+    legendSwatch: "stacked-meter__legend-swatch",
+    output: "stacked-meter__output",
+    segment: "stacked-meter__segment",
+    track: "stacked-meter__track",
+  },
+  variants: {
+    size: {
+      lg: {
+        base: "stacked-meter--lg",
+      },
+      md: {
+        base: "stacked-meter--md",
+      },
+      sm: {
+        base: "stacked-meter--sm",
+      },
+    },
+  },
+});
+
+export type StackedMeterVariants = VariantProps<typeof stackedMeterVariants>;


### PR DESCRIPTION
Closes #6565

## 📝 Description

Adds a **StackedMeter** component — a segmented horizontal bar that visualises a breakdown of a known capacity. This is the multi-segment sibling of the existing `Meter` component.

Common use cases: storage usage by file type, team capacity by role, language breakdown in a repo, budget allocation by category.

## ⛳️ Current behavior (updates)

HeroUI ships a `Meter` component for single-value-against-maximum display. There is no built-in way to show multiple named segments that sum toward a total.

## 🚀 New behavior

### API

Data-driven (segments as a prop) with compound slots:

```tsx
import { StackedMeter, Label } from '@heroui/react';

const segments = [
  { id: 'photos', value: 45, label: 'Photos', color: 'accent' },
  { id: 'videos', value: 20, label: 'Videos', color: 'success' },
  { id: 'docs', value: 10, label: 'Documents', color: 'warning' },
  { id: 'other', value: 5, label: 'Other', color: 'default' },
];

<StackedMeter segments={segments} maxValue={128} aria-label="Storage usage">
  <Label>Storage</Label>
  <StackedMeter.Output>
    {({ total, maxValue, format }) => `${format(total)} / ${format(maxValue)} GB`}
  </StackedMeter.Output>
  <StackedMeter.Track />
  <StackedMeter.Legend />
</StackedMeter>
```

### Features

- **Compound slots**: Output, Track, Legend — compose what you need
- **Per-segment Tooltip**: each segment shows details on hover
- **Fill animation**: staggered per-segment with `prefers-reduced-motion` support
- **ARIA**: `role="group"` on root, `role="meter"` on each segment with `aria-valuenow/min/max`
- **Overflow clamping**: proportional clamping with dev-mode console warning
- **Intl.NumberFormat**: currency, percent, or custom formatting
- **Size scale**: sm/md/lg matching Meter's proportions
- **Colour tokens**: uses existing `--accent`, `--success`, `--warning`, `--danger`, `--default`

### Files added/modified

- `packages/react/src/components/stacked-meter/` — React component, index, stories
- `packages/styles/components/stacked-meter.css` — BEM CSS
- `packages/styles/src/components/stacked-meter/` — tailwind-variants definition
- `packages/react/src/components/index.ts` — barrel export
- `packages/styles/src/components/index.ts` — barrel export
- `packages/styles/components/index.css` — CSS import
- `apps/docs/content/docs/react/components/(feedback)/stacked-meter.mdx` — documentation

## Screenshots

*(Screenshots from a production implementation of this component are attached to issue #6565, and copied in a comment below. The design matches HeroUI's existing Meter proportions and colour tokens.)*

## 💣 Is this a breaking change (Yes/No):

No. Purely additive — new component, no changes to existing components.

## 📝 Additional Information

- Follows HeroUI's compound component pattern (context + Object.assign)
- Uses `tailwind-variants` for slot-based styling (same as Meter)
- BEM class naming matches HeroUI conventions
- Documentation follows the same MDX structure as the Meter docs page
- Storybook stories cover: default, sizes, legend, custom format, without label

### Why this belongs in HeroUI

1. **Common pattern**: GitHub language bars, macOS storage, Jira sprint capacity — appears in nearly every dashboard
2. **Not trivially composable**: ARIA, tooltip integration, animation coordination, colour tokens
3. **Sibling to Meter**: Same size scale, same visual language, same component family
4. **Accessibility-first**: Per-segment screen reader announcements, reduced-motion support