### PR TITLE
fix: typecheck issues

### DIFF
--- a/apps/docs/src/components/fumadocs/layouts/notebook/client.tsx
+++ b/apps/docs/src/components/fumadocs/layouts/notebook/client.tsx
@@ -98,7 +98,7 @@ export function LayoutBody({children, className, style, ...props}: ComponentProp
         "sidebar sidebar toc-popover toc-popover ."
         "sidebar sidebar main toc ." 1fr / minmax(min-content, 1fr) var(--fd-sidebar-col) minmax(0, ${pageCol}) var(--fd-toc-width) minmax(min-content, 1fr)`,
           ...style,
-        } as object
+        } as React.CSSProperties
       }
       {...props}
     >

--- a/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
@@ -102,6 +102,11 @@ export const ScrollShadowRoot = ({
     [orientation, hideScrollBar, variant],
   );
 
+  const style = {
+    "--scroll-shadow-size": `${size}px`,
+    ...props.style,
+  } as React.CSSProperties;
+
   return (
     <div
       ref={mergeRefs(internalRef, ref)}
@@ -109,11 +114,7 @@ export const ScrollShadowRoot = ({
       data-orientation={orientation}
       data-scroll-shadow-size={size}
       data-slot="scroll-shadow"
-      style={{
-        // @ts-expect-error - CSS variables are not typed
-        "--scroll-shadow-size": `${size}px`,
-        ...props.style,
-      }}
+      style={style}
       {...props}
     >
       {children}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

This pull request makes minor improvements to type safety in the codebase by ensuring that inline style objects are explicitly typed as `React.CSSProperties`. This change helps prevent type errors and improves code clarity.

Type safety improvements:

* Updated the inline style object in `LayoutBody` (in `client.tsx`) to use `React.CSSProperties` instead of a generic object.
* Refactored the style object in `ScrollShadowRoot` (in `scroll-shadow.tsx`) to be explicitly typed as `React.CSSProperties`, replacing the previous workaround.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
