### PR TITLE
fix(styles): correct secondary header borders in virtualized mode

### DIFF
--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -41,12 +41,25 @@
   @apply bg-surface-secondary;
 }
 
-.table-root--secondary .table__column:first-child {
+/* Round only the truly first/last column header.
+   Non-virtualized: column is a <th> child of <tr>.
+   Virtualized: column is wrapped in a `VirtualizerItem` (role="presentation") so
+   `:first-child` / `:last-child` on `.table__column` would match every column
+   (each is the only child of its wrapper). Walk up to the row instead. */
+.table-root--secondary
+  :is(
+    th.table__column:first-child,
+    [role="row"] > [role="presentation"]:first-of-type > .table__column
+  ) {
   border-start-start-radius: min(32px, var(--radius-2xl));
   border-end-start-radius: min(32px, var(--radius-2xl));
 }
 
-.table-root--secondary .table__column:last-child {
+.table-root--secondary
+  :is(
+    th.table__column:last-child,
+    [role="row"] > [role="presentation"]:last-of-type > .table__column
+  ) {
   border-start-end-radius: min(32px, var(--radius-2xl));
   border-end-end-radius: min(32px, var(--radius-2xl));
 }
@@ -111,7 +124,7 @@
   /* Separator between columns — a short vertical line on the right edge */
   &::after {
     content: "";
-    @apply pointer-events-none absolute top-1/2 end-0 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
+    @apply pointer-events-none absolute end-0 top-1/2 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
   }
 
   &:last-child:not(:only-child)::after {
@@ -136,6 +149,13 @@
     @apply rounded-lg outline-none;
     box-shadow: inset 0 0 0 2px var(--focus);
   }
+}
+
+/* Virtualized: each column is wrapped in a `VirtualizerItem` (role="presentation"),
+   so `.table__column:last-child:not(:only-child)::after` above never matches.
+   Hide the trailing separator on the rightmost wrapper instead. */
+[role="row"] > [role="presentation"]:last-of-type:not(:only-of-type) > .table__column::after {
+  content: none;
 }
 
 /* --------------------------------------------------------------------------
@@ -326,7 +346,7 @@
    -------------------------------------------------------------------------- */
 .table__column-resizer {
   /* Match the ::after separator: absolute, right edge, short vertical line */
-  @apply absolute top-1/2 end-0 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
+  @apply absolute end-0 top-1/2 h-4 w-px -translate-y-1/2 rounded-sm bg-separator;
   /* Make it interactive — wider hit area with transparent padding */
   @apply box-content translate-x-1/2 cursor-col-resize touch-none px-2;
   /* Reset appearance */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6602

## 📝 Description

<!--- Add a brief description -->

When a `Table` is wrapped in React Aria's `<Virtualizer>`, every table element is rendered as a `<div>` and each column header is wrapped in a `VirtualizerItem` (`<div role="presentation">`). Because each `.table__column` is then the only child of its wrapper, the existing `:first-child` / `:last-child` selectors matched **every** column - producing two visible regressions in the secondary variant:
- Each column header rendered as its own rounded "pill" card instead of only the leftmost/rightmost column being rounded.
- The trailing vertical separator on the last column was never hidden (`:last-child:not(:only-child)::after` could not match), causing the "padding looks off" appearance in the issue screenshot.

This PR fixes the CSS only — no component/API changes — by mirroring

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="774" height="538" alt="image" src="https://github.com/user-attachments/assets/c942b2f3-1921-47a3-b85b-31e428d4969f" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="740" height="521" alt="image" src="https://github.com/user-attachments/assets/eef6ba88-f265-4b48-956f-ef37dbe2c70a" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
