### PR TITLE
fix(styles): inherit font-size from parent instead of forcing text-sm in link

### DIFF
--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -1,6 +1,6 @@
 /* Base link styles */
 .link {
-  @apply relative inline-flex h-fit w-fit items-center rounded-xl text-sm font-medium text-link no-underline decoration-separator-tertiary decoration-[1.5px] underline-offset-4 no-highlight;
+  @apply relative inline-flex h-fit w-fit items-center rounded-xl font-medium text-link no-underline decoration-separator-tertiary decoration-[1.5px] underline-offset-4 no-highlight;
 
   /**
    * Transitions
@@ -54,7 +54,7 @@
   }
 
   .link__icon {
-    @apply pointer-events-none inline-flex size-2 shrink-0 items-center justify-center text-current opacity-60;
+    @apply pointer-events-none inline-flex size-[0.75em] shrink-0 items-center justify-center text-current opacity-60;
 
     /**
      * Transitions


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6600

## 📝 Description

<!--- Add a brief description -->

This pull request makes minor adjustments to the styling of the `.link` component to improve consistency and scalability of its appearance.

- Link text styling: Removed the `text-sm` class from the `.link` base styles, so the link will now inherit font size rather than always being small.
- Icon sizing: Changed the `.link__icon` size from a fixed `size-2` to a relative `size-[0.75em]`, ensuring the icon scales with the surrounding text.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="480" height="207" alt="image" src="https://github.com/user-attachments/assets/4fa3054b-93f1-4617-85c3-26e52fbf1683" />


## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="527" height="210" alt="image" src="https://github.com/user-attachments/assets/27706483-5bec-406a-b29a-ef975f08e24b" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
