### PR TITLE
fix(docs): render native-showcase fallback page outside the [lang] tree

### DIFF
--- a/apps/docs/public/.well-known/assetlinks.json
+++ b/apps/docs/public/.well-known/assetlinks.json
@@ -8,7 +8,8 @@
       "namespace": "android_app",
       "package_name": "com.herouinative.android",
       "sha256_cert_fingerprints": [
-        "62:D8:E2:37:B2:F1:18:99:A5:08:6B:65:95:53:24:3F:5B:A2:A8:95:78:9E:AA:A3:D2:82:55:1F:83:74:7F:2E"
+        "62:D8:E2:37:B2:F1:18:99:A5:08:6B:65:95:53:24:3F:5B:A2:A8:95:78:9E:AA:A3:D2:82:55:1F:83:74:7F:2E",
+        "77:AC:EE:FC:3F:03:A2:E7:5F:5F:08:B1:53:C9:F1:25:8C:31:0A:F1:D9:63:C9:DE:FE:F8:31:CE:F1:9A:37:9E"
       ]
     }
   }

--- a/apps/docs/src/app/docs/native-showcase/layout.tsx
+++ b/apps/docs/src/app/docs/native-showcase/layout.tsx
@@ -1,0 +1,18 @@
+import type {ReactNode} from "react";
+
+import {Inter} from "next/font/google";
+
+import "../../global.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+});
+
+export default function NativeShowcaseLayout({children}: {children: ReactNode}) {
+  return (
+    <html suppressHydrationWarning className={inter.variable} lang="en">
+      <body className="flex min-h-screen flex-col font-sans">{children}</body>
+    </html>
+  );
+}

--- a/apps/docs/src/components/native/index.ts
+++ b/apps/docs/src/components/native/index.ts
@@ -5,6 +5,7 @@ export {DownloadAppBanner} from "./download-app-banner";
 export {ImageHeroView} from "./image-hero-view";
 export {QRPreviewPopover, pickNativeQRTarget} from "./qr-preview-popover";
 export type {NativeQRPreviewTarget} from "./qr-preview-popover";
-export {StoreButtons} from "./store-buttons";
+export {StoreButtonsLocalized} from "./store-buttons-localized";
+export {StoreButtons, StoreButtonsView} from "./store-buttons";
 export {TryOnDevice} from "./try-on-device";
 export {VideoPlayerView} from "./video-player-view";

--- a/apps/docs/src/components/native/qr-preview-popover/qr-preview-popover.tsx
+++ b/apps/docs/src/components/native/qr-preview-popover/qr-preview-popover.tsx
@@ -13,7 +13,7 @@ import {i18n} from "@/lib/i18n";
 
 import {Iconify} from "../../iconify";
 import {DeepLinkQRCode} from "../deep-link-qr-code";
-import {StoreButtons} from "../store-buttons";
+import {StoreButtonsLocalized} from "../store-buttons-localized";
 
 /**
  * Read `window.location.origin` synchronously when running in the browser.
@@ -132,7 +132,7 @@ export const QRPreviewPopover = (props: NativeQRPreviewTarget) => {
         <Popover.Dialog className="flex flex-col items-center gap-4 px-5 pb-6">
           <DeepLinkQRCode size={160} url={deepLinkUrl} />
           <span className="mb-2 text-center text-xs text-foreground">{downloadPrompt}</span>
-          <StoreButtons />
+          <StoreButtonsLocalized />
         </Popover.Dialog>
       </Popover.Content>
     </Popover>

--- a/apps/docs/src/components/native/store-buttons-localized.tsx
+++ b/apps/docs/src/components/native/store-buttons-localized.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import {useDictionary} from "@/hooks/use-dictionary";
+
+import {StoreButtonsView} from "./store-buttons";
+
+interface StoreButtonsLocalizedProps {
+  /**
+   * Button size variant. Controls padding and the icon's pixel size so the
+   * buttons can sit either inside a small popover (`"sm"`) or as the
+   * full-page CTA on the download banner (`"md"`).
+   * @default "sm"
+   */
+  size?: "sm" | "md";
+  /**
+   * Additional CSS class for the wrapping `<div>`. Lets the parent control
+   * width and spacing without StoreButtons baking in a max-width.
+   */
+  className?: string;
+}
+
+/**
+ * Localized App Store / Play Store buttons for docs content.
+ *
+ * Reads its copy from the active `DictionaryProvider` via {@link useDictionary},
+ * so it MUST be rendered inside the `[lang]` provider tree (e.g. the QR preview
+ * popover and the "try on device" section). For the locale-less Universal Links
+ * fallback page, use the static `StoreButtons` instead.
+ */
+export const StoreButtonsLocalized = ({className, size = "sm"}: StoreButtonsLocalizedProps) => {
+  const labels = useDictionary().storeButtons;
+
+  return <StoreButtonsView className={className} labels={labels} size={size} />;
+};

