### PR TITLE
fix(styles): constrain popover size for virtualized ListBox

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(pickers)/autocomplete.mdx
+++ b/apps/docs/content/docs/cn/react/components/(pickers)/autocomplete.mdx
@@ -125,6 +125,12 @@ Autocomplete 支持两种视觉变体：
 
 <ComponentPreview name="autocomplete-asynchronous-filtering" />
 
+### 虚拟化
+
+Autocomplete 通过 [Virtualizer](https://react-aria.adobe.com/Virtualizer) 支持虚拟化，仅渲染视口内可见的行，从而高效展示大数据集。
+
+<ComponentPreview name="autocomplete-virtualization" />
+
 ### 禁用
 
 <ComponentPreview name="autocomplete-disabled" />

--- a/apps/docs/content/docs/en/react/components/(pickers)/autocomplete.mdx
+++ b/apps/docs/content/docs/en/react/components/(pickers)/autocomplete.mdx
@@ -125,6 +125,12 @@ You can customize the displayed value using render props:
 
 <ComponentPreview name="autocomplete-asynchronous-filtering" />
 
+### Virtualization
+
+Autocomplete supports virtualization through [Virtualizer](https://react-aria.adobe.com/Virtualizer), enabling efficient rendering of large datasets by displaying only the rows visible within the viewport.
+
+<ComponentPreview name="autocomplete-virtualization" />
+
 ### Disabled
 
 <ComponentPreview name="autocomplete-disabled" />

--- a/apps/docs/src/demos/cn/autocomplete/index.ts
+++ b/apps/docs/src/demos/cn/autocomplete/index.ts
@@ -16,6 +16,7 @@ export {TagGroupSelection} from "./tag-group-selection";
 export {UserSelection} from "./user-selection";
 export {UserSelectionMultiple} from "./user-selection-multiple";
 export {Variants} from "./variants";
+export {Virtualization} from "./virtualization";
 export {WithDescription} from "./with-description";
 export {WithDisabledOptions} from "./with-disabled-options";
 export {WithSections} from "./with-sections";

--- a/apps/docs/src/demos/cn/autocomplete/virtualization.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/virtualization.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type {Key} from "@heroui/react";
+
+import {
+  Autocomplete,
+  Description,
+  EmptyState,
+  Label,
+  ListBox,
+  ListLayout,
+  SearchField,
+  Virtualizer,
+  useFilter,
+} from "@heroui/react";
+import {useMemo, useState} from "react";
+
+interface User {
+  email: string;
+  id: number;
+  name: string;
+}
+
+function generateUsers(n: number): User[] {
+  const firstNames = [
+    "Emma",
+    "Liam",
+    "Olivia",
+    "Noah",
+    "Ava",
+    "James",
+    "Sophia",
+    "Oliver",
+    "Isabella",
+    "Lucas",
+    "Mia",
+    "Ethan",
+    "Charlotte",
+    "Mason",
+    "Amelia",
+    "Logan",
+    "Harper",
+    "Alexander",
+    "Ella",
+    "Benjamin",
+  ];
+  const lastNames = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Anderson",
+    "Taylor",
+    "Thomas",
+    "Jackson",
+    "White",
+    "Harris",
+    "Clark",
+    "Lewis",
+    "Robinson",
+    "Walker",
+  ];
+  const users: User[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const firstName = firstNames[i % firstNames.length]!;
+    const lastName = lastNames[Math.floor(i / firstNames.length) % lastNames.length]!;
+    const name = `${firstName} ${lastName}`;
+
+    users.push({
+      email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@acme.com`,
+      id: i + 1,
+      name,
+    });
+  }
+
+  return users;
+}
+
+export function Virtualization() {
+  const [selectedKey, setSelectedKey] = useState<Key | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const {contains} = useFilter({sensitivity: "base"});
+
+  const allUsers = useMemo(() => generateUsers(1000), []);
+
+  const filteredUsers = useMemo(() => {
+    if (!searchQuery) return allUsers;
+
+    return allUsers.filter(
+      (user) => contains(user.name, searchQuery) || contains(user.email, searchQuery),
+    );
+  }, [allUsers, contains, searchQuery]);
+
+  return (
+    <Autocomplete
+      allowsEmptyCollection
+      className="w-[300px]"
+      placeholder="选择用户"
+      selectionMode="single"
+      value={selectedKey}
+      onChange={setSelectedKey}
+    >
+      <Label>用户</Label>
+      <Autocomplete.Trigger>
+        <Autocomplete.Value />
+        <Autocomplete.ClearButton />
+        <Autocomplete.Indicator />
+      </Autocomplete.Trigger>
+      <Autocomplete.Popover>
+        <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
+          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+            <SearchField.Group>
+              <SearchField.SearchIcon />
+              <SearchField.Input placeholder="搜索用户…" />
+              <SearchField.ClearButton />
+            </SearchField.Group>
+          </SearchField>
+          <Virtualizer layout={ListLayout} layoutOptions={{rowHeight: 50}}>
+            <ListBox
+              items={filteredUsers}
+              renderEmptyState={() => <EmptyState>未找到结果</EmptyState>}
+            >
+              {(user) => (
+                <ListBox.Item id={user.id} textValue={user.name}>
+                  <div className="flex flex-col">
+                    <Label>{user.name}</Label>
+                    <Description>{user.email}</Description>
+                  </div>
+                  <ListBox.ItemIndicator />
+                </ListBox.Item>
+              )}
+            </ListBox>
+          </Virtualizer>
+        </Autocomplete.Filter>
+      </Autocomplete.Popover>
+    </Autocomplete>
+  );
+}

--- a/apps/docs/src/demos/cn/index.ts
+++ b/apps/docs/src/demos/cn/index.ts
@@ -922,6 +922,10 @@ export const demos: Record<string, DemoItem> = {
     component: AutocompleteDemos.AsynchronousFiltering,
     file: "cn/autocomplete/asynchronous-filtering.tsx",
   },
+  "autocomplete-virtualization": {
+    component: AutocompleteDemos.Virtualization,
+    file: "cn/autocomplete/virtualization.tsx",
+  },
   "autocomplete-disabled": {
     component: AutocompleteDemos.Disabled,
     file: "cn/autocomplete/disabled.tsx",

--- a/apps/docs/src/demos/en/autocomplete/index.ts
+++ b/apps/docs/src/demos/en/autocomplete/index.ts
@@ -16,6 +16,7 @@ export {TagGroupSelection} from "./tag-group-selection";
 export {UserSelection} from "./user-selection";
 export {UserSelectionMultiple} from "./user-selection-multiple";
 export {Variants} from "./variants";
+export {Virtualization} from "./virtualization";
 export {WithDescription} from "./with-description";
 export {WithDisabledOptions} from "./with-disabled-options";
 export {WithSections} from "./with-sections";

--- a/apps/docs/src/demos/en/autocomplete/virtualization.tsx
+++ b/apps/docs/src/demos/en/autocomplete/virtualization.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type {Key} from "@heroui/react";
+
+import {
+  Autocomplete,
+  Description,
+  EmptyState,
+  Label,
+  ListBox,
+  ListLayout,
+  SearchField,
+  Virtualizer,
+  useFilter,
+} from "@heroui/react";
+import {useMemo, useState} from "react";
+
+interface User {
+  email: string;
+  id: number;
+  name: string;
+}
+
+function generateUsers(n: number): User[] {
+  const firstNames = [
+    "Emma",
+    "Liam",
+    "Olivia",
+    "Noah",
+    "Ava",
+    "James",
+    "Sophia",
+    "Oliver",
+    "Isabella",
+    "Lucas",
+    "Mia",
+    "Ethan",
+    "Charlotte",
+    "Mason",
+    "Amelia",
+    "Logan",
+    "Harper",
+    "Alexander",
+    "Ella",
+    "Benjamin",
+  ];
+  const lastNames = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Anderson",
+    "Taylor",
+    "Thomas",
+    "Jackson",
+    "White",
+    "Harris",
+    "Clark",
+    "Lewis",
+    "Robinson",
+    "Walker",
+  ];
+  const users: User[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const firstName = firstNames[i % firstNames.length]!;
+    const lastName = lastNames[Math.floor(i / firstNames.length) % lastNames.length]!;
+    const name = `${firstName} ${lastName}`;
+
+    users.push({
+      email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@acme.com`,
+      id: i + 1,
+      name,
+    });
+  }
+
+  return users;
+}
+
+export function Virtualization() {
+  const [selectedKey, setSelectedKey] = useState<Key | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const {contains} = useFilter({sensitivity: "base"});
+
+  const allUsers = useMemo(() => generateUsers(1000), []);
+
+  const filteredUsers = useMemo(() => {
+    if (!searchQuery) return allUsers;
+
+    return allUsers.filter(
+      (user) => contains(user.name, searchQuery) || contains(user.email, searchQuery),
+    );
+  }, [allUsers, contains, searchQuery]);
+
+  return (
+    <Autocomplete
+      allowsEmptyCollection
+      className="w-[300px]"
+      placeholder="Select a user"
+      selectionMode="single"
+      value={selectedKey}
+      onChange={setSelectedKey}
+    >
+      <Label>User</Label>
+      <Autocomplete.Trigger>
+        <Autocomplete.Value />
+        <Autocomplete.ClearButton />
+        <Autocomplete.Indicator />
+      </Autocomplete.Trigger>
+      <Autocomplete.Popover>
+        <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
+          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+            <SearchField.Group>
+              <SearchField.SearchIcon />
+              <SearchField.Input placeholder="Search users..." />
+              <SearchField.ClearButton />
+            </SearchField.Group>
+          </SearchField>
+          <Virtualizer layout={ListLayout} layoutOptions={{rowHeight: 50}}>
+            <ListBox
+              items={filteredUsers}
+              renderEmptyState={() => <EmptyState>No results found</EmptyState>}
+            >
+              {(user) => (
+                <ListBox.Item id={user.id} textValue={user.name}>
+                  <div className="flex flex-col">
+                    <Label>{user.name}</Label>
+                    <Description>{user.email}</Description>
+                  </div>
+                  <ListBox.ItemIndicator />
+                </ListBox.Item>
+              )}
+            </ListBox>
+          </Virtualizer>
+        </Autocomplete.Filter>
+      </Autocomplete.Popover>
+    </Autocomplete>
+  );
+}

--- a/apps/docs/src/demos/en/index.ts
+++ b/apps/docs/src/demos/en/index.ts
@@ -916,6 +916,10 @@ export const demos: Record<string, DemoItem> = {
     component: AutocompleteDemos.AsynchronousFiltering,
     file: "en/autocomplete/asynchronous-filtering.tsx",
   },
+  "autocomplete-virtualization": {
+    component: AutocompleteDemos.Virtualization,
+    file: "en/autocomplete/virtualization.tsx",
+  },
   "autocomplete-disabled": {
     component: AutocompleteDemos.Disabled,
     file: "en/autocomplete/disabled.tsx",

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -5,6 +5,7 @@ import {Icon} from "@iconify/react";
 import {useAsyncList} from "@react-stately/data";
 import React, {useState} from "react";
 import {useFilter} from "react-aria-components/Autocomplete";
+import {ListLayout, Virtualizer} from "react-aria-components/Virtualizer";
 import {cn} from "tailwind-variants";
 
 import {Avatar, AvatarFallback, AvatarImage} from "../avatar";
@@ -1137,6 +1138,137 @@ export const AsynchronousFiltering: Story = {
                 </ListBox.Item>
               )}
             </ListBox>
+          </Autocomplete.Filter>
+        </Autocomplete.Popover>
+      </Autocomplete>
+    );
+  },
+};
+
+interface User {
+  email: string;
+  id: number;
+  name: string;
+}
+
+function generateUsers(n: number): User[] {
+  const firstNames = [
+    "Emma",
+    "Liam",
+    "Olivia",
+    "Noah",
+    "Ava",
+    "James",
+    "Sophia",
+    "Oliver",
+    "Isabella",
+    "Lucas",
+    "Mia",
+    "Ethan",
+    "Charlotte",
+    "Mason",
+    "Amelia",
+    "Logan",
+    "Harper",
+    "Alexander",
+    "Ella",
+    "Benjamin",
+  ];
+  const lastNames = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+    "Anderson",
+    "Taylor",
+    "Thomas",
+    "Jackson",
+    "White",
+    "Harris",
+    "Clark",
+    "Lewis",
+    "Robinson",
+    "Walker",
+  ];
+  const users: User[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const firstName = firstNames[i % firstNames.length]!;
+    const lastName = lastNames[Math.floor(i / firstNames.length) % lastNames.length]!;
+    const name = `${firstName} ${lastName}`;
+
+    users.push({
+      email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@acme.com`,
+      id: i + 1,
+      name,
+    });
+  }
+
+  return users;
+}
+
+export const Virtualization: Story = {
+  render: () => {
+    const [selectedKey, setSelectedKey] = useState<Key | null>(null);
+    const [searchQuery, setSearchQuery] = useState("");
+    const {contains} = useFilter({sensitivity: "base"});
+
+    const allUsers = React.useMemo(() => generateUsers(1000), []);
+
+    const filteredUsers = React.useMemo(() => {
+      if (!searchQuery) return allUsers;
+
+      return allUsers.filter(
+        (user) => contains(user.name, searchQuery) || contains(user.email, searchQuery),
+      );
+    }, [allUsers, contains, searchQuery]);
+
+    return (
+      <Autocomplete
+        allowsEmptyCollection
+        className="w-[300px]"
+        placeholder="Select a user"
+        selectionMode="single"
+        value={selectedKey}
+        onChange={setSelectedKey}
+      >
+        <Label>User</Label>
+        <Autocomplete.Trigger>
+          <Autocomplete.Value />
+          <Autocomplete.ClearButton />
+          <Autocomplete.Indicator />
+        </Autocomplete.Trigger>
+        <Autocomplete.Popover>
+          <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
+            <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+              <SearchField.Group>
+                <SearchField.SearchIcon />
+                <SearchField.Input placeholder="Search users..." />
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
+            <Virtualizer layout={ListLayout} layoutOptions={{rowHeight: 50}}>
+              <ListBox
+                items={filteredUsers}
+                renderEmptyState={() => <EmptyState>No results found</EmptyState>}
+              >
+                {(user) => (
+                  <ListBox.Item id={user.id} textValue={user.name}>
+                    <div className="flex flex-col">
+                      <Label>{user.name}</Label>
+                      <Description>{user.email}</Description>
+                    </div>
+                    <ListBox.ItemIndicator />
+                  </ListBox.Item>
+                )}
+              </ListBox>
+            </Virtualizer>
           </Autocomplete.Filter>
         </Autocomplete.Popover>
       </Autocomplete>

--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -130,7 +130,7 @@
 
 /* Similar to popover content styles */
 .autocomplete__popover {
-  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain bg-overlay p-0 pt-2 text-sm scrollbar;
+  @apply w-(--trigger-width) max-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 overflow-hidden overscroll-contain bg-overlay p-0 pt-2 text-sm;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 
@@ -192,7 +192,7 @@
 
   /* Listbox styles */
   [data-slot="list-box"] {
-    @apply p-1.5 outline-none;
+    @apply max-h-[320px] scrollbar overflow-y-auto p-1.5 outline-none;
   }
 
   [data-slot="list-box-item"] {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6637

## 📝 Description

<!--- Add a brief description -->

- Lock the popover to trigger width and cap listbox height so Virtualizer no longer expands the overlay. Move scrolling from the popover to the listbox to keep the search field fixed above the list.
- Add Virtualization example in autocomplete docs & storybook

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="609" height="409" alt="image" src="https://github.com/user-attachments/assets/19db42ff-f81b-43ab-9f8d-880db7381e59" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="396" height="492" alt="image" src="https://github.com/user-attachments/assets/b6854aaa-fb8c-45ad-b37b-74bfe17a7abc" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
