### PR TITLE
fix(react): externalize react-aria subpaths to prevent vendored copy

### DIFF
--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -50,6 +50,7 @@ const external = [
   /^@react-stately/,
   /^@react-types\//,
   /^@internationalized\//,
+  /^react-aria($|\/)/,
   /^react-aria-components($|\/)/,
   /^tailwind-merge/,
   /^tailwind-variants/,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6651

## 📝 Description

<!--- Add a brief description -->

The rollup `external` list only externalized the exact `react-aria` string (from dependencies) and `react-aria-components` subpaths, but not `react-aria/*` subpaths. As a result, subpath imports like `react-aria/useFocusable` (Tooltip) and `react-aria/useCalendar` (CalendarYearPicker) were bundled, and `preserveModules` vendored a full second copy of react-aria into `dist/node_modules/`.

That duplicate copy created its own `FocusableContext`, so in pnpm hoisted monorepos (where react-aria isn't deduped) `Tooltip.Trigger` consumed a different context than the `react-aria-components` provider, leaving the trigger non-focusable and the tooltip never opening.

Add `/^react-aria($|\/)/` so all react-aria subpaths resolve against the consumer's single deduped copy. Both subpaths are public via react-aria's `./*` exports, so externalizing is safe and removes the vendored `dist/node_modules` entirely.


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

`tooltip.js`

```js
import { useFocusable as $d1116acdf220c2da$export$4c014de7c8940b4c } from '../../node_modules/.pnpm/react-aria@3.49.0_react-dom@19.2.6_react@19.2.6__react@19.2.6/node_modules/react-aria/dist/private/interactions/useFocusable.js';
```

`calendar-year-picker.js`

```js
import { useCalendarYearPicker as $e4b70edea91ee6b0$export$89757cae093b4b95 } from '../../node_modules/.pnpm/react-aria@3.49.0_react-dom@19.2.6_react@19.2.6__react@19.2.6/node_modules/react-aria/dist/private/calendar/useCalendarYearPicker.js';
import { useCalendarHeading as $bfcd16e7c55c9482$export$72ad8e10aa105341 } from '../../node_modules/.pnpm/react-aria@3.49.0_react-dom@19.2.6_react@19.2.6__react@19.2.6/node_modules/react-aria/dist/private/calendar/useCalendarHeading.js';
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

`tooltip.js`

```js
import { useFocusable } from 'react-aria/useFocusable';
```

`calendar-year-picker.js`

```js
import { useCalendarYearPicker, useCalendarHeading } from 'react-aria/useCalendar';
```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
