### PR TITLE
fix(styles): prevent visually hidden inputs from causing overflow scroll

### DIFF
--- a/packages/styles/components/checkbox.css
+++ b/packages/styles/components/checkbox.css
@@ -235,7 +235,7 @@
 
 /* Checkbox content — the clickable label (control + label text) */
 .checkbox__content {
-  @apply inline-flex cursor-[inherit] items-center gap-3 text-sm font-medium text-foreground outline-none select-none no-highlight;
+  @apply relative inline-flex cursor-[inherit] items-center gap-3 text-sm font-medium text-foreground outline-none select-none no-highlight;
 }
 
 /* Unselected state background for secondary variant */

--- a/packages/styles/components/radio.css
+++ b/packages/styles/components/radio.css
@@ -44,7 +44,7 @@
 
 /* Radio content — the clickable label (control + label text) */
 .radio__content {
-  @apply inline-flex cursor-[inherit] items-center gap-3 text-sm font-medium text-foreground outline-none select-none no-highlight;
+  @apply relative inline-flex cursor-[inherit] items-center gap-3 text-sm font-medium text-foreground outline-none select-none no-highlight;
 }
 
 /* ==========================================================================

--- a/packages/styles/components/switch.css
+++ b/packages/styles/components/switch.css
@@ -144,7 +144,7 @@
 
 /* Switch content — the clickable label (control + label text) */
 .switch__content {
-  @apply inline-flex cursor-[inherit] items-center gap-3 text-sm font-medium text-foreground outline-none select-none no-highlight;
+  @apply relative inline-flex cursor-[inherit] items-center gap-3 text-sm font-medium text-foreground outline-none select-none no-highlight;
 }
 
 /* Size-specific control dimensions */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6652

## 📝 Description

<!--- Add a brief description -->

`Switch`, `Checkbox`, and `Radio` render React Aria's label primitives (`SwitchButton` / `CheckboxButton` / `RadioButton`), which include a visually hidden native `<input>` styled with `position: absolute; margin: -1px`.
The `*__content` slots were only `inline-flex` with no `position`, so the hidden input had no positioned ancestor. Its containing block fell back to the initial containing block, allowing the `-1px` margin to extend past the
document edge and produce a phantom scrollbar (most visible on Edge/Windows).

This PR adds `position: relative` to each content slot so it becomes the input's containing block. Combined with the input's own `overflow: hidden` and `1px` size, it can no longer affect document dimensions. `relative` has no layout effect on `inline-flex`, so there is no visual change.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Page is unexpectedly scrollable.

<img width="1583" height="864" alt="image" src="https://github.com/user-attachments/assets/3d7093ff-30d4-4d5e-b2b2-1e800c8a8870" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Page is not scrollable.

<img width="1431" height="797" alt="image" src="https://github.com/user-attachments/assets/b32c45cf-906a-4e01-a5e0-ba829fd35f0a" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
