### PR TITLE
fix(styles): prevent flex-shrink from collapsing virtualized ListBox scroll height

### DIFF
--- a/packages/styles/components/list-box.css
+++ b/packages/styles/components/list-box.css
@@ -3,7 +3,20 @@
    ========================================================================== */
 
 .list-box {
-  @apply relative flex w-full flex-col gap-1 overflow-clip p-1;
+  @apply relative w-full overflow-clip p-1;
+
+  /**
+   * Spacing between direct children.
+   *
+   * NOTE: We intentionally avoid `display: flex` + `gap` here because
+   * react-aria's Virtualizer renders a `position: relative` content
+   * div with an explicit large height (e.g. 50000px) as the only child
+   * of the ListBox. Flex shrinking would collapse that height and break
+   * scrollbar sizing during virtualized scroll.
+   */
+  & > * + * {
+    @apply mt-1;
+  }
 
   /* This makes the horizontal separator take up 94% of the width and be centered */
   [data-slot="separator"][data-orientation="horizontal"] {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported in [discord](https://discord.com/channels/856545348885676062/1514230221425873057).

- Fixes the scrollbar thumb visibly resizing while scrolling the virtualized ListBox [demo](https://storybook-v3.heroui.com/?path=/story/components-collections-listbox--virtualization).
- Root cause: `.list-box` applied `display: flex; flex-direction: column; gap: 0.25rem`. With `<Virtualizer>`, react-aria renders a single `position: relative` content div with an inline `height: 50000px`. Because that div became a flex item with the default `flex-shrink: 1`, the browser collapsed it down to ~392px, so `scrollHeight` was determined by whichever absolutely-positioned items happened to be mounted. As more items mounted during scroll, `scrollHeight` grew (650 → 50,000+), making the scrollbar thumb shrink — which is exactly what React Aria's own example does not do.
- Fix: replace `flex flex-col gap-1` on `.list-box` with normal block flow plus `& > * + * { @apply mt-1 }`. Non-virtualized ListBoxes keep their inter-item spacing (multiple direct children get the margin), while the virtualized case has only one direct child (the inner virtualizer div), so the selector gracefully no-ops and the inline `height: 50000px` is honored.


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

[pr6636-before.webm](https://github.com/user-attachments/assets/4a271c2a-fff4-44ba-845b-3008a03f6e5b)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr6636-after.webm](https://github.com/user-attachments/assets/3223615c-7bae-4932-ba9b-e3d0c595a0bb)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
