### PR TITLE
fix(styles): prevent icon or text shift on press

### DIFF
--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -12,7 +12,7 @@
     transform 250ms var(--ease-smooth),
     background-color 100ms var(--ease-out),
     box-shadow 100ms var(--ease-out);
-  @apply transform-gpu motion-reduce:transition-none;
+  @apply transform-gpu will-change-transform motion-reduce:transition-none;
 
   /* Cursor */
   cursor: var(--cursor-interactive);

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -49,7 +49,7 @@
 
 /* Similar to select popover styles */
 .dropdown__popover {
-  @apply max-w-[48svw] origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain bg-overlay p-0 text-sm scrollbar md:min-w-55;
+  @apply max-w-[48svw] origin-(--trigger-anchor-point) scroll-py-1 scrollbar overflow-y-auto overscroll-contain bg-overlay p-0 text-sm will-change-transform md:min-w-55;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 

--- a/packages/styles/components/menu-item.css
+++ b/packages/styles/components/menu-item.css
@@ -13,7 +13,7 @@
     transform 250ms var(--ease-out-quart),
     box-shadow 150ms var(--ease-out);
 
-  @apply motion-reduce:transition-none;
+  @apply will-change-transform motion-reduce:transition-none;
 
   /* Cursor */
   cursor: var(--cursor-interactive);
@@ -37,7 +37,7 @@
 
   /* Add inline-end padding when indicator is present and has submenu */
   &[data-has-submenu="true"]:has(.menu-item__indicator) {
-    @apply pe-7 ps-2;
+    @apply ps-2 pe-7;
   }
 
   /* Focus visible state (keyboard focus only) */
@@ -97,7 +97,7 @@
    ========================================================================== */
 
 .menu-item__indicator {
-  @apply absolute top-1/2 start-2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-muted;
+  @apply absolute start-2 top-1/2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-muted;
 
   /**
    * Transitions
@@ -106,7 +106,7 @@
 
   /* Position on the inline-end when menu item has submenu */
   .menu-item[data-has-submenu="true"] & {
-    @apply end-2 start-auto;
+    @apply start-auto end-2;
   }
 
   /* Checkmark SVG indicator */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported in discord by power user.

- Icons and text inside `.button` / `.menu-item` were shifting around (instead of zooming) when pressed in Chrome. The `transform: scale()` applied on `:active`/`[data-pressed]` overrides the `transform-gpu` (`translateZ(0)`) hint, dropping the element off its GPU compositing layer mid-press and causing children to re-rasterize at fractional pixel positions.
- Added `will-change-transform` to `.button`, `.menu-item`, and `.dropdown__popover` to keep them promoted to a dedicated compositing layer, so the scale transform animates smoothly.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
