### PR TITLE
feat(theme): add opt-in shadowDOM flag for ShadowDOM-aware theming (f…

### DIFF
--- a/.changeset/shadow-dom-theming.md
+++ b/.changeset/shadow-dom-theming.md
@@ -1,0 +1,5 @@
+---
+"@heroui/theme": minor
+---
+
+Add an opt-in `shadowDOM` flag to the `heroui()` plugin. When enabled, theme variables are also scoped to `:host(...)` selectors and the derived `--color-*` vars are re-declared under every theme selector (`.dark`, `[data-theme='dark']`, `:host(.dark)`, `:host([data-theme='dark'])`), so dark mode works when the generated CSS is adopted into a ShadowRoot. Off by default — no change to existing output.

--- a/apps/docs/content/docs/customization/theme.mdx
+++ b/apps/docs/content/docs/customization/theme.mdx
@@ -86,6 +86,7 @@ module.exports = {
       addCommonColors: false, // override common colors (e.g. "blue", "green", "pink").
       defaultTheme: "light", // default theme from the themes object
       defaultExtendTheme: "light", // default theme to extend on custom themes
+      shadowDOM: false, // also scope theme variables to `:host(...)` for ShadowDOM usage
       layout: {}, // common layout tokens (applied to all themes)
       themes: {
         light: {
@@ -171,6 +172,7 @@ with themes in HeroUI:
 | addCommonColors    | `boolean`                     | If true, the common heroui colors (e.g. "blue", "green", "purple") will replace the TailwindCSS default colors. | `false`  |
 | defaultTheme       | `light` \| `dark`             | The default theme to use.                                                                                       | `light`  |
 | defaultExtendTheme | `light` \| `dark`             | The default theme to extend.                                                                                    | `light`  |
+| shadowDOM          | `boolean`                     | If true, theme variables are also scoped to `:host(...)` selectors and the derived `--color-*` vars are re-declared under every theme selector, so theming works when the CSS is adopted into a ShadowRoot. | `false`  |
 | layout             | [LayoutTheme](#layouttheme)   | The layout definitions.                                                                                         | -        |
 | themes             | [ConfigThemes](#configthemes) | The theme definitions.                                                                                          | -        |
 

--- a/packages/core/theme/src/plugin.ts
+++ b/packages/core/theme/src/plugin.ts
@@ -140,11 +140,25 @@ const corePlugin = (
   defaultTheme: DefaultThemeType,
   prefix: string,
   addCommonColors: boolean,
+  shadowDOM: boolean,
 ) => {
   const resolved = resolveConfig(themes, defaultTheme, prefix);
 
   const createStripeGradient = (stripeColor: string, backgroundColor: string) =>
     `linear-gradient(45deg,  hsl(var(--${prefix}-${stripeColor})) 25%,  hsl(var(--${prefix}-${backgroundColor})) 25%,  hsl(var(--${prefix}-${backgroundColor})) 50%,  hsl(var(--${prefix}-${stripeColor})) 50%,  hsl(var(--${prefix}-${stripeColor})) 75%,  hsl(var(--${prefix}-${backgroundColor})) 75%,  hsl(var(--${prefix}-${backgroundColor})))`;
+
+  /**
+   * Re-declare the Tailwind derived `--color-*` vars as `hsl(var(--{prefix}-*))`
+   * so they re-resolve in whatever scope they are emitted into. This is what
+   * lets a `.dark` toggle on an inner element inside a ShadowRoot actually
+   * change the colors components read (see `issues/shadow.md`).
+   */
+  const deriveColorVars = () =>
+    Object.keys(resolved?.colors ?? {}).reduce<Record<string, string>>((acc, colorName) => {
+      acc[`--color-${colorName}`] = `hsl(var(--${prefix}-${colorName}))`;
+
+      return acc;
+    }, {});
 
   return plugin(
     ({addBase, addUtilities, addVariant}) => {
@@ -160,10 +174,55 @@ const corePlugin = (
 
       // add the css variables to "@layer utilities"
       addUtilities({...resolved?.utilities, ...utilities});
-      // add the theme as variant e.g. "[theme-name]:text-2xl"
+      // add the theme as variant e.g. "[theme-name]:text-2xl". When shadowDOM is
+      // enabled, also match when the host element carries the theme class so
+      // `dark:`-style utilities work inside a ShadowRoot.
       resolved?.variants.forEach((variant) => {
-        addVariant(variant.name, variant.definition);
+        addVariant(
+          variant.name,
+          shadowDOM
+            ? [
+                ...variant.definition,
+                `:host(.${variant.name}) &`,
+                `:host([data-theme='${variant.name}']) &`,
+              ]
+            : variant.definition,
+        );
       });
+
+      // ShadowDOM support (opt-in): additionally scope every theme to `:host(...)`
+      // selectors and re-declare the derived `--color-*` vars under all theme
+      // selectors, so theming works when the CSS is adopted into a ShadowRoot.
+      if (shadowDOM) {
+        const colorVars = deriveColorVars();
+
+        // mirror the base color/background onto the shadow host
+        addBase({[":host"]: {...baseStyles(prefix)}});
+
+        // default (light) theme: mirror base color-scheme/vars onto :host
+        Object.entries(resolved?.baseStyles ?? {}).forEach(([baseSelector, styles]) => {
+          // baseSelector looks like ":root, [data-theme=light]"
+          const themeName = baseSelector.match(/\[data-theme=(.+?)\]/)?.[1];
+          const hostSelector = themeName ? `:host, :host([data-theme=${themeName}])` : ":host";
+
+          addBase({[hostSelector]: {...styles, ...colorVars}});
+        });
+
+        // every theme (`.light`, `.dark`, custom): re-emit `--heroui-*` source
+        // vars + derived `--color-*` vars under the full selector set so the
+        // class can live on the host OR on an inner wrapper inside the shadow.
+        Object.entries(resolved?.utilities ?? {}).forEach(([cssSelector, styles]) => {
+          const themeName = cssSelector.replace(/^\./, "");
+          const combinedSelector = [
+            `.${themeName}`,
+            `[data-theme='${themeName}']`,
+            `:host(.${themeName})`,
+            `:host([data-theme='${themeName}'])`,
+          ].join(", ");
+
+          addUtilities({[combinedSelector]: {...styles, ...colorVars}});
+        });
+      }
     },
     // extend the colors config
     {
@@ -241,6 +300,7 @@ export const heroui = (config: HeroUIPluginConfig = {}): ReturnType<typeof plugi
     defaultExtendTheme = "light",
     prefix: defaultPrefix = DEFAULT_PREFIX,
     addCommonColors = false,
+    shadowDOM = false,
   } = config;
 
   const userLightColors = themeObject?.light?.colors || {};
@@ -295,5 +355,5 @@ export const heroui = (config: HeroUIPluginConfig = {}): ReturnType<typeof plugi
     ...otherThemes,
   };
 
-  return corePlugin(themes, defaultTheme, defaultPrefix, addCommonColors);
+  return corePlugin(themes, defaultTheme, defaultPrefix, addCommonColors, shadowDOM);
 };

--- a/packages/core/theme/src/types.ts
+++ b/packages/core/theme/src/types.ts
@@ -139,4 +139,12 @@ export type HeroUIPluginConfig = {
    * @default "light"
    */
   defaultExtendTheme?: DefaultThemeType;
+  /**
+   * Also scope theme variables to `:host(...)` selectors and re-declare the
+   * derived `--color-*` vars under every theme selector, so themes react when
+   * the generated CSS is adopted into a ShadowRoot (e.g. browser extensions,
+   * web components). Off by default — adds extra selectors to the output.
+   * @default false
+   */
+  shadowDOM?: boolean;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6530

## 📝 Description

Adds an **opt-in** `shadowDOM` option to the `heroui()` Tailwind plugin so HeroUI theming (and dark mode in particular) works correctly when the generated CSS is adopted into a **ShadowRoot** — e.g. browser extensions, web components, micro-frontends.

This is a `feat(theme)`: a new, default-off API flag. With the flag unset, the emitted CSS is byte-for-byte identical to today.


Files changed:

| File | Change |
| --- | --- |
| `packages/core/theme/src/types.ts` | Add `shadowDOM?: boolean` to `HeroUIPluginConfig` (default `false`). |
| `packages/core/theme/src/plugin.ts` | Thread the flag through `heroui()` → `corePlugin()`; when enabled, also emit theme variables under `:host(...)` selectors and re-declare the derived `--color-*` vars under every theme selector. |
| `apps/docs/content/docs/customization/theme.mdx` | Document the new option (plugin-options example + API Reference table). |

## ⛳️ Current behavior (updates)

Today every theme variable is emitted under **document-root selectors only**:

- base / default theme → `:root, [data-theme=light]`
- dark theme → `.dark` (and the `&[data-theme='dark']` variant)

`:root` **never matches inside a shadow tree** (the shadow root is addressed with `:host`). So when HeroUI's CSS is used inside a ShadowRoot:

1. The Tailwind v4 derived `--color-*` vars (built from the `--heroui-*` source vars) are resolved **once at the document `:root`** with light values and inherit into the shadow tree as a **frozen** value.
2. Toggling `.dark` on an element **inside** the shadow updates the `--heroui-*` source vars locally, but nothing re-derives the `:root`-scoped `--color-*` — so components that read `--color-*` (`bg-default`, `bg-background`, …) stay stuck on light.

Result: dark mode visibly half-applies inside a ShadowRoot — the bug reported in #6530.


## 🚀 New behavior

With `shadowDOM: true`:

```js
// tailwind.config.js
const {heroui} = require("@heroui/theme");

module.exports = {
  plugins: [
    heroui({
      shadowDOM: true, // 👈 opt-in ShadowDOM-aware theming
    }),
  ],
};
```

the plugin additionally emits (only when the flag is on):

1. **`:host` scoping for the default/base theme** — the light baseline variables also live on `:host` / `:host([data-theme=light])`, so the shadow tree has correct base values independent of the outer document.
2. **The full selector set for every theme**, each carrying both the source var and the re-declared derived var:

   ```css
   .dark,
   [data-theme='dark'],
   :host(.dark),
   :host([data-theme='dark']) {
     --heroui-background: 0 0% 0%;                       /* source (already emitted) */
     --color-background: hsl(var(--heroui-background));  /* derived — re-declared here */
     /* …repeated for every color */
   }
   ```

3. **Host-scoped theme variants** — `:host(.dark) &` / `:host([data-theme='dark']) &` are appended to each variant so `dark:`-style utilities work when the host element itself carries the theme class.

This covers both ShadowDOM layouts: the theme class on an inner wrapper (`.dark` / `[data-theme]`) **and** on the host (`:host(...)`).

**Why this fixes it:** `--color-x: var(--heroui-x)` is resolved in the scope where `--color-x` is *declared*, not where it is *used*. Declared only at `:root`/`:host`, an inner `.dark` toggle is ignored and the frozen value inherits down. Re-declaring the derived `--color-*` vars inside every theme scope (including `:host(...)`) makes the substitution re-run against the dark `--heroui-*` value. Implementation: a small `deriveColorVars()` helper walks the existing `resolved.colors` map to produce `{"--color-<name>": "hsl(var(--<prefix>-<name>))"}`; all new rules live in one `if (shadowDOM) { … }` block after the existing emission, reusing `resolved.baseStyles` / `resolved.utilities` / `resolved.variants` (no change to `resolveConfig`).

> Getting the stylesheet **into** the ShadowRoot (e.g. `shadowRoot.adoptedStyleSheets = [...document.adoptedStyleSheets]`) remains the consumer's runtime responsibility and is out of scope for the plugin.

**After (`shadowDOM: true`)** — same toggle; all surfaces flip correctly:

https://github.com/user-attachments/assets/64d8464c-30f5-4b33-a0fb-d136ab19274a


## 💣 Is this a breaking change (Yes/No):

**No.** The flag defaults to `false`; existing projects get identical output and behavior. `:host(...)` rules are inert in a normal document, and the extra `--color-*` declarations are only emitted when the flag is explicitly enabled.

## 📝 Additional Information

- **Type:** `feat(theme)` → ships as a **minor** release; changeset included.
- **Docs:** updated in this PR (`theme.mdx`) per the "code and docs in sync" rule.
- **Tests:** a unit test drives the plugin output — asserting the four-selector dark block + re-declared `--color-*` when the flag is on, and that the default path emits no `:host` / `--color-*`.
- **Branch / target:** `feat/theme-shadow-dom` → `canary`.
