### PR TITLE
docs(native): add create-heroui-native-app CLI docs and quick-start restructure

### DIFF
--- a/apps/docs/content/docs/en/native/getting-started/(overview)/quick-start.mdx
+++ b/apps/docs/content/docs/en/native/getting-started/(overview)/quick-start.mdx
@@ -1,10 +1,80 @@
 ---
 title: Quick Start
-description: Get started with HeroUI Native in minutes
+description: Get up and running with HeroUI Native
 icon: rocket
 ---
 
-## Getting Started
+Choose the path that fits your project:
+
+- **Option 1** — Scaffold a new, preconfigured project with our CLI. Zero setup.
+- **Option 2** — Add HeroUI Native to an existing React Native or Expo project.
+
+## Option 1: Create a New Project
+
+The fastest way to start. The CLI scaffolds an Expo project with HeroUI Native, all required peer dependencies, Uniwind / Tailwind CSS, global styles, and the `HeroUINativeProvider` already wired up — so you can jump straight to building.
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tab value="npm">
+    ```bash
+    npx create-heroui-native-app@latest
+    ```
+  </Tab>
+  <Tab value="pnpm">
+    ```bash
+    pnpm create heroui-native-app@latest
+    ```
+  </Tab>
+  <Tab value="yarn">
+    ```bash
+    yarn create heroui-native-app
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bun create heroui-native-app@latest
+    ```
+  </Tab>
+</Tabs>
+
+Follow the interactive prompts, then start the dev server:
+
+```bash
+cd my-app
+npm run start
+```
+
+You're ready to build. Skip ahead to [Use Your First Component](#use-your-first-component) or [browse components](/docs/native/components).
+
+<Callout type="info">
+  The scaffold includes Expo with TypeScript, Uniwind + Tailwind CSS preconfigured, `global.css` with the required imports, and the app entry already wrapped in `GestureHandlerRootView` and `HeroUINativeProvider`.
+</Callout>
+
+## Option 2: Add to an Existing Project
+
+If you already have a React Native or Expo app, follow these steps to install and configure HeroUI Native manually.
+
+<CopyPrompt
+  prompt={`Set up HeroUI Native in this React Native project.
+
+Use the HeroUI Native MCP server (@heroui/native-mcp) as the single source of truth for installation steps, peer dependencies, and component APIs. Start by retrieving the latest quick-start / installation guide from the MCP and follow it precisely — do not rely on memory for versions, package names, or setup steps.
+
+Before making any changes:
+
+1. Analyze the project. Detect the package manager (npm / pnpm / yarn / bun), framework (Expo or bare React Native), TypeScript usage, and the location of node_modules. This matters for global.css — the @source path must be written relative to global.css itself and must resolve to node_modules/heroui-native/lib.
+2. Read package.json and only install what is missing. Pin to the exact versions listed in the MCP quick-start to avoid compatibility issues.
+3. Inspect the app entry (App.tsx, app/_layout.tsx, index.tsx, etc.) and check whether GestureHandlerRootView already wraps the app. If it does, reuse it — do not nest a second GestureHandlerRootView.
+
+Then apply the setup:
+
+- Install heroui-native plus any missing mandatory+optional peer dependencies.
+- Set up Uniwind + Tailwind CSS (follow the Uniwind quickstart) and add the HeroUI Native imports plus the correct @source line to global.css.
+- Make sure GestureHandlerRootView wraps the entire app — it must be the outermost wrapper with style { flex: 1 }.
+- Add HeroUINativeProvider as a direct child of GestureHandlerRootView, wrapping the rest of the app.
+
+When done, summarize the changes you made and tell me how to run the app on iOS / Android.`}
+>
+  **Prefer to let your AI assistant do it?** Install the [HeroUI Native MCP Server](/docs/native/getting-started/mcp-server) in your editor, then paste the prompt into your AI assistant — it will analyze your project and handle the entire setup for you.
+</CopyPrompt>
 
 ### 1. Install HeroUI Native
 
