### PR TITLE
feat(docs): enable Android Play Store download link

### DIFF
--- a/apps/docs/src/config/native-app.ts
+++ b/apps/docs/src/config/native-app.ts
@@ -29,7 +29,7 @@ export const NATIVE_APP = {
    * automatically when this is `null`. When the Play Store listing goes live,
    * paste its URL here and both surfaces re-enable with no other code changes.
    */
-  PLAY_STORE_URL: null,
+  PLAY_STORE_URL: "https://play.google.com/store/apps/details?id=com.herouinative.android",
   /**
    * Custom URL scheme registered by the native app. Used by the in-page
    * "Open in app" tap link on mobile to bypass iOS's same-domain Safari


### PR DESCRIPTION
## 📝 Description

Enables the HeroUI Native Android download link now that the app is live on Google Play. Updates the centralized `NATIVE_APP.PLAY_STORE_URL` config so all docs surfaces that reference the Play Store listing stay in sync from a single source of truth.

## ⛳️ Current behavior (updates)

The Android Play Store button in the docs site (QR popover, store buttons, and related download UI) shows a disabled "Coming soon" state because `PLAY_STORE_URL` is set to `null`.

## 🚀 New behavior

- `PLAY_STORE_URL` points to the live Google Play listing (`com.herouinative.android`)
- QR popover and store button components render an active, clickable Google Play badge
- No component or MDX changes required — existing conditional logic picks up the new URL automatically

## 💣 Is this a breaking change (Yes/No):

**No** - This is a config-only update that enables existing UI behavior; no public API or component contracts change.

## 📝 Additional Information

Change is limited to `apps/docs/src/config/native-app.ts`. Manual verification: confirm the Google Play badge appears and links correctly in the QR popover and "Try on Device" sections on the docs site.