### PR TITLE
fix(toast): catch ViewTransition `ready` rejection in toast queue

### DIFF
--- a/packages/react/src/components/toast/toast-queue.ts
+++ b/packages/react/src/components/toast/toast-queue.ts
@@ -38,13 +38,12 @@ export class ToastQueue<T extends object = ToastContentValue> {
     // Serialize successive ViewTransitions through a tail-extending promise
     // chain. The View Transitions API only allows one active transition at a
     // time — starting a second while the first is still animating aborts the
-    // first with a "Skipped ViewTransition due to another transition starting"
-    // DOMException (which surfaces as an unhandled rejection on .finished).
-    // Appending each new transition to the end of the chain (rather than
-    // attaching them all to the first active one) keeps them strictly ordered
-    // even when three or more mutations stack inside a single microtask, as
-    // happens during toast.promise() while the loading toast's own add
-    // transition is still in flight.
+    // first with a "Transition was skipped" DOMException (which surfaces as an
+    // unhandled rejection on .ready). Appending each new transition to the end
+    // of the chain (rather than attaching them all to the first active one)
+    // keeps them strictly ordered even when three or more mutations stack
+    // inside a single microtask, as happens during toast.promise() while the
+    // loading toast's own add transition is still in flight.
     let transitionChain: Promise<unknown> = Promise.resolve();
 
     const defaultWrapUpdate = (fn: () => void): void => {
@@ -58,6 +57,13 @@ export class ToastQueue<T extends object = ToastContentValue> {
         const transition = document.startViewTransition(() => {
           flushSync(fn);
         });
+
+        // When a transition is superseded or aborted, it's `ready` that
+        // rejects (e.g. "AbortError: Transition was skipped" /
+        // "InvalidStateError: Transition was aborted because of invalid
+        // state"); `finished` still fulfills. Catch `ready` so the rejection
+        // doesn't surface as an unhandled promise rejection.
+        transition.ready.catch(() => {});
 
         // Swallow the "skipped" rejection so that chain steps after a
         // superseded transition still run.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6673

## 📝 Description

<!--- Add a brief description -->

When two toasts fire close together (one closing while another opens, or `toast.promise` swapping the loading toast for a success/error one), an uncaught promise rejection appeared in the console — `AbortError: Transition was skipped` or `InvalidStateError: Transition was aborted because of invalid state`. On Next.js it popped the dev error overlay.

`document.startViewTransition()` returns three promises: `ready`, `updateCallbackDone`, and `finished`. When a transition is skipped/aborted, it is **`ready`** that rejects — **`finished` still fulfills**. The default `wrapUpdate` in `toast-queue.ts` only attached `.catch()` to `finished`, so the `ready` rejection went unhandled.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
