### PR TITLE
fix(react): set type="button" on clear/close buttons to avoid form submission

### DIFF
--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -314,6 +314,7 @@ const AutocompleteClearButton = <E extends keyof React.JSX.IntrinsicElements = "
       data-empty={dataAttr(state?.selectionManager.selectedKeys.size === 0)}
       data-slot="autocomplete-clear-button"
       disabled={isDisabled ?? false}
+      type="button"
       onClick={handleClick}
       {...(props as any)}
     >

--- a/packages/react/src/components/close-button/close-button.tsx
+++ b/packages/react/src/components/close-button/close-button.tsx
@@ -33,6 +33,7 @@ const CloseButtonRoot = ({
       data-slot="close-button"
       slot={slot}
       style={style}
+      type="button"
       {...rest}
     >
       {(renderProps) =>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported in [Discord](https://discord.com/channels/856545348885676062/1517153726337388666)

Pressing `Autocomplete.ClearButton` while the component is inside a `<form>` unexpectedly submitted the form. The clear button rendered a native `<button>` with no `type` attribute, so the browser defaulted it to `type="submit"`. The same issue affected `CloseButton` (used by `SearchField.ClearButton` and others).

This PR sets `type="button"` on both, so they perform only their intended action and no longer trigger form submission. The attribute is applied before prop spreading, so consumers can still override it.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
