### PR TITLE
fix(styles): restore Modal scroll="inside" scrolling (fix #6603)

### DIFF
--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -196,7 +196,7 @@
  * Modifier: dialog--scroll-inside
  */
 .modal__dialog--scroll-inside {
-  @apply overflow-clip;
+  @apply overflow-clip min-h-0;
 }
 
 /**


### PR DESCRIPTION
Closes #6603

## Summary

`Modal` with `scroll="inside"` stopped scrolling its body in `@heroui/styles@3.1.0`. `.modal__dialog--scroll-inside` was changed from `overflow: hidden` to `overflow: clip`.

Unlike `hidden`, **`overflow: clip` is not a scroll container**. Per the CSS Flexbox spec, a flex item only gets an automatic `min-height` of `0` when it is a scroll container — otherwise it stays content-based. So with `clip`, the dialog (a flex item inside the `h-(--visual-viewport-height)` `.modal__container`) no longer shrinks to the viewport, and the body (`.modal__body { flex-1 min-h-0 }` + `.modal__body--scroll-inside { overflow-y-auto }`) never gets a bounded height to scroll within — the header/footer get pushed off-screen and content becomes unreachable.

## Fix

```diff
 .modal__dialog--scroll-inside {
-  @apply overflow-clip;
+  @apply overflow-clip min-h-0;
 }
```

`min-h-0` re-supplies the `min-height: 0` that `overflow: hidden` provided implicitly, **keeping the intentional `overflow: clip`** while restoring the dialog's ability to shrink. (A straight revert to `overflow: hidden` also fixes it — happy to switch if maintainers prefer.)

## Why it matters

Besides broken inside-scroll, the regression nudges users toward `scroll="outside"`, whose `.modal__container--scroll-outside { pointer-events-auto }` then swallows backdrop clicks and breaks `isDismissable` (click-outside-to-close) — so one CSS change cascades into two visible problems.

## Verification

- Matches the behavior `@heroui/styles@3.0.5` shipped (it used `overflow: hidden`, i.e. the same implicit `min-height: 0`, and scrolled correctly).
- The docs' own "Scroll Comparison" example (30 paragraphs, `scroll="inside"`, no height class) scrolls again with this change.

## Notes

- CSS-only, one line; no change to `scroll="outside"` behavior.
- Opened as a **draft** for maintainer input on `min-h-0` vs reverting to `overflow-hidden`.
