### PR TITLE
fix(styles): cap modal/alert-dialog scroll-inside height so body scrolls

### DIFF
--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -142,7 +142,8 @@
  */
 .alert-dialog__dialog {
   @apply relative;
-  @apply flex w-full flex-col;
+  @apply flex min-h-0 w-full flex-col;
+  @apply max-h-full;
   @apply bg-overlay shadow-overlay outline-none;
   border-radius: min(32px, var(--radius-3xl));
   @apply p-6;

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -196,7 +196,7 @@
  * Modifier: dialog--scroll-inside
  */
 .modal__dialog--scroll-inside {
-  @apply overflow-clip;
+  @apply max-h-full min-h-0 overflow-clip;
 }
 
 /**


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6583

## 📝 Description

<!--- Add a brief description -->

```tsx
  <Modal>
    <Button variant="secondary">Open scroll="inside" modal</Button>
    <Modal.Backdrop>
      <Modal.Container scroll="inside">
        <Modal.Dialog className="sm:max-w-[420px]">
          <Modal.CloseTrigger />
          <Modal.Header>
            <Modal.Heading>Pinned header</Modal.Heading>
            <p className="text-sm leading-5 text-muted">
              The body below contains 30 paragraphs. The dialog should not grow past the viewport;
              only the body should scroll.
            </p>
          </Modal.Header>
          <Modal.Body>
            {Array.from({length: 30}).map((_, i) => (
              <p key={i} className="mb-3">
                Paragraph {i + 1}: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
                pulvinar risus non risus hendrerit venenatis. Pellentesque sit amet hendrerit risus,
                sed porttitor quam.
              </p>
            ))}
          </Modal.Body>
          <Modal.Footer>
            <Button slot="close" variant="secondary">
              Cancel
            </Button>
            <Button slot="close">Confirm</Button>
          </Modal.Footer>
        </Modal.Dialog>
      </Modal.Container>
    </Modal.Backdrop>
  </Modal>
```

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="683" height="808" alt="image" src="https://github.com/user-attachments/assets/4160b727-d1b0-4806-a3f4-4255c5ecf65e" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="535" height="771" alt="image" src="https://github.com/user-attachments/assets/6480e473-a4f9-4e9d-9a8d-39facd446d08" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
