### PR TITLE
build(docs): configure android asset links for herouinative app

### DIFF
--- a/apps/docs/public/.well-known/assetlinks.json
+++ b/apps/docs/public/.well-known/assetlinks.json
@@ -6,8 +6,10 @@
     ],
     "target": {
       "namespace": "android_app",
-      "package_name": "TODO_ANDROID_PACKAGE_NAME",
-      "sha256_cert_fingerprints": ["TODO_YOUR_SIGNING_KEY_SHA256"]
+      "package_name": "com.herouinative.android",
+      "sha256_cert_fingerprints": [
+        "62:D8:E2:37:B2:F1:18:99:A5:08:6B:65:95:53:24:3F:5B:A2:A8:95:78:9E:AA:A3:D2:82:55:1F:83:74:7F:2E"
+      ]
     }
   }
 ]


### PR DESCRIPTION
## 📝 Description

Replaces placeholder values in the Android `assetlinks.json` file with the production package name and signing certificate fingerprint. This enables Android App Links verification for the `com.herouinative.android` app, allowing it to handle deep links from the docs site domain.

## ⛳️ Current behavior (updates)

The `assetlinks.json` file at `apps/docs/public/.well-known/` contains `TODO_ANDROID_PACKAGE_NAME` and `TODO_YOUR_SIGNING_KEY_SHA256` placeholders, so Android App Links verification cannot succeed.

## 🚀 New behavior

- Sets `package_name` to `com.herouinative.android`
- Adds the real SHA-256 certificate fingerprint for the app's signing key
- Enables verified Android App Links / Digital Asset Links for the docs domain

## 💣 Is this a breaking change (Yes/No):

**No** - This only fills in previously unused placeholder values in a well-known config file; no runtime, API, or component behavior changes.

## 📝 Additional Information

Verification can be confirmed via Google's Statement List Generator/Tester or by running `adb shell pm verify-app-links` once the docs site is deployed. No code dependencies are affected and no tests are required.