### PR TITLE
fix(styles): set chip width to w-fit

### DIFF
--- a/packages/styles/components/chip.css
+++ b/packages/styles/components/chip.css
@@ -1,6 +1,6 @@
 /* Base styles */
 .chip {
-  @apply inline-flex shrink-0 items-center gap-0.5 rounded-2xl px-2 py-0.5 text-xs leading-5 font-medium;
+  @apply inline-flex w-fit shrink-0 items-center gap-0.5 rounded-2xl px-2 py-0.5 text-xs leading-5 font-medium;
 
   /* Default tokens */
   --chip-bg: var(--default);


### PR DESCRIPTION
## Summary
- Add `w-fit` to the base `.chip` class so chips size to their content instead of stretching in flex layouts.

## Test plan
- [ ] Verify chips in Storybook only take up the width of their label/icon content
- [ ] Confirm chips in flex containers no longer stretch unexpectedly


Made with [Cursor](https://cursor.com)