### PR TITLE
fix(table): use logical border-radius for RTL corners 

### DIFF
--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -74,13 +74,13 @@
 }
 
 .table-root--secondary .table__column:first-child {
-  border-top-left-radius: min(32px, var(--radius-2xl));
-  border-bottom-left-radius: min(32px, var(--radius-2xl));
+  border-start-start-radius: min(32px, var(--radius-2xl));
+  border-end-start-radius: min(32px, var(--radius-2xl));
 }
 
 .table-root--secondary .table__column:last-child {
-  border-top-right-radius: min(32px, var(--radius-2xl));
-  border-bottom-right-radius: min(32px, var(--radius-2xl));
+  border-start-end-radius: min(32px, var(--radius-2xl));
+  border-end-end-radius: min(32px, var(--radius-2xl));
 }
 
 /* Secondary: body has no shadow or rounded corners */
@@ -175,18 +175,19 @@
    -------------------------------------------------------------------------- */
 .table__body {
   /* Non-virtualized: round corners via first/last cells
-     (border-radius on <tbody> itself has no effect) */
+     (border-radius on <tbody> itself has no effect).
+     Logical properties so corners follow `dir` in RTL. */
   & tr:first-child td:first-child {
-    border-top-left-radius: min(32px, var(--radius-2xl));
+    border-start-start-radius: min(32px, var(--radius-2xl));
   }
   & tr:first-child td:last-child {
-    border-top-right-radius: min(32px, var(--radius-2xl));
+    border-start-end-radius: min(32px, var(--radius-2xl));
   }
   & tr:last-child td:first-child {
-    border-bottom-left-radius: min(32px, var(--radius-2xl));
+    border-end-start-radius: min(32px, var(--radius-2xl));
   }
   & tr:last-child td:last-child {
-    border-bottom-right-radius: min(32px, var(--radius-2xl));
+    border-end-end-radius: min(32px, var(--radius-2xl));
   }
 
   /* Virtualized: elements are divs, not tr/td. VirtualizerItem wrappers


### PR DESCRIPTION
## What

`packages/styles/components/table.css` rounds the table body corners and the secondary-variant column corners with physical `border-{top,bottom}-{left,right}-radius`. In RTL the DOM-first cell renders on the visual right, so the rounding lands on interior corners and the visible outer edges are sharp.

This PR replaces those declarations with logical equivalents so the corners follow `dir` automatically.

## Why

Reported in #6445 (table corners section). Same root cause: physical CSS properties where logical ones auto-handle direction.

## Changes

Two blocks in `packages/styles/components/table.css`:

**Secondary variant — header columns**
- `border-top-left-radius` / `border-bottom-left-radius` → `border-start-start-radius` / `border-end-start-radius` (first child)
- `border-top-right-radius` / `border-bottom-right-radius` → `border-start-end-radius` / `border-end-end-radius` (last child)

**Body — first/last cells of first/last rows (non-virtualized)**
- `border-top-left-radius` → `border-start-start-radius`
- `border-top-right-radius` → `border-start-end-radius`
- `border-bottom-left-radius` → `border-end-start-radius`
- `border-bottom-right-radius` → `border-end-end-radius`

LTR behaviour is unchanged (logical properties resolve identically to the previous physical ones). The virtualized branch already uses a symmetric `border-radius` so it needed no change.

## Scope

Only the table portion of #6445. The pagination chevron RTL bug mentioned in the same issue is not addressed here and is a separate fix.

## Test

Wrap a `Table` in `<html dir=rtl>` with several rows — outer corners now round on the right side (visual start) as expected. LTR rendering is unchanged.