### PR TITLE
fix(tooltip): avoid Focusable warning when mounted inside inert subtree

### DIFF
--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -5,8 +5,9 @@ import type {TooltipVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {tooltipVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
-import {Focusable as FocusablePrimitive} from "react-aria-components/Focusable";
+import {mergeProps} from "@react-aria/utils";
+import React, {createContext, useContext, useRef} from "react";
+import {useFocusable} from "react-aria/useFocusable";
 import {
   OverlayArrow,
   Tooltip as TooltipPrimitive,
@@ -146,18 +147,27 @@ const TooltipTrigger = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...props
 }: TooltipTriggerProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof TooltipTriggerProps<E>>) => {
   const {slots} = useContext(TooltipContext);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  // Use the `useFocusable` hook directly rather than the `<Focusable>` wrapper component.
+  // Both consume the FocusableContext provided by TooltipTriggerPrimitive's internal
+  // <FocusableProvider> (which carries the tooltip trigger props + triggerRef) and produce
+  // the same `focusableProps` (tabIndex, focus, keyboard handlers). However, the wrapper
+  // component runs a dev-only `isFocusable(el)` assertion in a useEffect that walks the
+  // ancestor chain for `inert`. When the Tooltip mounts inside an inert subtree (e.g. behind
+  // an open Drawer/Modal), that check produces a false-positive warning:
+  // "<Focusable> child must be focusable. Please ensure the tabIndex prop is passed through."
+  const {focusableProps} = useFocusable({}, triggerRef as React.RefObject<HTMLElement>);
 
   return (
-    <FocusablePrimitive>
-      <dom.div
-        className={composeSlotClassName(slots?.trigger, className)}
-        data-slot="tooltip-trigger"
-        role="button"
-        {...(props as any)}
-      >
-        {children}
-      </dom.div>
-    </FocusablePrimitive>
+    <dom.div
+      ref={triggerRef as unknown as React.Ref<HTMLDivElement>}
+      className={composeSlotClassName(slots?.trigger, className)}
+      data-slot="tooltip-trigger"
+      role="button"
+      {...mergeProps(focusableProps, props as any)}
+    >
+      {children}
+    </dom.div>
   );
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6494

## 📝 Description

<!--- Add a brief description -->

When `Tooltip` mounts (e.g. via `useEffect`, Suspense, or a route transition) **after** a `Drawer`/`Modal` is already open, React Aria logs:

> `<Focusable> child must be focusable. Please ensure the tabIndex prop is passed through.`

The trigger is actually focusable (`role="button"`, `tabIndex="0"`); the warning fires because React Aria's `<Focusable>` runs a dev-only `useEffect` that calls `isFocusable(el)`, which walks ancestors checking `node.inert` and returns `false` because the overlay has marked the rest of the page inert.

The fix here is `Tooltip.Trigger` now calls `useFocusable({}, triggerRef)` and merges its props onto the existing `dom.div`, instead of wrapping the div in `<Focusable>`. No runtime behavior changes, the dev warning is eliminated.

---

Reproducible Code:

```tsx
const DelayedInsideInertTemplate = () => {
  const [showTooltip, setShowTooltip] = React.useState(false);
  const [isOpen, setIsOpen] = React.useState(true);

  React.useEffect(() => {
    setShowTooltip(true);
  }, []);

  return (
    <div className="flex flex-col items-start gap-4 p-8">
      <Button onPress={() => setIsOpen(true)}>Reopen drawer</Button>
      {showTooltip ? (
        <Tooltip delay={0}>
          <Tooltip.Trigger aria-label="Tooltip trigger">
            <div className="rounded-full bg-accent-soft p-2">
              <Icon icon="gravity-ui:circle-info" />
            </div>
          </Tooltip.Trigger>
          <Tooltip.Content>
            <Tooltip.Arrow />
            <p>Tooltip content</p>
          </Tooltip.Content>
        </Tooltip>
      ) : null}
      <Drawer.Backdrop isOpen={isOpen} onOpenChange={setIsOpen}>
        <Drawer.Content placement="right">
          <Drawer.Dialog>
            <Drawer.Header>
              <Drawer.Heading>Drawer Title</Drawer.Heading>
            </Drawer.Header>
            <Drawer.Body>
              <p>
                The Tooltip behind this drawer mounts while the rest of the page is inert.
                Close the drawer and hover the chip to confirm the tooltip still works, and
                check the console for the absence of the React Aria Focusable warning.
              </p>
            </Drawer.Body>
            <Drawer.Footer>
              <Button slot="close" variant="secondary">
                Cancel
              </Button>
              <Button slot="close">Confirm</Button>
            </Drawer.Footer>
          </Drawer.Dialog>
        </Drawer.Content>
      </Drawer.Backdrop>
    </div>
  );
};
```

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="658" height="62" alt="image" src="https://github.com/user-attachments/assets/899ffba9-9d3f-4b97-80dc-8bc95ebc2233" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

No such warning

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
