### PR TITLE
fix(styles): prevent excess width in date-range-picker popover

### DIFF
--- a/packages/styles/components/date-picker.css
+++ b/packages/styles/components/date-picker.css
@@ -40,7 +40,7 @@
 }
 
 .date-picker__popover {
-  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scrollbar-none overflow-y-auto overscroll-contain bg-overlay p-3;
+  @apply w-fit origin-(--trigger-anchor-point) scrollbar-none overflow-y-auto overscroll-contain bg-overlay p-3;
   @apply motion-reduce:transition-none;
 
   box-shadow: var(--shadow-overlay);

--- a/packages/styles/components/date-range-picker.css
+++ b/packages/styles/components/date-range-picker.css
@@ -44,7 +44,7 @@
 }
 
 .date-range-picker__popover {
-  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scrollbar-none overflow-y-auto overscroll-contain bg-overlay p-3;
+  @apply w-fit origin-(--trigger-anchor-point) scrollbar-none overflow-y-auto overscroll-contain bg-overlay p-3;
   @apply motion-reduce:transition-none;
 
   box-shadow: var(--shadow-overlay);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported in [Discord](https://discord.com/channels/856545348885676062/1414957667243397182/1518348408912347157)

The `DateRangePicker` popover rendered with a large empty area on the right side of the calendar.
The popover used `min-w-(--trigger-width)`, which forces its width to at least the trigger field width. Because the `DateRangePicker` field is wide (two date inputs + separator, ~320px) but the `RangeCalendar` content is a
fixed width (~252px), this left ~53px of empty space on the right. This was introduced in #6622, which changed the constraint from `max-w-(--trigger-width)` to `min-w-(--trigger-width)` while fixing horizontal clipping on the DatePicker calendar popover.

This PR changes `.date-range-picker__popover` to use `w-fit` so the popover sizes to the calendar content, eliminating the empty space while still avoiding the clipping that #6622 addressed. `DatePicker` was unaffected because its trigger width is close to the calendar width.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Popover forced to 320px wide, ~53px empty gap on the right.

<img width="935" height="723" alt="image" src="https://github.com/user-attachments/assets/95d235d1-73ae-4355-8871-3c61b8fc7599" />

<img width="935" height="809" alt="image" src="https://github.com/user-attachments/assets/0e9a2d60-9302-4b28-bf03-7c84da27b66b" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Popover hugs the calendar; gap reduced to the intended 12px padding.

<img width="910" height="534" alt="image" src="https://github.com/user-attachments/assets/c1dd3d9c-ccc8-4271-9d19-5019d51beee5" />

<img width="842" height="673" alt="image" src="https://github.com/user-attachments/assets/a2836dd5-094a-4c76-9dc3-6a9aa8542290" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
