### PR TITLE
fix(button): prevent translate-induced crash on pending changes

### DIFF
--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type {ButtonVariants} from "@heroui/styles";
-import type {ComponentPropsWithRef} from "react";
+import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {buttonVariants} from "@heroui/styles";
-import {useContext} from "react";
+import {Children, Fragment, cloneElement, isValidElement, useContext} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 
 import {composeTwRenderProps} from "../../utils";
@@ -16,6 +16,23 @@ import {BUTTON_GROUP_CHILD, ButtonGroupContext} from "../button-group";
 interface ButtonRootProps extends ComponentPropsWithRef<typeof ButtonPrimitive>, ButtonVariants {
   [BUTTON_GROUP_CHILD]?: boolean;
 }
+
+const wrapTextNodes = (node: ReactNode): ReactNode =>
+  Children.map(node, (child) => {
+    if (typeof child === "string") {
+      return child.trim() === "" ? child : <span>{child}</span>;
+    }
+
+    if (typeof child === "number") {
+      return <span>{child}</span>;
+    }
+
+    if (isValidElement<{children?: ReactNode}>(child) && child.type === Fragment) {
+      return cloneElement(child, undefined, wrapTextNodes(child.props.children));
+    }
+
+    return child;
+  });
 
 const ButtonRoot = ({
   children,
@@ -70,7 +87,7 @@ const ButtonRoot = ({
           return renderedChildren;
         }
 
-        return <span>{renderedChildren}</span>;
+        return wrapTextNodes(renderedChildren);
       }}
     </ButtonPrimitive>
   );

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {ButtonVariants} from "@heroui/styles";
-import type {ComponentPropsWithRef} from "react";
+import type {CSSProperties, ComponentPropsWithRef} from "react";
 
 import {buttonVariants} from "@heroui/styles";
 import {useContext} from "react";
@@ -17,12 +17,15 @@ interface ButtonRootProps extends ComponentPropsWithRef<typeof ButtonPrimitive>,
   [BUTTON_GROUP_CHILD]?: boolean;
 }
 
+const contentWrapperStyle: CSSProperties = {display: "contents"};
+
 const ButtonRoot = ({
   children,
   className,
   fullWidth,
   isDisabled,
   isIconOnly,
+  isPending,
   size,
   slot,
   style,
@@ -43,6 +46,8 @@ const ButtonRoot = ({
   const finalFullWidth =
     fullWidth ?? (shouldUseContext ? buttonGroupContext?.fullWidth : undefined);
 
+  const hasPendingState = typeof isPending === "boolean";
+
   const styles = buttonVariants({
     fullWidth: finalFullWidth,
     isIconOnly,
@@ -55,11 +60,28 @@ const ButtonRoot = ({
       className={composeTwRenderProps(className, styles)}
       data-slot="button"
       isDisabled={finalIsDisabled}
+      isPending={isPending}
       slot={slot}
       style={style}
       {...rest}
     >
-      {(renderProps) => (typeof children === "function" ? children(renderProps) : children)}
+      {(renderProps) => {
+        const renderedChildren = typeof children === "function" ? children(renderProps) : children;
+
+        if (!hasPendingState) {
+          return renderedChildren;
+        }
+
+        return (
+          <span
+            key={renderProps.isPending ? "pending" : "idle"}
+            data-slot="button-content"
+            style={contentWrapperStyle}
+          >
+            {renderedChildren}
+          </span>
+        );
+      }}
     </ButtonPrimitive>
   );
 };

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type {ButtonVariants} from "@heroui/styles";
-import type {CSSProperties, ComponentPropsWithRef} from "react";
+import type {ComponentPropsWithRef} from "react";
 
 import {buttonVariants} from "@heroui/styles";
 import {useContext} from "react";
@@ -16,8 +16,6 @@ import {BUTTON_GROUP_CHILD, ButtonGroupContext} from "../button-group";
 interface ButtonRootProps extends ComponentPropsWithRef<typeof ButtonPrimitive>, ButtonVariants {
   [BUTTON_GROUP_CHILD]?: boolean;
 }
-
-const contentWrapperStyle: CSSProperties = {display: "contents"};
 
 const ButtonRoot = ({
   children,
@@ -72,15 +70,7 @@ const ButtonRoot = ({
           return renderedChildren;
         }
 
-        return (
-          <span
-            key={renderProps.isPending ? "pending" : "idle"}
-            data-slot="button-content"
-            style={contentWrapperStyle}
-          >
-            {renderedChildren}
-          </span>
-        );
+        return <span>{renderedChildren}</span>;
       }}
     </ButtonPrimitive>
   );


### PR DESCRIPTION
Closes #6480

## 📝 Description

Fixes a React DOM crash that can occur when `Button` content is mutated by browser translation tools such as Chrome Google Translate and the `isPending` state changes afterward.

<br/>

## ⛳️ Current behavior (updates)

When Chrome Google Translate translates text inside a `Button`, it can remove the original React-rendered text node and replace it with new DOM nodes such as `<font>` elements.

React still keeps references to the original text nodes. If `isPending` changes after translation, React may try to insert or remove button content relative to a text node that is no longer a child of the button.

This can crash the page with errors such as:

```text
NotFoundError: Failed to execute 'insertBefore' on 'Node'
The node before which the new node is to be inserted is not a child of this node.
```

<br/>

## 🚀 New behavior
When isPending is explicitly provided as a boolean, Button now renders its content inside a stable display: contents wrapper.

The content subtree is remounted when the pending state changes, which avoids reconciling directly against text nodes that may have been replaced by browser translation.

This follows the same general mitigation approach used by MUI Button for Google Translate related React crashes.

<br/>

## 💣 Is this a breaking change (Yes/No):
No.

Buttons that do not use isPending continue to render as before. The wrapper is only added when isPending is explicitly passed as true or false.


<br/> 

## Test
### before
- Before this change, enabling Chrome Google Translate and then changing the `Button` `isPending` state could crash the page.

https://github.com/user-attachments/assets/aa3d765a-a41a-4800-9482-9d654283c7ad




### after
- After this change, the same flow no longer crashes.

https://github.com/user-attachments/assets/ff18753d-c3ee-4f10-a028-00ae15ebc5fb

