### PR TITLE
fix(docs): correct NumberField "With Chevrons" demo layout

### DIFF
--- a/apps/docs/src/demos/number-field/with-chevrons.tsx
+++ b/apps/docs/src/demos/number-field/with-chevrons.tsx
@@ -14,10 +14,10 @@ export function WithChevrons() {
       }}
     >
       <Label>Number field with chevrons</Label>
-      <NumberField.Group>
-        <NumberField.Input />
-        <div className="flex h-[calc(100%+2px)] flex-col border-l border-field-placeholder/15">
-          <NumberField.IncrementButton className="-ml-px flex h-1/2 w-6 flex-1 rounded-none border-r-0 border-l-0 pt-0.5 text-sm">
+      <NumberField.Group className="flex">
+        <NumberField.Input className="flex-1" />
+        <div className="flex h-full flex-col border-l border-field-placeholder/15">
+          <NumberField.IncrementButton className="flex h-1/2 w-6 items-center justify-center rounded-none border-0 pt-0.5 text-sm">
             <svg
               aria-hidden="true"
               height="11"
@@ -33,7 +33,7 @@ export function WithChevrons() {
               />
             </svg>
           </NumberField.IncrementButton>
-          <NumberField.DecrementButton className="-ml-px flex h-1/2 w-6 flex-1 rounded-none border-r-0 border-l-0 pb-0.5 text-sm">
+          <NumberField.DecrementButton className="flex h-1/2 w-6 items-center justify-center rounded-none border-0 pb-0.5 text-sm">
             <svg
               aria-hidden="true"
               height="11"

--- a/packages/react/src/components/number-field/number-field.stories.tsx
+++ b/packages/react/src/components/number-field/number-field.stories.tsx
@@ -434,10 +434,10 @@ export const WithChevrons: Story = {
       }}
     >
       <Label>Number field with chevrons</Label>
-      <NumberField.Group>
-        <NumberField.Input />
-        <div className="flex h-[calc(100%+2px)] flex-col border-l border-field-placeholder/15">
-          <NumberField.IncrementButton className="-ml-px flex h-1/2 w-6 flex-1 rounded-none border-r-0 border-l-0 pt-0.5 text-sm">
+      <NumberField.Group className="flex">
+        <NumberField.Input className="flex-1" />
+        <div className="flex h-full flex-col border-l border-field-placeholder/15">
+          <NumberField.IncrementButton className="flex h-1/2 w-6 items-center justify-center rounded-none border-0 pt-0.5 text-sm">
             <svg
               aria-hidden="true"
               height="11"
@@ -453,7 +453,7 @@ export const WithChevrons: Story = {
               />
             </svg>
           </NumberField.IncrementButton>
-          <NumberField.DecrementButton className="-ml-px flex h-1/2 w-6 flex-1 rounded-none border-r-0 border-l-0 pb-0.5 text-sm">
+          <NumberField.DecrementButton className="flex h-1/2 w-6 items-center justify-center rounded-none border-0 pb-0.5 text-sm">
             <svg
               aria-hidden="true"
               height="11"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6558

## 📝 Description

<!--- Add a brief description -->

In Beta 9 (commit 7cdbf5f95), `.number-field__group` was migrated from `inline-flex` to `display: grid` with a hard-coded `grid-template-columns: 40px 1fr 40px`, and `.number-field__input` lost its `flex-1` in favor of `min-w-0`.

That works fine for the canonical 3-child layout (`DecrementButton` | `Input` | `IncrementButton`), but the With Chevrons demo intentionally uses a custom 2-child layout: Input + a vertical stack of chevron buttons. With the new grid:
- the Input was placed in column 1 → squeezed to 40 px wide
- the chevron `<div>` was placed in column 2 (1fr) → swallowed the middle
- column 3 (40 px) was empty → produced the visible dead gap on the right

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="276" height="88" alt="image" src="https://github.com/user-attachments/assets/9f2ccb21-2411-4199-814e-ed8bd7424cb0" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="282" height="91" alt="image" src="https://github.com/user-attachments/assets/b4b0a62b-8211-4d7b-ac97-72d149674455" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
