### PR TITLE
fix(pagination): improve active page contrast

### DIFF
--- a/packages/styles/components/pagination.css
+++ b/packages/styles/components/pagination.css
@@ -74,11 +74,12 @@
     transform: scale(0.97);
   }
 
-  /* Active page - tertiary button style */
+  /* Active page - solid accent fill so the current page reads clearly on any surface */
   &[data-active="true"] {
-    --pagination-link-bg: var(--default);
-    --pagination-link-bg-hover: var(--default-hover);
-    --pagination-link-bg-pressed: var(--default-hover);
+    --pagination-link-bg: var(--accent);
+    --pagination-link-bg-hover: var(--accent-hover);
+    --pagination-link-bg-pressed: var(--accent-hover);
+    --pagination-link-fg: var(--accent-foreground);
   }
 }
 


### PR DESCRIPTION
Closes #6488

## 📝 Description

The active (current) page in the Pagination component is barely distinguishable from idle pages. The active-state rule only swapped the link background to the faint `--default` surface token, so when Pagination sits on another `--default`/surface-tinted container (e.g. a Table footer, the exact repro in the issue) the selected page blends into the background.

See https://github.com/heroui-inc/heroui/issues/6488

## ⛳️ Current behavior (updates)

In `packages/styles/components/pagination.css`, the `&[data-active="true"]` block set the link background to `var(--default)` with no foreground change, border, or ring:

```css
&[data-active="true"] {
  --pagination-link-bg: var(--default);
  --pagination-link-bg-hover: var(--default-hover);
  --pagination-link-bg-pressed: var(--default-hover);
}
```

`--default` is a low-contrast surface token, so the active page reads almost identically to idle pages and to the surrounding surface.

## 🚀 New behavior

The active page now uses a solid accent fill with a matching readable foreground, mirroring the existing "current item" affordance already used elsewhere in the styles package (e.g. the selected/current year in `calendar-year-picker.css` uses `bg-accent text-accent-foreground`):

```css
&[data-active="true"] {
  --pagination-link-bg: var(--accent);
  --pagination-link-bg-hover: var(--accent-hover);
  --pagination-link-bg-pressed: var(--accent-hover);
  --pagination-link-fg: var(--accent-foreground);
}
```

This keeps the file's `@apply` + CSS-custom-property convention and reuses tokens already defined in the theme variables (no hard-coded colors), so it respects light/dark/custom themes. Idle, focus-visible, disabled, hover, and pressed states are unchanged.

## 💣 Is this a breaking change (Yes/No):

No. Visual-only change to the active page affordance; the API and class names are untouched.

## 📝 Additional Information

Testing:
- Active page is clearly distinguishable from idle pages on a plain page background.
- Pagination inside a Table footer (issue repro) no longer blends into the surface.
- Light and dark themes both hold contrast; no hard-coded colors leak through theming.
- Hover/press on the active item preserves contrast (uses `--accent-hover`).
- Idle, focus-visible, and disabled states are visually unchanged.
