### PR TITLE
fix(spinner): restore animation in non-flex layouts

### DIFF
--- a/packages/styles/components/spinner.css
+++ b/packages/styles/components/spinner.css
@@ -1,6 +1,6 @@
 /* Base spinner styles */
 .spinner {
-  @apply pointer-events-none relative size-6 origin-center animate-spin-fast;
+  @apply pointer-events-none inline-flex size-6 shrink-0 animate-spin-fast motion-reduce:animate-none;
 }
 
 /* Size variants */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6460

## 📝 Description

<!--- Add a brief description -->

- `Spinner` did not rotate when used in a plain block container (e.g. `<div><Spinner /></div>`)
- Root cause: `.spinner` is applied to a `<span>` (`display: inline`), so `size-*` and `animate-spin-fast` (`transform`) had no effect; flex layouts masked this because flex items are blockified
- Update base `.spinner` styles to use `inline-flex shrink-0` so dimensions and rotation apply in all layouts
- Add `motion-reduce:animate-none` for reduced-motion accessibility, consistent with `progress-circle` and other animated components

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Spinner will not be shown.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr6644.webm](https://github.com/user-attachments/assets/be39ac40-2e10-47ff-aaa1-7cc7d18a45a7)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
