### PR TITLE
fix(select): ensure selected item is visible when reopening popover

### DIFF
--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -7,11 +7,7 @@ import type {SelectVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {selectVariants} from "@heroui/styles";
-<<<<<<< HEAD
-import React, {createContext, use} from "react";
-=======
-import React, {createContext, useContext, useEffect, useRef} from "react";
->>>>>>> 7e28d2b55 (fix(select): correct popover scroll position when opening)
+import React, {createContext, use, useEffect, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
 import {
@@ -166,11 +162,8 @@ const SelectPopover = ({
   placement = "bottom",
   ...props
 }: SelectPopoverProps) => {
-<<<<<<< HEAD
   const {slots} = use(SelectContext);
-=======
-  const {slots} = useContext(SelectContext);
-  const state = useContext(SelectStateContext);
+  const state = use(SelectStateContext);
   const popoverRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -193,7 +186,6 @@ const SelectPopover = ({
       window.cancelAnimationFrame(rafId);
     };
   }, [state?.isOpen]);
->>>>>>> 7e28d2b55 (fix(select): correct popover scroll position when opening)
 
   return (
     <SurfaceContext

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -134,8 +134,8 @@ const SelectIndicator = <E extends keyof React.JSX.IntrinsicElements = "svg">({
       {
         ...(props as any),
         className: composeSlotClassName(slots?.indicator, className),
-        "data-open": dataAttr(state?.isOpen),
         "data-slot": "select-indicator",
+        "data-open": dataAttr(state?.isOpen),
       },
     );
   }
@@ -176,34 +176,21 @@ const SelectPopover = ({
   useEffect(() => {
     if (!state?.isOpen || !popoverRef.current) return;
 
-    const scrollSelectedItem = () => {
-      const popover = popoverRef.current;
+    let rafId = 0;
 
-      if (!popover) return;
+    const timerId = window.setTimeout(() => {
+      rafId = window.requestAnimationFrame(() => {
+        const selectedItem =
+          popoverRef.current?.querySelector<HTMLElement>('[aria-selected="true"]');
 
-      const selectedItem = popover.querySelector<HTMLElement>('[aria-selected="true"]');
-
-      if (!selectedItem) return;
-
-      const popoverHeight = popover.clientHeight;
-      const itemTop = selectedItem.offsetTop;
-      const itemHeight = selectedItem.offsetHeight;
-      const scrollTop = Math.max(
-        0,
-        itemTop - Math.floor(popoverHeight / 2) + Math.floor(itemHeight / 2),
-      );
-
-      popover.scrollTo({
-        behavior: "auto",
-        top: scrollTop,
+        selectedItem?.scrollIntoView({block: "nearest"});
       });
-    };
-
-    const timer = window.setTimeout(() => {
-      window.requestAnimationFrame(scrollSelectedItem);
     }, 0);
 
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timerId);
+      window.cancelAnimationFrame(rafId);
+    };
   }, [state?.isOpen]);
 >>>>>>> 7e28d2b55 (fix(select): correct popover scroll position when opening)
 

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -7,6 +7,7 @@ import type {SelectVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {selectVariants} from "@heroui/styles";
+import {mergeRefs} from "@react-aria/utils";
 import React, {createContext, use, useEffect, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
@@ -160,11 +161,13 @@ const SelectPopover = ({
   children,
   className,
   placement = "bottom",
+  ref,
   ...props
 }: SelectPopoverProps) => {
   const {slots} = use(SelectContext);
   const state = use(SelectStateContext);
   const popoverRef = useRef<HTMLElement>(null);
+  const mergedRef = mergeRefs(ref, popoverRef);
 
   useEffect(() => {
     if (!state?.isOpen || !popoverRef.current) return;
@@ -173,8 +176,9 @@ const SelectPopover = ({
 
     const timerId = window.setTimeout(() => {
       rafId = window.requestAnimationFrame(() => {
-        const selectedItems =
-          popoverRef.current?.querySelectorAll<HTMLElement>('[aria-selected="true"]');
+        const selectedItems = popoverRef.current?.querySelectorAll<HTMLElement>(
+          '[data-slot="list-box-item"][aria-selected="true"]',
+        );
         const selectedItem = selectedItems?.[selectedItems.length - 1];
 
         selectedItem?.scrollIntoView({block: "nearest"});
@@ -195,7 +199,7 @@ const SelectPopover = ({
     >
       <PopoverPrimitive
         {...props}
-        ref={popoverRef}
+        ref={mergedRef}
         className={composeTwRenderProps(className, slots?.popover())}
         data-slot="select-popover"
         placement={placement}

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -7,7 +7,11 @@ import type {SelectVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {selectVariants} from "@heroui/styles";
+<<<<<<< HEAD
 import React, {createContext, use} from "react";
+=======
+import React, {createContext, useContext, useEffect, useRef} from "react";
+>>>>>>> 7e28d2b55 (fix(select): correct popover scroll position when opening)
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
 import {
@@ -130,8 +134,8 @@ const SelectIndicator = <E extends keyof React.JSX.IntrinsicElements = "svg">({
       {
         ...(props as any),
         className: composeSlotClassName(slots?.indicator, className),
-        "data-slot": "select-indicator",
         "data-open": dataAttr(state?.isOpen),
+        "data-slot": "select-indicator",
       },
     );
   }
@@ -162,7 +166,46 @@ const SelectPopover = ({
   placement = "bottom",
   ...props
 }: SelectPopoverProps) => {
+<<<<<<< HEAD
   const {slots} = use(SelectContext);
+=======
+  const {slots} = useContext(SelectContext);
+  const state = useContext(SelectStateContext);
+  const popoverRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!state?.isOpen || !popoverRef.current) return;
+
+    const scrollSelectedItem = () => {
+      const popover = popoverRef.current;
+
+      if (!popover) return;
+
+      const selectedItem = popover.querySelector<HTMLElement>('[aria-selected="true"]');
+
+      if (!selectedItem) return;
+
+      const popoverHeight = popover.clientHeight;
+      const itemTop = selectedItem.offsetTop;
+      const itemHeight = selectedItem.offsetHeight;
+      const scrollTop = Math.max(
+        0,
+        itemTop - Math.floor(popoverHeight / 2) + Math.floor(itemHeight / 2),
+      );
+
+      popover.scrollTo({
+        behavior: "auto",
+        top: scrollTop,
+      });
+    };
+
+    const timer = window.setTimeout(() => {
+      window.requestAnimationFrame(scrollSelectedItem);
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [state?.isOpen]);
+>>>>>>> 7e28d2b55 (fix(select): correct popover scroll position when opening)
 
   return (
     <SurfaceContext
@@ -172,6 +215,7 @@ const SelectPopover = ({
     >
       <PopoverPrimitive
         {...props}
+        ref={popoverRef}
         className={composeTwRenderProps(className, slots?.popover())}
         data-slot="select-popover"
         placement={placement}

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -180,8 +180,9 @@ const SelectPopover = ({
 
     const timerId = window.setTimeout(() => {
       rafId = window.requestAnimationFrame(() => {
-        const selectedItem =
-          popoverRef.current?.querySelector<HTMLElement>('[aria-selected="true"]');
+        const selectedItems =
+          popoverRef.current?.querySelectorAll<HTMLElement>('[aria-selected="true"]');
+        const selectedItem = selectedItems?.[selectedItems.length - 1];
 
         selectedItem?.scrollIntoView({block: "nearest"});
       });

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -137,7 +137,7 @@
 
 /* Similar to popover content styles */
 .select__popover {
-  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain bg-overlay p-0 text-sm scrollbar;
+  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scrollbar bg-overlay p-0 text-sm;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 
@@ -199,7 +199,8 @@
 
   /* Listbox styles */
   [data-slot="list-box"] {
-    @apply p-1.5 outline-none;
+    @apply scroll-py-1 scrollbar overflow-y-auto overscroll-contain p-1.5 outline-none;
+    max-height: inherit;
   }
 
   [data-slot="list-box-item"] {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6489 

## 📝 Description

Fixes an issue where the Select popover did not scroll to the currently selected item when reopened. As a result, the selected option could remain outside the visible area of the list.

## ⛳️ Current behavior (updates)

After selecting an option and reopening the Select popover, the list remains at its default scroll position. The selected item may be located outside the visible viewport, requiring the user to manually scroll to find it.

## 🚀 New behavior

When the Select popover is opened, it automatically scrolls to the currently selected item, ensuring that the selected option is visible to the user.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Verified that reopening the Select popover automatically scrolls the list to the selected item.

Demo

https://github.com/user-attachments/assets/effb6d82-fe6e-4cc9-b6d9-31fff7195020