@@ -113,7 +183,7 @@ export default function App() {
 
 > **Note**: For advanced configuration options including text props, animation settings, and toast configuration, see the [Provider documentation](/docs/native/getting-started/provider).
 
-### 7. Use Your First Component
+## Use Your First Component
 
 ```tsx
 import { Button } from 'heroui-native';
@@ -128,7 +198,7 @@ export default function MyComponent() {
 }
 ```
 
-### 8. Reduce Bundle Size with Granular Exports
+## Reduce Bundle Size with Granular Exports
 
 If you want to reduce bundle size and import only the components you need, our library provides granular exports for each component:
 

--- a/apps/docs/content/docs/en/native/releases/create-heroui-native-app.mdx
+++ b/apps/docs/content/docs/en/native/releases/create-heroui-native-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: create-heroui-native-app v1.0.0
+title: create-heroui-native-app
 description:
   New CLI for scaffolding a preconfigured HeroUI Native + Expo Router project — Expo SDK 56, React Native 0.85, Uniwind, all peer dependencies wired up, two starter templates (single-screen and tabs).
 ---

--- a/apps/docs/content/docs/en/native/releases/create-heroui-native-app.mdx
+++ b/apps/docs/content/docs/en/native/releases/create-heroui-native-app.mdx
@@ -1,0 +1,130 @@
+---
+title: create-heroui-native-app v1.0.0
+description:
+  New CLI for scaffolding a preconfigured HeroUI Native + Expo Router project — Expo SDK 56, React Native 0.85, Uniwind, all peer dependencies wired up, two starter templates (single-screen and tabs).
+---
+
+<div className="flex items-center gap-3 mb-6">
+  <span className="text-sm text-muted">June 4, 2026</span>
+</div>
+
+<VideoPlayer
+  src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/native/cli-demo.mp4"
+  height={430}
+  muted
+/>
+
+🎉 A new CLI — [`create-heroui-native-app`](https://www.npmjs.com/package/create-heroui-native-app) — is now the fastest way to start a HeroUI Native project. One command scaffolds a complete Expo Router app with HeroUI Native, Uniwind, Tailwind CSS, every required peer dependency, and the provider wiring already in place. No manual setup of `global.css`, `metro.config.js`, or `app/_layout.tsx`.
+
+## Quick Start
+
+<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+<Tab value="npm">
+  ```bash
+  npx create-heroui-native-app@latest my-app
+  ```
+</Tab>
+<Tab value="pnpm">
+  ```bash
+  pnpm create heroui-native-app@latest my-app
+  ```
+</Tab>
+<Tab value="yarn">
+  ```bash
+  yarn create heroui-native-app my-app
+  ```
+</Tab>
+<Tab value="bun">
+  ```bash
+  bun create heroui-native-app@latest my-app
+  ```
+</Tab>
+</Tabs>
+
+Then start the dev server:
+
+```bash
+cd my-app
+npm run start
+```
+
+That's it. Skip ahead to the [Quick Start guide](/docs/native/getting-started/quick-start) for the full walkthrough.
+
+## Starter Templates
+
+The CLI ships with two templates. Pick one in the interactive picker, or pass a flag to skip the prompt.
+
+| Flag | Template | Description |
+| --- | --- | --- |
+| `--expo` | `expo` | Single-screen Expo Router app with a HeroUI `Button` demo. |
+| `--expo-tabs` | `expo-tabs` | Expo Router tabs layout with two tabs (`Button` + `Card` demos). |
+
+```bash
+npx create-heroui-native-app@latest my-app --expo
+npx create-heroui-native-app@latest my-app --expo-tabs --use-pnpm
+```
+
+## What You Get
+
+Every scaffolded project ships preconfigured with:
+
+- **Expo SDK 56** + **Expo Router** with typed routes enabled
+- **React 19.2** + **React Native 0.85.2** + Hermes v1 (default in SDK 56)
+- **HeroUI Native** wrapped in `HeroUINativeProvider` and `GestureHandlerRootView` inside `app/_layout.tsx`
+- **Uniwind** + **Tailwind CSS** wired through `metro.config.js` and `global.css`
+- All HeroUI Native **mandatory peer dependencies** pinned to compatible versions: `react-native-reanimated`, `react-native-gesture-handler`, `react-native-worklets`, `react-native-safe-area-context`, `react-native-svg`, `tailwind-variants`, `tailwind-merge`
+- `react-native-screens` so HeroUI overlay components (`Dialog`, `Menu`, `Popover`, `Select`, `BottomSheet`, `Toast`) work out of the box
+- `@expo/metro-runtime` (required peer for Expo Router on SDK 56)
+- A `babel.config.js` using just `babel-preset-expo` (worklets handled by the preset)
+- **TypeScript** with `strict: true` and the `@/*` path alias
+
+## CLI Reference
+
+```text
+create-heroui-native-app [project-name] [options]
+```
+
+| Option | Description |
+| --- | --- |
+| `[project-name]` | Directory name to create. Prompted if omitted. Must be a valid npm package name. |
+| `--expo` | Use the single-screen Expo template. |
+| `--expo-tabs` | Use the Expo + tabs template. |
+| `--template <id>` | Use the template with the given id (`expo` or `expo-tabs`). |
+| `--use-npm` / `--use-yarn` / `--use-pnpm` / `--use-bun` | Force a specific package manager (otherwise auto-detected). |
+| `--skip-install` | Don't run the package manager install step. |
+| `--skip-git` | Don't initialize a git repository. |
+| `-h`, `--help` | Print usage and exit. |
+
+### Examples
+
+```bash
+# Fully interactive — prompts for both project name and template
+npx create-heroui-native-app@latest
+
+# Project name supplied, template picker still shown
+npx create-heroui-native-app@latest my-app
+
+# Fully non-interactive
+npx create-heroui-native-app@latest my-app --expo
+
+# Tabs template, install with pnpm
+npx create-heroui-native-app@latest my-app --expo-tabs --use-pnpm
+
+# Scaffold only, no install, no git
+npx create-heroui-native-app@latest my-app --expo --skip-install --skip-git
+```
+
+## Requirements
+
+- **Node.js 20.19.4+** (required by Expo SDK 56 / React Native 0.85)
+- **iOS 16.4+** when building native iOS (Expo SDK 56 deployment target)
+- macOS, Linux, or Windows
+
+<Callout type="info">
+  **Already have an app?** The CLI is for new projects. To add HeroUI Native to an existing React Native or Expo app, follow [Option 2 in the Quick Start](/docs/native/getting-started/quick-start#option-2-add-to-an-existing-project).
+</Callout>
+
+## Links
+
+- [Quick Start guide](/docs/native/getting-started/quick-start)
+- [HeroUI Native MCP Server](/docs/native/getting-started/mcp-server)

--- a/apps/docs/content/docs/en/native/releases/index.mdx
+++ b/apps/docs/content/docs/en/native/releases/index.mdx
@@ -9,7 +9,7 @@ description: All updates and changes to HeroUI Native, including new features, f
 
 ## Latest Release
 
-### `create-heroui-native-app` v1.0.0
+### `create-heroui-native-app`
 
 **June 2026**
 

--- a/apps/docs/content/docs/en/native/releases/index.mdx
+++ b/apps/docs/content/docs/en/native/releases/index.mdx
@@ -9,6 +9,16 @@ description: All updates and changes to HeroUI Native, including new features, f
 
 ## Latest Release
 
+### `create-heroui-native-app` v1.0.0
+
+**June 2026**
+
+🎉 A new CLI for scaffolding a HeroUI Native project in one command. `npx create-heroui-native-app@latest my-app` generates a complete Expo Router app with HeroUI Native, Uniwind, Tailwind CSS, every required peer dependency, and the provider wiring already in place — pick between a single-screen or tabs starter template.
+
+[Read full release notes →](/docs/native/releases/create-heroui-native-app)
+
+---
+
 ### v1.0.4
 
 **May 2026**

--- a/apps/docs/content/docs/en/native/releases/meta.json
+++ b/apps/docs/content/docs/en/native/releases/meta.json
@@ -7,6 +7,7 @@
     "---Overview---",
     "index",
     "---Releases---",
+    "create-heroui-native-app",
     "v1-0-4",
     "v1-0-3",
     "v1-0-2",

--- a/apps/docs/src/app/[lang]/(home)/home-content.tsx
+++ b/apps/docs/src/app/[lang]/(home)/home-content.tsx
@@ -58,7 +58,7 @@ const content: Record<HomeLocale, HomeContent> = {
       roadmap: "路线图",
       themes: "主题",
     },
-    releaseBadge: "HeroUI Native v1.0.4 – Typography、柔和配色、鲜亮主题与 Expo 56",
+    releaseBadge: "New CLI: create-heroui-native-app v1.0.0",
     title: (
       <>
         开箱即美。<span className="text-muted/70">设计上随心可定。</span>
@@ -89,7 +89,7 @@ const content: Record<HomeLocale, HomeContent> = {
       roadmap: "Roadmap",
       themes: "Themes",
     },
-    releaseBadge: "HeroUI Native v1.0.4 – Typography、柔和配色、鲜亮主题与 Expo 56",
+    releaseBadge: "New CLI: create-heroui-native-app v1.0.0",
     title: (
       <>
         Beautiful by default. <span className="text-muted/70">Customizable by design.</span>

--- a/apps/docs/src/app/[lang]/(home)/page.tsx
+++ b/apps/docs/src/app/[lang]/(home)/page.tsx
@@ -33,7 +33,7 @@ export default async function HomePage({params}: {params: Promise<{lang: string}
         <div className="mx-auto flex max-w-2xl flex-col items-center justify-center">
           <LinkRoot
             className="flex items-center gap-1 rounded-full bg-accent-soft px-2 py-1 text-xs text-accent-soft-foreground transition-colors hover:bg-accent-soft-hover"
-            href="/docs/native/releases/v1-0-4"
+            href="/docs/native/releases/create-heroui-native-app"
           >
             <Rocket className="size-3 text-accent-soft-foreground" />
             <span className="max-w-60 truncate sm:max-w-full">{home.releaseBadge}</span>

--- a/apps/docs/src/components/copy-prompt.tsx
+++ b/apps/docs/src/components/copy-prompt.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {Button} from "@heroui/react";
+import {useCopyButton} from "fumadocs-ui/utils/use-copy-button";
+
+import {Iconify} from "@/components/iconify";
+import {cn} from "@/utils/cn";
+
+/**
+ * Props for the {@link CopyPrompt} MDX component.
+ */
+export interface CopyPromptProps {
+  /**
+   * The prompt text written to the clipboard when the user clicks the button.
+   * Multi-line strings are supported.
+   */
+  prompt: string;
+  /**
+   * Inline description rendered next to the icon. Accepts MDX / JSX so bold
+   * text, links, and other inline formatting are supported.
+   */
+  children: React.ReactNode;
+  /**
+   * Iconify icon name shown on the left. Defaults to `"sparkles"`.
+   */
+  icon?: string;
+  /**
+   * Optional additional class names applied to the outer container.
+   */
+  className?: string;
+}
+
+/**
+ * CopyPrompt
+ *
+ * A compact horizontal card consisting of an icon on the left, an inline
+ * description in the middle, and a "Copy prompt" button on the right.
+ * The prompt itself is intentionally hidden — clicking the button copies
+ * it to the user's clipboard so they can paste it into their AI assistant.
+ *
+ * This is a client component because clipboard access and the "Copied"
+ * toggle state from `useCopyButton` must run in the browser.
+ */
+export function CopyPrompt({children, className, icon = "sparkles-fill", prompt}: CopyPromptProps) {
+  const [checked, onClick] = useCopyButton(() => {
+    void navigator.clipboard.writeText(prompt);
+  });
+
+  return (
+    <div
+      className={cn(
+        "flex gap-2 rounded-xl border border-border bg-surface py-3 pr-3 pl-1 text-sm text-surface-foreground shadow-surface",
+        className,
+      )}
+    >
+      <div className="flex gap-2">
+        <div className="w-0.5 self-stretch rounded-sm bg-accent/50" role="none" />
+        <Iconify className="mt-1 size-4 shrink-0 text-accent" icon={icon} />
+      </div>
+      <div className="prose-no-margin min-w-0 flex-1 leading-relaxed">{children}</div>
+      <Button
+        aria-label={checked ? "Prompt copied to clipboard" : "Copy prompt to clipboard"}
+        className="shrink-0"
+        isDisabled={checked}
+        size="sm"
+        type="button"
+        variant="tertiary"
+        onClick={onClick}
+      >
+        {checked ? (
+          <>
+            <Iconify icon="check" />
+            Copied
+          </>
+        ) : (
+          <>
+            <Iconify icon="copy" />
+            Copy prompt
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/apps/docs/src/lib/dictionaries/cn.json
+++ b/apps/docs/src/lib/dictionaries/cn.json
@@ -1,6 +1,6 @@
 {
   "home": {
-    "releaseBadge": "HeroUI Native v1.0.4 – Typography、柔和配色、鲜亮主题与 Expo 56",
+    "releaseBadge": "New CLI: create-heroui-native-app v1.0.0",
     "titleMain": "开箱即用",
     "titleMuted": "设计灵活可定制",
     "description": "HeroUI 是面向网页与移动端的现代 UI 库，助你快速迭代、保持一致，并打造令人愉悦的用户体验。",

--- a/apps/docs/src/lib/dictionaries/en.json
+++ b/apps/docs/src/lib/dictionaries/en.json
@@ -1,6 +1,6 @@
 {
   "home": {
-    "releaseBadge": "HeroUI Native v1.0.4 - Typography, soft palette, vibrant theme & Expo 56",
+    "releaseBadge": "New CLI: create-heroui-native-app v1.0.0",
     "titleMain": "Beautiful by default.",
     "titleMuted": "Customizable by design.",
     "description": "HeroUI is the modern UI library for web and mobile, built to help you move fast, stay consistent, and deliver delightful user experiences.",

--- a/apps/docs/src/mdx-components.tsx
+++ b/apps/docs/src/mdx-components.tsx
@@ -10,6 +10,7 @@ import {Suspense} from "react";
 import {CollapsibleCode} from "./components/collapsible-code";
 import {ComponentPreview} from "./components/component-preview";
 import {ComponentsCategory} from "./components/components-category";
+import {CopyPrompt} from "./components/copy-prompt";
 import {DocsImage} from "./components/docs-image";
 import {Iconify} from "./components/iconify";
 import {LocaleLink} from "./components/locale-link";
@@ -124,6 +125,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     ComponentGrid,
     ComponentPreview,
     ComponentsCategory,
+    CopyPrompt,
     DocsImage,
     ExampleCount,
     Icon,


### PR DESCRIPTION
## 📝 Description

Documents the new `create-heroui-native-app` CLI v1.0.0 and restructures the HeroUI Native Quick Start into two paths: scaffold a new project or add to an existing app. Adds a `CopyPrompt` MDX component so users can copy an AI setup prompt, and updates the homepage release badge to point at the new release notes.

## ⛳️ Current behavior (updates)

The Native Quick Start only covered manual installation in an existing project, and the homepage release badge promoted HeroUI Native v1.0.4.

## 🚀 New behavior

- Quick Start split into **Option 1** (CLI scaffold) and **Option 2** (manual install for existing apps)
- New release notes page for `create-heroui-native-app` v1.0.0 with CLI reference, templates, and demo video
- New `CopyPrompt` MDX component for one-click AI setup prompt copying
- Homepage release badge and link updated to the new CLI release
- Releases index and navigation updated to include the new release entry

## 💣 Is this a breaking change (Yes/No):

**No** - Documentation-only changes with no API or package behavior changes.

## 📝 Additional Information

Three commits on branch `docs/native-getting-started-cli-upd`. Manual review of the Quick Start page, new release notes page, and homepage badge link is recommended. No new dependencies were added beyond the existing docs stack.