### PR TITLE
fix(styles): correct right padding of virtualized list items

### DIFF
--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -199,6 +199,15 @@
     @apply px-2.5;
   }
 
+  /* Virtualized rows: react-aria's Virtualizer wraps each row in an absolutely-positioned
+   * [role="presentation"] element whose width equals the scroll container's clientWidth
+   * (which includes the list-box horizontal padding) while sitting inside the padded content
+   * box. Without this, rows overflow the right padding and the hover background reaches the
+   * popover edge. Subtract the horizontal padding (2 × p-1.5 = 12px) to keep rows aligned. */
+  [role="presentation"] > [data-slot="list-box-item"] {
+    width: calc(100% - var(--spacing) * 3);
+  }
+
   /* As the popover closes fast in single-select mode, the default item indicator transition is not even visible - so we disable it only for single-select */
   [data-slot="list-box"]:not([aria-multiselectable="true"]) [data-slot="list-box-item-indicator"],
   [data-slot="list-box"]:not([aria-multiselectable="true"])


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported [here](https://discord.com/channels/856545348885676062/1514230221425873057/1519242509518246021)

- Fixes the autocomplete virtualization example where hovering a list item showed the hover background bleeding to the popover's right edge — the right padding was gone while the left was correct.
- Root cause: react-aria's `Virtualizer` renders each row inside an absolutely-positioned `[role="presentation"]` wrapper sized to the scroll container's `clientWidth` (which *includes* the list-box horizontal padding), while the wrapper sits inside the padded content box. The `w-full` row therefore overflowed the right padding by `2 × 6px`. Non-virtualized lists were unaffected because their rows are normal-flow `w-full` children that fit the content box.
- Fix is CSS-only and surgical: a single rule scoped to the virtualizer wrapper inside `.autocomplete__popover` trims the row to the content-box width (`calc(100% - var(--spacing) * 3)`). No consumer changes (`layoutOptions`/`style`) required; non-virtualized lists, sections, and scrollbar positioning are untouched.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="368" height="465" alt="image" src="https://github.com/user-attachments/assets/96052c4e-3c1a-4bef-9376-fa25e6e44437" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="370" height="477" alt="image" src="https://github.com/user-attachments/assets/f8419cd5-3a3f-475e-878c-ff7af12128de" />


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
