### PR TITLE
fix(autocomplete): popover focus

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(pickers)/autocomplete.mdx
+++ b/apps/docs/content/docs/cn/react/components/(pickers)/autocomplete.mdx
@@ -221,6 +221,10 @@ function CustomAutocomplete() {
   .autocomplete__popover {
     @apply rounded-lg border border-border bg-surface p-2;
   }
+
+  .autocomplete__popover-dialog {
+    @apply outline-none;
+  }
 }
 ```
 
@@ -238,6 +242,7 @@ Autocomplete 使用以下 CSS 类（[查看源码样式](https://github.com/hero
 - `.autocomplete__clear-button` - 清除已选值的按钮
 - `.autocomplete__indicator` - 下拉指示图标
 - `.autocomplete__popover` - 弹出层容器
+- `.autocomplete__popover-dialog` - 弹出层内部的 dialog 包裹层，用于焦点管理（与 [Popover](/docs/components/popover) 行为一致）
 - `.autocomplete__filter` - 过滤区域包裹层
 
 #### 变体类
@@ -323,7 +328,7 @@ Autocomplete 使用以下 CSS 类（[查看源码样式](https://github.com/hero
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ------------------------------------------------ |
 | `placement` | `"bottom" \| "bottom left" \| "bottom right" \| "bottom start" \| "bottom end" \| "top" \| "top left" \| "top right" \| "top start" \| "top end" \| "left" \| "left top" \| "left bottom" \| "start" \| "start top" \| "start bottom" \| "right" \| "right top" \| "right bottom" \| "end" \| "end top" \| "end bottom"` | `"bottom"` | 弹出层相对触发器的位置 |
 | `className` | `string`                                                                                                                                                                                                                                                                                                                 | -          | 额外的 CSS 类 |
-| `children`  | `ReactNode`                                                                                                                                                                                                                                                                                                              | -          | 子内容 |
+| `children`  | `ReactNode`                                                                                                                                                                                                                                                                                                              | -          | 子内容。内部会包裹在 dialog 元素中以管理焦点，样式类为 `.autocomplete__popover-dialog`。 |
 
 ### Autocomplete.Filter Props
 
@@ -380,9 +385,11 @@ Autocomplete 实现带过滤的 ARIA 选择模式，并提供：
 
 - 完整键盘导航支持
 - 选择变化时的屏幕阅读器播报
-- 合理的焦点管理
+- 与 [Popover](/docs/components/popover) 一致的焦点管理：`Autocomplete.Popover` 会在内部用 dialog 包裹内容，避免触摸交互时在弹出层 overlay 上出现多余的焦点环
 - 禁用状态支持
 - 可搜索与过滤
 - HTML 表单集成
+
+若希望在弹出层打开时不立即唤起移动端键盘，可在 `SearchField` 上设置 `autoFocus={false}`。用户聚焦搜索输入框后仍可正常过滤。
 
 更多信息见 [React Aria Select 文档](https://react-spectrum.adobe.com/react-aria/Select.html)。

--- a/apps/docs/content/docs/en/react/components/(pickers)/autocomplete.mdx
+++ b/apps/docs/content/docs/en/react/components/(pickers)/autocomplete.mdx
@@ -221,6 +221,10 @@ To customize the Autocomplete component classes, you can use the `@layer compone
   .autocomplete__popover {
     @apply rounded-lg border border-border bg-surface p-2;
   }
