### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/apps/docs/content/docs/en/react/getting-started/(overview)/quick-start.mdx
+++ b/apps/docs/content/docs/en/react/getting-started/(overview)/quick-start.mdx
@@ -36,7 +36,7 @@ When done, summarize the changes you made and tell me how to start the dev serve
 
 Install HeroUI and required dependencies:
 
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+<Tabs items={["npm", "pnpm", "yarn", "bun", "deno"]}>
   <Tab value="npm">
     ```bash
     npm i @heroui/styles @heroui/react
@@ -55,6 +55,11 @@ Install HeroUI and required dependencies:
   <Tab value="bun">
     ```bash
     bun add @heroui/styles @heroui/react
+    ```
+  </Tab>
+  <Tab value="deno">
+    ```bash
+    deno install @heroui/styles @heroui/react
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm, pnpm, yarn, and bun, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install @heroui/styles @heroui/react
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install @heroui/react`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._

---

## 📝 Description

Adds a `deno` tab to the install instructions on the React quick-start page (`apps/docs/content/docs/en/react/getting-started/(overview)/quick-start.mdx`), alongside the existing npm / pnpm / yarn / bun tabs.

## ⛳️ Current behavior (updates)

The install snippet offers npm, pnpm, yarn, and bun, but no Deno command.

## 🚀 New behavior

Adds a fifth `deno` tab with `deno install @heroui/styles @heroui/react`, mirroring the packages the other tabs install. Only the install snippet is touched.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Verified the command works: `deno install @heroui/react` resolves and downloads cleanly (Deno 2.x), with no lifecycle-script prompts or hard errors.
