### PR TITLE
fix(styles): column separator and resizer position in RTL layout

### DIFF
--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -111,7 +111,7 @@
   /* Separator between columns — a short vertical line on the right edge */
   &::after {
     content: "";
-    @apply pointer-events-none absolute top-1/2 right-0 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
+    @apply pointer-events-none absolute top-1/2 end-0 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
   }
 
   &:last-child:not(:only-child)::after {

--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -306,7 +306,7 @@
    -------------------------------------------------------------------------- */
 .table__column-resizer {
   /* Match the ::after separator: absolute, right edge, short vertical line */
-  @apply absolute top-1/2 right-0 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
+  @apply absolute top-1/2 end-0 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
   /* Make it interactive — wider hit area with transparent padding */
   @apply box-content translate-x-1/2 cursor-col-resize touch-none px-2;
   /* Reset appearance */


### PR DESCRIPTION
Closes #6599

## 📝 Description

This PR fixes a layout and user experience (UX) issue in the Table component when rendered in RTL (Right-to-Left) mode (e.g., Hebrew or Arabic).

## ⛳️ Current behavior (updates)

The Table component used physical CSS utility classes (`right-0`) for both the column separator (`::after`) and the column resizer (`.table__column-resizer`). 
In RTL mode, this caused:
1. The vertical separator line to appear incorrectly on the right side of the column instead of the left side.
2. The interactive column resizer (hitbox) to remain on the physical right side, mismatching the visual layout and breaking the resize functionality's intuitive UX.

## 🚀 New behavior

Replaced the physical Tailwind property `right-0` with the logical property `end-0` in both places:
- Inside the table column separator (`&::after`)
- Inside the table column resizer (`.table__column-resizer`)

This ensures both elements dynamically align to the correct edge based on the document direction (right for LTR, left for RTL) while keeping them perfectly synchronized and functioning correctly.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Issue Link: https://github.com/heroui-inc/heroui/issues/6599