--- a/apps/docs/src/components/native/store-buttons.tsx
+++ b/apps/docs/src/components/native/store-buttons.tsx
@@ -1,11 +1,37 @@
-"use client";
+import type {Dictionary} from "@/lib/dictionaries";
 
 import {NATIVE_APP} from "@/config/native-app";
-import {useDictionary} from "@/hooks/use-dictionary";
 
 import {Iconify} from "../iconify";
 
-interface StoreButtonsProps {
+/**
+ * Shape of the localized strings consumed by the store buttons. Mirrors the
+ * `storeButtons` slice of the docs dictionary so the localized and static
+ * variants share a single, type-safe contract.
+ */
+export type StoreButtonsLabels = Dictionary["storeButtons"];
+
+/**
+ * English fallback strings used by the static {@link StoreButtons} variant,
+ * which renders on the locale-less Universal Links page at
+ * `/docs/native-showcase/components/{slug}` where no `DictionaryProvider` is
+ * mounted.
+ */
+const DEFAULT_STORE_BUTTONS: StoreButtonsLabels = {
+  androidComingSoon: "Android · Coming soon",
+  androidComingSoonLabel: "Android version coming soon",
+  appStore: "Download on App Store",
+  appStoreLabel: "Download {name} on the App Store",
+  playStore: "Download on Play Store",
+  playStoreLabel: "Download {name} on Google Play",
+};
+
+interface StoreButtonsViewProps {
+  /**
+   * Localized strings to render. Supplied by the static variant (English
+   * defaults) or the localized variant (dictionary-backed).
+   */
+  labels: StoreButtonsLabels;
   /**
    * Button size variant. Controls padding and the icon's pixel size so the
    * buttons can sit either inside a small popover (`"sm"`) or as the
@@ -21,7 +47,11 @@ interface StoreButtonsProps {
 }
 
 /**
- * App Store and Play Store download buttons.
+ * Presentational App Store / Play Store buttons.
+ *
+ * This component holds the shared markup for both the static and localized
+ * variants and receives its copy via the `labels` prop. It has no hooks, so it
+ * renders in both server and client contexts.
  *
  * When `NATIVE_APP.PLAY_STORE_URL` is `null` (Android build not yet
  * published), the Play Store button is automatically replaced with a disabled
@@ -29,15 +59,14 @@ interface StoreButtonsProps {
  * config flips both this surface and the in-popover variant simultaneously —
  * no other code changes are required.
  */
-export const StoreButtons = ({className, size = "sm"}: StoreButtonsProps) => {
-  const dict = useDictionary().storeButtons;
+export const StoreButtonsView = ({className, labels, size = "sm"}: StoreButtonsViewProps) => {
   // The button system uses BEM modifiers — only `--sm` exists; `--md` is the
   // default and produced by omitting the modifier.
   const sizeClass = size === "sm" ? "button--sm" : "";
   const iconSize = size === "sm" ? 18 : 20;
 
-  const appStoreLabel = dict.appStoreLabel.replace("{name}", NATIVE_APP.NAME);
-  const playStoreLabel = dict.playStoreLabel.replace("{name}", NATIVE_APP.NAME);
+  const appStoreLabel = labels.appStoreLabel.replace("{name}", NATIVE_APP.NAME);
+  const playStoreLabel = labels.playStoreLabel.replace("{name}", NATIVE_APP.NAME);
 
   return (
     <div className={className ?? "flex w-full flex-col items-stretch gap-2"}>
@@ -49,7 +78,7 @@ export const StoreButtons = ({className, size = "sm"}: StoreButtonsProps) => {
         target="_blank"
       >
         <Iconify icon="tabler:brand-apple-filled" width={iconSize} />
-        {dict.appStore}
+        {labels.appStore}
       </a>
       {NATIVE_APP.PLAY_STORE_URL ? (
         <a
@@ -60,7 +89,7 @@ export const StoreButtons = ({className, size = "sm"}: StoreButtonsProps) => {
           target="_blank"
         >
           <Iconify icon="simple-icons:googleplay" width={iconSize} />
-          {dict.playStore}
+          {labels.playStore}
         </a>
       ) : (
         // `role="link"` + `aria-disabled` keeps the placeholder semantically
@@ -68,7 +97,7 @@ export const StoreButtons = ({className, size = "sm"}: StoreButtonsProps) => {
         // unavailable App Store entries.
         <span
           aria-disabled="true"
-          aria-label={dict.androidComingSoonLabel}
+          aria-label={labels.androidComingSoonLabel}
           role="link"
           className={[
             "button button--tertiary w-full cursor-not-allowed justify-center opacity-50",
@@ -76,9 +105,34 @@ export const StoreButtons = ({className, size = "sm"}: StoreButtonsProps) => {
           ].join(" ")}
         >
           <Iconify icon="simple-icons:googleplay" width={iconSize} />
-          {dict.androidComingSoon}
+          {labels.androidComingSoon}
         </span>
       )}
     </div>
   );
 };
+
+interface StoreButtonsProps {
+  /**
+   * Button size variant. @see StoreButtonsViewProps.size
+   * @default "sm"
+   */
+  size?: "sm" | "md";
+  /**
+   * Additional CSS class for the wrapping `<div>`.
+   * @see StoreButtonsViewProps.className
+   */
+  className?: string;
+}
+
+/**
+ * Static, English-only store buttons for the locale-less Universal Links
+ * fallback page (`/docs/native-showcase/components/{slug}`).
+ *
+ * This variant has no client hooks and does NOT depend on a
+ * `DictionaryProvider`, so the surrounding page renders fully statically. For
+ * localized docs content, use `StoreButtonsLocalized` instead.
+ */
+export const StoreButtons = ({className, size = "sm"}: StoreButtonsProps) => (
+  <StoreButtonsView className={className} labels={DEFAULT_STORE_BUTTONS} size={size} />
+);

--- a/apps/docs/src/components/native/try-on-device.tsx
+++ b/apps/docs/src/components/native/try-on-device.tsx
@@ -5,7 +5,7 @@ import {useState} from "react";
 import {NATIVE_APP} from "@/config/native-app";
 
 import {DeepLinkQRCode} from "./deep-link-qr-code";
-import {StoreButtons} from "./store-buttons";
+import {StoreButtonsLocalized} from "./store-buttons-localized";
 
 /**
  * Read `window.location.origin` synchronously when running in the browser.
@@ -52,7 +52,7 @@ export const TryOnDevice = () => {
         <span className="mb-2 text-center text-xs text-foreground">
           {["Don't have the ", NATIVE_APP.NAME, " app yet? Download it below."].join("")}
         </span>
-        <StoreButtons className="flex w-full max-w-xs flex-col items-stretch gap-2" />
+        <StoreButtonsLocalized className="flex w-full max-w-xs flex-col items-stretch gap-2" />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 Description

Splits the native-showcase store buttons into a presentational `StoreButtonsView`, a dictionary-backed `StoreButtonsLocalized`, and a static English `StoreButtons`. This lets the locale-less Universal Links fallback page render statically without a `DictionaryProvider`, while localized docs surfaces keep their translated copy.

## ⛳️ Current behavior (updates)

`StoreButtons` was a client component that always called `useDictionary()`, so it required a `DictionaryProvider` and broke when rendered on the locale-less native-showcase fallback page.

## 🚀 New behavior

- Extracts shared markup into a hook-free `StoreButtonsView` that takes a `labels` prop.
- Adds `StoreButtonsLocalized` (reads copy from `useDictionary`) for the QR popover and "try on device" sections.
- Keeps `StoreButtons` as a static, English-only variant for the fallback page.
- Adds a dedicated `native-showcase/layout.tsx` so the fallback page renders outside the `[lang]` tree.
- Adds a second Android `sha256_cert_fingerprint` to `assetlinks.json`.

## 💣 Is this a breaking change (Yes/No):

**No** - Public docs surfaces keep the same rendered output; only the internal component split and a new layout were introduced.

## 📝 Additional Information

Changes are confined to `apps/docs`. Manual verification should confirm the QR popover/try-on-device still show localized copy and the Universal Links fallback page renders without a dictionary provider.