### PR TITLE
fix(style): use logical inline-end/start for chevrons, value text and indicators

### DIFF
--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -225,7 +225,7 @@
 /* Clear Button styles */
 .autocomplete__clear-button {
   @apply relative isolate inline-flex h-6 w-6 shrink-0 origin-center items-center justify-center rounded-xl p-1 text-muted select-none no-highlight;
-  @apply mr-0 size-5 shrink-0 self-center bg-transparent;
+  @apply me-0 size-5 shrink-0 self-center bg-transparent;
 
   /* Cursor */
   cursor: var(--cursor-interactive);

--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -22,9 +22,9 @@
   border-width: var(--border-width-field);
   border-color: var(--field-border);
 
-  /* Add padding-right when indicator is present */
+  /* Add inline-end padding when indicator is present */
   &:has(.autocomplete__indicator) {
-    @apply pr-7;
+    @apply pe-7;
   }
 
   /* Hover state - exclude when clear button is hovered to prevent double hover effect */
@@ -96,7 +96,7 @@
 }
 
 .autocomplete__value {
-  @apply flex-1 text-left text-base wrap-break-word text-current sm:text-sm;
+  @apply flex-1 text-start text-base wrap-break-word text-current sm:text-sm;
 
   &[data-placeholder="true"] {
     @apply text-field-placeholder;
@@ -109,7 +109,7 @@
 }
 
 .autocomplete__indicator {
-  @apply absolute inset-y-0 right-2 my-auto flex shrink-0 items-center justify-center text-field-placeholder transition duration-150;
+  @apply absolute inset-y-0 end-2 my-auto flex shrink-0 items-center justify-center text-field-placeholder transition duration-150;
 
   /* Cursor */
   cursor: var(--cursor-interactive);

--- a/packages/styles/components/combo-box.css
+++ b/packages/styles/components/combo-box.css
@@ -16,9 +16,9 @@
   [data-slot="input"] {
     @apply min-w-0 flex-1;
 
-    /* Add padding-right when trigger is present */
+    /* Add inline-end padding when trigger is present */
     &:has(+ .combo-box__trigger) {
-      @apply pr-7;
+      @apply pe-7;
     }
 
     /* Focus state (input.css only has focus-visible, but combo-box also needs focus) */
@@ -43,7 +43,7 @@
 }
 
 .combo-box__trigger {
-  @apply absolute top-1/2 right-0 flex h-full shrink-0 -translate-y-1/2 cursor-pointer items-center justify-center pr-2 text-field-placeholder transition duration-150 no-highlight;
+  @apply absolute top-1/2 end-0 flex h-full shrink-0 -translate-y-1/2 cursor-pointer items-center justify-center pe-2 text-field-placeholder transition duration-150 no-highlight;
 
   /* Remove default button styles */
   @apply border-none bg-transparent outline-none;

--- a/packages/styles/components/list-box-item.css
+++ b/packages/styles/components/list-box-item.css
@@ -26,9 +26,9 @@
     @apply pointer-events-none text-wrap select-none;
   }
 
-  /* Add padding-right when indicator is present */
+  /* Add inline-end padding when indicator is present */
   &:has(.list-box-item__indicator) {
-    @apply pr-7;
+    @apply pe-7;
   }
 
   /* Focus visible state (keyboard focus only) */
@@ -72,7 +72,7 @@
    ========================================================================== */
 
 .list-box-item__indicator {
-  @apply absolute top-1/2 right-2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-default-foreground;
+  @apply absolute top-1/2 end-2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-default-foreground;
 
   /**
    * Transitions

--- a/packages/styles/components/menu-item.css
+++ b/packages/styles/components/menu-item.css
@@ -30,14 +30,14 @@
     @apply size-3.5;
   }
 
-  /* Add padding-left when indicator is present */
+  /* Add inline-start padding when indicator is present */
   &:has(.menu-item__indicator) {
-    @apply pl-7;
+    @apply ps-7;
   }
 
-  /* Add padding-right when indicator is present and has submenu */
+  /* Add inline-end padding when indicator is present and has submenu */
   &[data-has-submenu="true"]:has(.menu-item__indicator) {
-    @apply pr-7 pl-2;
+    @apply pe-7 ps-2;
   }
 
   /* Focus visible state (keyboard focus only) */
@@ -97,16 +97,16 @@
    ========================================================================== */
 
 .menu-item__indicator {
-  @apply absolute top-1/2 left-2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-muted;
+  @apply absolute top-1/2 start-2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-muted;
 
   /**
    * Transitions
    */
   @apply transition duration-250 motion-reduce:transition-none;
 
-  /* Position on the right when menu item has submenu */
+  /* Position on the inline-end when menu item has submenu */
   .menu-item[data-has-submenu="true"] & {
-    @apply right-2 left-auto;
+    @apply end-2 start-auto;
   }
 
   /* Checkmark SVG indicator */

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -33,9 +33,9 @@
   border-width: var(--border-width-field);
   border-color: var(--field-border);
 
-  /* Add padding-right when indicator is present */
+  /* Add inline-end padding when indicator is present */
   &:has(.select__indicator) {
-    @apply pr-7;
+    @apply pe-7;
   }
 
   /* Hover state */
@@ -106,7 +106,7 @@
 }
 
 .select__value {
-  @apply flex-1 text-left text-base wrap-break-word text-current sm:text-sm;
+  @apply flex-1 text-start text-base wrap-break-word text-current sm:text-sm;
 
   &[data-placeholder="true"] {
     @apply text-field-placeholder;
@@ -119,7 +119,7 @@
 }
 
 .select__indicator {
-  @apply absolute inset-y-0 right-2 my-auto flex shrink-0 items-center justify-center text-field-placeholder transition duration-150;
+  @apply absolute inset-y-0 end-2 my-auto flex shrink-0 items-center justify-center text-field-placeholder transition duration-150;
 
   &[data-open="true"] {
     @apply rotate-180;


### PR DESCRIPTION
## What

Five style files pin the chevron, value text, item checkmark, combo-box trigger and menu-item indicator with physical `pr-`/`pl-`/`right-`/`left-`/`text-left`. In RTL the chevron lands on the start side, the value text aligns to the visual left (away from the right-side start), and the per-option checkmark or menu-item indicator overlaps the label.

This PR replaces those declarations with logical equivalents so every picker (`Select`, `ListBox.Item`, `Autocomplete`, `ComboBox`) and `MenuItem` follows `dir` automatically.

## Why

Reported under the same umbrella as #6445 / #6568 — physical CSS properties where logical ones auto-handle direction. Same root cause and same one-line shape as the table corners fix.

## Changes

**`packages/styles/components/select.css`**

- `.select__trigger:has(.select__indicator) { pr-7 }` → `pe-7`
- `.select__value { text-left }` → `text-start`
- `.select__indicator { right-2 }` → `end-2`

**`packages/styles/components/list-box-item.css`**

- `.list-box-item:has(.list-box-item__indicator) { pr-7 }` → `pe-7`
- `.list-box-item__indicator { right-2 }` → `end-2`

**`packages/styles/components/autocomplete.css`**

- `.autocomplete__trigger:has(.autocomplete__indicator) { pr-7 }` → `pe-7`
- `.autocomplete__value { text-left }` → `text-start`
- `.autocomplete__indicator { right-2 }` → `end-2`

**`packages/styles/components/combo-box.css`**

- `[data-slot=\"input\"]:has(+ .combo-box__trigger) { pr-7 }` → `pe-7`
- `.combo-box__trigger { right-0 ... pr-2 }` → `end-0 ... pe-2`

**`packages/styles/components/menu-item.css`**

- `.menu-item:has(.menu-item__indicator) { pl-7 }` → `ps-7`
- `.menu-item[data-has-submenu]:has(.menu-item__indicator) { pr-7 pl-2 }` → `pe-7 ps-2`
- `.menu-item__indicator { left-2 }` → `start-2`
- `.menu-item[data-has-submenu] .menu-item__indicator { right-2 left-auto }` → `end-2 start-auto`

LTR behaviour is unchanged (logical properties resolve identically to the previous physical ones).

## Scope

Pickers (`Select`, `ListBox.Item`, `Autocomplete`, `ComboBox`) plus `MenuItem`. Other components reported in #6445 (pagination chevrons, etc.) are not addressed here and remain for separate PRs.

## Test

Wrap each component in `<html dir=\"rtl\">`:

- **Select / Autocomplete / ComboBox** — chevron renders at the inline-end (visual left), value text aligns to start (visual right), placeholder doesn't overlap the chevron.
- **ListBox.Item** (rendered inside `Select.Popover`, `Autocomplete.Popover`, `ComboBox.Popover` or directly) — each item's checkmark renders at the inline-end (visual left) instead of overlapping the label.
- **MenuItem** — selected/checkmark indicator renders at the inline-start (visual right); when the menu item has a submenu, the submenu chevron renders at the inline-end (visual left).

LTR rendering is unchanged for all five.