### PR TITLE
fix(link): update underline hover states

### DIFF
--- a/apps/docs/content/docs/en/react/components/(navigation)/link.mdx
+++ b/apps/docs/content/docs/en/react/components/(navigation)/link.mdx
@@ -50,6 +50,8 @@ export default () => (
 
 ### Text Decoration with Tailwind CSS
 
+Link is underlined on hover by default. Use Tailwind CSS text-decoration utilities to make the underline always visible, remove it entirely, or customize its color, style, thickness, and offset.
+
 <ComponentPreview
   name="link-underline-and-offset"
 />
@@ -57,7 +59,7 @@ export default () => (
 **Text Decoration Line:**
 - `underline` - Always visible underline
 - `no-underline` - Remove underline
-- `hover:underline` - Underline appears on hover
+- default `Link` styles - Underline appears on hover
 
 **Text Decoration Color:**
 - `decoration-primary`, `decoration-secondary`, etc. - Set underline color using theme colors
@@ -123,7 +125,7 @@ To customize the Link component classes, you can use the `@layer components` dir
 ```css
 @layer components {
   .link {
-    @apply font-semibold no-underline hover:underline;
+    @apply font-semibold;
   }
 }
 ```
@@ -143,6 +145,8 @@ The Link component uses these CSS classes ([View source styles](https://github.c
 The component supports both CSS pseudo-classes and data attributes for flexibility:
 
 - **Focus**: `:focus-visible` or `[data-focus-visible="true"]`
+- **Hover**: `:hover` or `[data-hovered="true"]`
+- **Pressed**: `:active` or `[data-pressed="true"]`
 - **Disabled**: `:disabled` or `[aria-disabled="true"]`
 
 ## API Reference
@@ -202,7 +206,7 @@ import NextLink from 'next/link';
 // Apply classes directly with Tailwind utilities
 export default function Demo() {
   return (
-    <NextLink href="/about" className="link hover:underline underline-offset-2">
+    <NextLink href="/about" className="link underline-offset-2">
       About Page
     </NextLink>
   );

--- a/apps/docs/content/docs/en/react/migration/(components)/link.mdx
+++ b/apps/docs/content/docs/en/react/migration/(components)/link.mdx
@@ -127,7 +127,7 @@ export default function App() {
   </Tab>
   <Tab value="v3">
     ```tsx
-    <Link href="#" className="hover:underline">
+    <Link href="#">
       Hover to underline
     </Link>
     <Link href="#" className="underline underline-offset-2">
@@ -156,7 +156,7 @@ export default function App() {
     import { Link } from "@heroui/react";
 
     {/* Style your router link with the same classes as Link; add an icon if needed */}
-    <NextLink href="/about" className="link hover:underline">
+    <NextLink href="/about" className="link">
       About
     </NextLink>
     ```
@@ -180,7 +180,7 @@ Link (Root)
 3. **Size Prop Removed**: Use Tailwind CSS classes (`text-sm`, `text-base`, `text-lg`)
 4. **Color Prop Removed**: Use Tailwind CSS classes (`text-primary`, `text-danger`, etc.)
 5. **Block Prop Removed**: Use Tailwind CSS classes (`block`, `hover:bg-surface`)
-6. **Underline**: No longer a prop; use Tailwind (`underline`, `hover:underline`, `no-underline`, `underline-offset-1`, etc.)
+6. **Underline**: No longer a prop; Link underlines on hover by default. Use Tailwind (`underline`, `no-underline`, `underline-offset-1`, etc.) to customize it.
 7. **Routing**: v3 Link does not support `as` or `asChild`; use your router's Link with Tailwind classes (e.g. `link`, `link__icon`) for consistent styling
 8. **Animation Removed**: `disableAnimation` prop removed
 9. **`onPress` Handler**: New `onPress` prop available for handling link activation events (click or keyboard)

--- a/apps/docs/src/demos/en/link/underline-and-offset.tsx
+++ b/apps/docs/src/demos/en/link/underline-and-offset.tsx
@@ -4,17 +4,17 @@ export function LinkUnderlineAndOffset() {
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-muted">Always visible underline</p>
-        <Link className="underline" href="#">
-          Underline always visible
+        <p className="text-sm font-medium text-muted">Default hover underline</p>
+        <Link href="#">
+          Hover to see the underline
           <Link.Icon />
         </Link>
       </div>
 
       <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-muted">Underline visible on hover</p>
-        <Link className="no-underline hover:underline" href="#">
-          Hover to see the underline
+        <p className="text-sm font-medium text-muted">Always visible underline</p>
+        <Link className="underline" href="#">
+          Underline always visible
           <Link.Icon />
         </Link>
       </div>
@@ -30,19 +30,19 @@ export function LinkUnderlineAndOffset() {
       <div className="flex flex-col gap-2">
         <p className="text-sm font-medium text-muted">Changing the underline offset</p>
         <div className="flex flex-col gap-3">
-          <Link className="underline-offset-1 hover:underline" href="#">
+          <Link className="underline-offset-1" href="#">
             Offset 1 (1px space)
             <Link.Icon />
           </Link>
-          <Link className="underline-offset-2 hover:underline" href="#">
+          <Link className="underline-offset-2" href="#">
             Offset 2 (2px space)
             <Link.Icon />
           </Link>
-          <Link className="underline-offset-3 hover:underline" href="#">
+          <Link className="underline-offset-3" href="#">
             Offset 3 (3px space)
             <Link.Icon />
           </Link>
-          <Link className="underline-offset-4 hover:underline" href="#">
+          <Link className="underline-offset-4" href="#">
             Offset 4 (4px space)
             <Link.Icon />
           </Link>

--- a/apps/docs/src/demos/en/link/underline-offset.tsx
+++ b/apps/docs/src/demos/en/link/underline-offset.tsx
@@ -3,15 +3,15 @@ import {Link} from "@heroui/react";
 export function LinkUnderlineOffset() {
   return (
     <div className="flex flex-col gap-4">
-      <Link className="underline-offset-1 hover:underline" href="#">
+      <Link className="underline-offset-1" href="#">
         Offset 1
         <Link.Icon />
       </Link>
-      <Link className="underline-offset-2 hover:underline" href="#">
+      <Link className="underline-offset-2" href="#">
         Offset 2
         <Link.Icon />
       </Link>
-      <Link className="underline-offset-3 hover:underline" href="#">
+      <Link className="underline-offset-3" href="#">
         Offset 3
         <Link.Icon />
       </Link>

--- a/apps/docs/src/demos/en/link/underline-variants.tsx
+++ b/apps/docs/src/demos/en/link/underline-variants.tsx
@@ -4,9 +4,9 @@ export function LinkUnderlineVariants() {
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-muted">Underline on hover</p>
-        <Link className="hover:underline" href="#">
-          Hover to see underline animation
+        <p className="text-sm font-medium text-muted">Default hover underline</p>
+        <Link href="#">
+          Hover to see the underline
           <Link.Icon />
         </Link>
       </div>

--- a/packages/react/src/components/link/link.stories.tsx
+++ b/packages/react/src/components/link/link.stories.tsx
@@ -78,17 +78,17 @@ const IconPlacementTemplate = (_props: Link["RootProps"]) => (
 const UnderlineVariantsTemplate = (_props: LinkProps) => (
   <div className="flex flex-col gap-6">
     <div className="flex flex-col gap-2">
-      <p className="text-sm text-muted">Always visible underline</p>
-      <Link className="underline" href="#">
-        Underline always visible
+      <p className="text-sm text-muted">Default hover underline</p>
+      <Link href="#">
+        Hover to see the underline
         <Link.Icon />
       </Link>
     </div>
 
     <div className="flex flex-col gap-2">
-      <p className="text-sm text-muted">Underline visible on hover</p>
-      <Link className="no-underline hover:underline" href="#">
-        Hover to see the underline
+      <p className="text-sm text-muted">Always visible underline</p>
+      <Link className="underline" href="#">
+        Underline always visible
         <Link.Icon />
       </Link>
     </div>
@@ -104,19 +104,19 @@ const UnderlineVariantsTemplate = (_props: LinkProps) => (
     <div className="flex flex-col gap-2">
       <p className="text-sm text-muted">Changing the underline offset</p>
       <div className="flex flex-col gap-3">
-        <Link className="underline-offset-1 hover:underline" href="#">
+        <Link className="underline-offset-1" href="#">
           Offset 1 (1px space)
           <Link.Icon />
         </Link>
-        <Link className="underline-offset-2 hover:underline" href="#">
+        <Link className="underline-offset-2" href="#">
           Offset 2 (2px space)
           <Link.Icon />
         </Link>
-        <Link className="underline-offset-3 hover:underline" href="#">
+        <Link className="underline-offset-3" href="#">
           Offset 3 (3px space)
           <Link.Icon />
         </Link>
-        <Link className="underline-offset-4 hover:underline" href="#">
+        <Link className="underline-offset-4" href="#">
           Offset 4 (4px space)
           <Link.Icon />
         </Link>

--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -1,6 +1,6 @@
 /* Base link styles */
 .link {
-  @apply relative inline-flex h-fit w-fit items-center rounded-xl text-sm font-medium text-link underline decoration-separator-tertiary decoration-[1.5px] underline-offset-4 no-highlight;
+  @apply relative inline-flex h-fit w-fit items-center rounded-xl text-sm font-medium text-link no-underline decoration-separator-tertiary decoration-[1.5px] underline-offset-4 no-highlight;
 
   /**
    * Transitions
@@ -8,7 +8,6 @@
    */
   transition:
     color 100ms var(--ease-smooth),
-    text-decoration-color 100ms var(--ease-out),
     background-color 150ms var(--ease-smooth),
     box-shadow 150ms var(--ease-out),
     opacity 100ms var(--ease-out);
@@ -21,11 +20,21 @@
   @media (hover: hover) {
     &:hover,
     &[data-hovered="true"] {
-      @apply decoration-muted;
+      @apply underline decoration-muted/50;
 
       .link__icon {
         @apply opacity-100;
       }
+    }
+  }
+
+  /* Pressed state */
+  &:active,
+  &[data-pressed="true"] {
+    @apply underline decoration-muted;
+
+    .link__icon {
+      @apply opacity-100;
     }
   }
 


### PR DESCRIPTION
## Summary
- make Link underlines hidden at rest and visible on hover by default
- use 50% opacity underline color on hover and full opacity on pressed/active
- remove underline decoration color transition
- update Link Storybook and docs examples to reflect the default behavior

## Testing
- pnpm --filter @heroui/styles typecheck
- pnpm --filter @heroui/react typecheck
- pnpm --filter @heroui/styles build
- pnpm exec prettier --check packages/styles/components/link.css 'apps/docs/content/docs/react/components/(navigation)/link.mdx'
- git diff --check -- packages/styles/components/link.css 'apps/docs/content/docs/react/components/(navigation)/link.mdx'

## Notes
- `pnpm --filter @heroui/docs typecheck` currently fails on an unrelated `src/app/themes/hooks/use-toggle-locked-variable.ts` `vibrantPalette` type mismatch.