+
+  .autocomplete__popover-dialog {
+    @apply outline-none;
+  }
 }
 ```
 
@@ -238,6 +242,7 @@ The Autocomplete component uses these CSS classes ([View source styles](https://
 - `.autocomplete__clear-button` - The clear button that removes the selected value
 - `.autocomplete__indicator` - The dropdown indicator icon
 - `.autocomplete__popover` - The popover container
+- `.autocomplete__popover-dialog` - Internal dialog wrapper inside the popover for focus management (matches [Popover](/docs/components/popover) behavior)
 - `.autocomplete__filter` - The filter wrapper
 
 #### Variant Classes
@@ -323,7 +328,7 @@ The component supports both CSS pseudo-classes and data attributes for flexibili
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ------------------------------------------------ |
 | `placement` | `"bottom" \| "bottom left" \| "bottom right" \| "bottom start" \| "bottom end" \| "top" \| "top left" \| "top right" \| "top start" \| "top end" \| "left" \| "left top" \| "left bottom" \| "start" \| "start top" \| "start bottom" \| "right" \| "right top" \| "right bottom" \| "end" \| "end top" \| "end bottom"` | `"bottom"` | Placement of the popover relative to the trigger |
 | `className` | `string`                                                                                                                                                                                                                                                                                                                 | -          | Additional CSS classes                           |
-| `children`  | `ReactNode`                                                                                                                                                                                                                                                                                                              | -          | Content children                                 |
+| `children`  | `ReactNode`                                                                                                                                                                                                                                                                                                              | -          | Content children. Wrapped internally in a dialog element for focus management, styled with `.autocomplete__popover-dialog`. |
 
 ### Autocomplete.Filter Props
 
@@ -380,9 +385,11 @@ The Autocomplete component implements the ARIA select pattern with filtering and
 
 - Full keyboard navigation support
 - Screen reader announcements for selection changes
-- Proper focus management
+- Focus management aligned with [Popover](/docs/components/popover): `Autocomplete.Popover` wraps its content in an internal dialog so touch interactions do not show a stray focus ring on the popover overlay
 - Support for disabled states
 - Search functionality with filtering
 - HTML form integration
+
+Use `autoFocus={false}` on `SearchField` when you want to avoid opening the mobile keyboard as soon as the popover appears. Filtering still works once the user focuses the search input.
 
 For more information, see the [React Aria Select documentation](https://react-spectrum.adobe.com/react-aria/Select.html).

--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -11,6 +11,7 @@ import {mergeRefs, useResizeObserver} from "@react-aria/utils";
 import React, {createContext, useCallback, useContext, useRef, useState} from "react";
 import {Autocomplete as AutocompletePrimitive} from "react-aria-components/Autocomplete";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
+import {Dialog as DialogPrimitive} from "react-aria-components/Dialog";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
 import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
 import {
@@ -248,7 +249,9 @@ const AutocompletePopover = ({
           } as React.CSSProperties
         }
       >
-        {children}
+        <DialogPrimitive className={slots?.popoverDialog()} data-slot="autocomplete-popover-dialog">
+          {children}
+        </DialogPrimitive>
       </PopoverPrimitive>
     </SurfaceContext>
   );

--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -130,7 +130,7 @@
 
 /* Similar to popover content styles */
 .autocomplete__popover {
-  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain bg-overlay p-0 pt-2 text-sm scrollbar;
+  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 scrollbar overflow-y-auto overscroll-contain bg-overlay p-0 pt-2 text-sm;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 
@@ -215,6 +215,17 @@
   /* Empty State */
   [data-slot="empty-state"] {
     @apply text-center text-sm text-overlay-foreground/60;
+  }
+}
+
+/* Popover dialog — mirrors Popover.Dialog focus management without a visible focus ring */
+.autocomplete__popover-dialog {
+  @apply outline-none;
+
+  &:focus,
+  &:focus-visible,
+  &[data-focus-visible="true"] {
+    @apply outline-none;
   }
 }
 

--- a/packages/styles/src/components/autocomplete/autocomplete.styles.ts
+++ b/packages/styles/src/components/autocomplete/autocomplete.styles.ts
@@ -13,6 +13,7 @@ export const autocompleteVariants = tv({
     filter: "autocomplete__filter",
     indicator: "autocomplete__indicator",
     popover: "autocomplete__popover",
+    popoverDialog: "autocomplete__popover-dialog",
     trigger: "autocomplete__trigger",
     value: "autocomplete__value",
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported by power user.

- Wraps `Autocomplete.Popover` content in a React Aria `Dialog`, mirroring how `Popover.Dialog` works for the regular `Popover` component. This stabilizes focus management so the popover overlay never receives a stray browser focus ring.
- Adds a new `popoverDialog` slot (`autocomplete__popover-dialog`) and moves the outline reset into `autocomplete.css` to keep styling in the CSS layer where the rest of HeroUI lives.
- Updates the EN/CN docs to document the new slot and the dialog-based focus management.


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="313" height="396" alt="image" src="https://github.com/user-attachments/assets/29f0e687-3a94-450b-8a50-6893afcd7f08" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="348" height="395" alt="image" src="https://github.com/user-attachments/assets/b8455ea1-c950-4d2e-b243-416d893d35a5" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
