### PR TITLE
fix(switch-group): add missing switch-group-items

### DIFF
--- a/apps/docs/content/docs/cn/react/releases/index.mdx
+++ b/apps/docs/content/docs/cn/react/releases/index.mdx
@@ -13,7 +13,7 @@ description: HeroUI v3 的所有更新与变更，包含新功能、修复以及
 
 **2026 年 6 月 17 日**
 
-补丁版本：`@heroui/react` 不再内置自己的 `react-aria` 副本。`react-aria` 的子路径在 Rollup 构建中被外部化，使消费方解析到项目中安装的单一 `react-aria`，而非内联副本。
+补丁版本：`@heroui/react` 不再内置自己的 `react-aria` 副本。`react-aria` 的子路径在 Rollup 构建中被外部化，使消费方解析到项目中安装的单一 `react-aria`，而非内联副本。同时修复了 `SwitchGroup` 横向布局。
 
 [阅读完整发布说明 →](/docs/react/releases/v3-2-1)
 

--- a/apps/docs/content/docs/cn/react/releases/v3-2-1.mdx
+++ b/apps/docs/content/docs/cn/react/releases/v3-2-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: v3.2.1
-description: 补丁版本：将 react-aria 从 @heroui/react 产物中外部化，使其使用项目中已去重的单一副本，而非内置的内联副本。
+description: 补丁版本：将 react-aria 从 @heroui/react 产物中外部化，并修复 SwitchGroup 横向布局。
 github:
   pull: 6654
 ---
@@ -9,7 +9,7 @@ github:
   <span className="text-sm text-muted">2026 年 6 月 17 日</span>
 </div>
 
-补丁版本：`@heroui/react` 不再内置自己的 `react-aria` 副本。`react-aria` 的子路径现在在 Rollup 构建中被外部化，因此会解析到你项目中安装的版本 —— 避免在 `@heroui/react` 内部打包出一份重复、内联的 `react-aria` 副本。
+补丁版本：`@heroui/react` 不再内置自己的 `react-aria` 副本。`react-aria` 的子路径现在在 Rollup 构建中被外部化，因此会解析到你项目中安装的版本 —— 避免在 `@heroui/react` 内部打包出一份重复、内联的 `react-aria` 副本。本次发布还修复了 `SwitchGroup` 横向布局，补全缺失的 `switch-group__items` 包装层。
 
 ## 安装
 
@@ -45,6 +45,7 @@ github:
 ## 错误修复
 
 - **@heroui/react**：将 `react-aria` 子路径与其他 `@react-*` 和 `react-aria-components` 一起在 Rollup 构建中外部化，使 `@heroui/react` 不再内置自己的 `react-aria` 副本。消费方现在会解析到项目中安装的单一 `react-aria`，避免重复实例的问题以及不必要的产物体积膨胀 ([#6653](https://github.com/heroui-inc/heroui/pull/6653))。
+- **SwitchGroup**：补全缺失的 `switch-group__items` 包装层，使 `orientation="horizontal"` 时开关横向排列，而不再垂直堆叠 ([#6655](https://github.com/heroui-inc/heroui/pull/6655))。
 
 ## 链接
 

--- a/apps/docs/content/docs/en/react/releases/index.mdx
+++ b/apps/docs/content/docs/en/react/releases/index.mdx
@@ -13,7 +13,7 @@ description: All updates and changes to HeroUI v3, including new features, fixes
 
 **June 17, 2026**
 
-Patch release: `@heroui/react` no longer bundles its own copy of `react-aria`. The `react-aria` subpaths are externalized in the Rollup build, so consumers resolve to the single `react-aria` installed in their project instead of a vendored copy.
+Patch release: `@heroui/react` no longer bundles its own copy of `react-aria`. The `react-aria` subpaths are externalized in the Rollup build, so consumers resolve to the single `react-aria` installed in their project instead of a vendored copy. Also fixes `SwitchGroup` horizontal layout.
 
 [Read full release notes →](/docs/react/releases/v3-2-1)
 

--- a/apps/docs/content/docs/en/react/releases/v3-2-1.mdx
+++ b/apps/docs/content/docs/en/react/releases/v3-2-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: v3.2.1
-description: Patch release that externalizes react-aria from the @heroui/react bundle so consumers use a single deduped copy instead of a vendored one.
+description: Patch release that externalizes react-aria from the @heroui/react bundle and fixes SwitchGroup horizontal layout.
 github:
   pull: 6654
 ---
@@ -9,7 +9,7 @@ github:
   <span className="text-sm text-muted">June 17, 2026</span>
 </div>
 
-Patch release: `@heroui/react` no longer bundles its own copy of `react-aria`. The `react-aria` subpaths are now externalized in the Rollup build, so they resolve to the version installed in your project — preventing a duplicated, vendored copy of `react-aria` from shipping inside `@heroui/react`.
+Patch release: `@heroui/react` no longer bundles its own copy of `react-aria`. The `react-aria` subpaths are now externalized in the Rollup build, so they resolve to the version installed in your project — preventing a duplicated, vendored copy of `react-aria` from shipping inside `@heroui/react`. This release also fixes `SwitchGroup` horizontal layout by rendering the missing `switch-group__items` wrapper.
 
 ## Installation
 
@@ -45,6 +45,7 @@ Update to the latest version:
 ## Bug Fixes
 
 - **@heroui/react**: Externalize the `react-aria` subpaths in the Rollup build alongside the other `@react-*` and `react-aria-components` externals, so `@heroui/react` no longer vendors its own copy of `react-aria`. Consumers now resolve to the single `react-aria` installed in their project, avoiding duplicate-instance bugs and unnecessary bundle bloat ([#6653](https://github.com/heroui-inc/heroui/pull/6653)).
+- **SwitchGroup**: Render the missing `switch-group__items` wrapper so `orientation="horizontal"` lays out switches in a row instead of stacking vertically ([#6655](https://github.com/heroui-inc/heroui/pull/6655)).
 
 ## Links
 

--- a/packages/react/src/components/switch-group/switch-group.tsx
+++ b/packages/react/src/components/switch-group/switch-group.tsx
@@ -32,7 +32,9 @@ const SwitchGroupRoot = <E extends keyof React.JSX.IntrinsicElements = "div">({
 
   return (
     <dom.div data-slot="switch-group" {...(props as any)} className={slots.base({className})}>
-      {children}
+      <dom.div className={slots.items()} data-slot="switch-group-items">
+        {children}
+      </dom.div>
     </dom.div>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported in [Discord](https://discord.com/channels/856545348885676062/1516388749322223646) - The example in [Group Horizontal](https://heroui.com/en/docs/react/components/switch#group-horizontal) is incorrect. Upon investigation, the component never renders `switch-group__items`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

https://storybook-v3.heroui.com/?path=/story/components-controls-switchgroup--horizontal

<img width="253" height="160" alt="image" src="https://github.com/user-attachments/assets/380c9f26-13f1-424d-88e2-ccce20044d36" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

https://heroui-sb-git-fix-switch-group-items-heroui.vercel.app/?path=/story/components-controls-switchgroup--horizontal

<img width="454" height="50" alt="image" src="https://github.com/user-attachments/assets/0e6120e0-05dc-42d0-af53-d7e38f84302f" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
