### PR TITLE
fix(styles): prevent date-picker calendar popover from being horizontally clipped

### DIFF
--- a/packages/styles/components/date-picker.css
+++ b/packages/styles/components/date-picker.css
@@ -40,7 +40,7 @@
 }
 
 .date-picker__popover {
-  @apply max-w-(--trigger-width) origin-(--trigger-anchor-point) overflow-x-hidden overflow-y-auto overscroll-contain bg-overlay p-3 scrollbar-none;
+  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scrollbar-none overflow-y-auto overscroll-contain bg-overlay p-3;
   @apply motion-reduce:transition-none;
 
   box-shadow: var(--shadow-overlay);

--- a/packages/styles/components/date-range-picker.css
+++ b/packages/styles/components/date-range-picker.css
@@ -44,7 +44,7 @@
 }
 
 .date-range-picker__popover {
-  @apply max-w-(--trigger-width) origin-(--trigger-anchor-point) overflow-x-hidden overflow-y-auto overscroll-contain bg-overlay p-3 scrollbar-none;
+  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scrollbar-none overflow-y-auto overscroll-contain bg-overlay p-3;
   @apply motion-reduce:transition-none;
 
   box-shadow: var(--shadow-overlay);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6605

## 📝 Description

<!--- Add a brief description -->

This pull request updates the styling of the `date-picker` and `date-range-picker` components to improve popover sizing behavior. The main change is switching from a maximum width to a minimum width for popover containers, ensuring that popovers are at least as wide as their trigger elements.

Popover sizing adjustments:

* Changed `@apply max-w-(--trigger-width)` to `@apply min-w-(--trigger-width)` in `.date-picker__popover` in `date-picker.css`, so the popover will not be smaller than the trigger element.
* Made the same change in `.date-range-picker__popover` in `date-range-picker.css` for consistent behavior.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

https://storybook-v3.heroui.com/?path=/story/components-date-and-time-datepicker--with-custom-indicator

<img width="345" height="378" alt="image" src="https://github.com/user-attachments/assets/3d2857ae-520e-4eff-bcd0-22ca43ef006d" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="406" height="400" alt="image" src="https://github.com/user-attachments/assets/1271c859-fa81-44c4-a01d-a4189b94c02f" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
