### PR TITLE
fix(popover): fixed popover content clipping and overflow on small viewports

### DIFF
--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -5,6 +5,11 @@
   @apply origin-(--trigger-anchor-point) bg-overlay p-0 text-sm;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
+  max-width: min(var(--popover-max-width, 22rem), calc(100vw - 1.5rem));
+  display: flex;
+  flex-direction: column;
+  overflow: clip;
+  overflow-clip-margin: 12px;
 
   /* Entering animations */
   &[data-entering="true"] {
@@ -60,6 +65,9 @@
 /* Popover dialog */
 .popover__dialog {
   @apply p-4 outline-none;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-wrap: break-word;
 }
 
 /* Popover heading */


### PR DESCRIPTION
Hello!
I found a bug in the Popover component when opened in constrained viewports.

## 📝 Description

### Problem

On very small viewports (less than mobile, ~375px) or when the trigger is near the bottom/right edge of the screen, the `Popover` component had two visual bugs:

1. **Content cut off from below**: when React Aria injects `maxHeight` inline (because there is not enough space below the trigger), the dialog content did not scroll — it was simply clipped. The popover background resized but the dialog content kept floating below it, without background or clipping.

2. **Text overflowing horizontally**: without a `max-width` defined in CSS, the popover relied entirely on the `maxWidth` React Aria applies inline when approaching the right edge. Without `overflow-wrap`, long words could escape the container.

Both bugs are reproducible in the official HeroUI documentation by reducing the viewport to mobile width.

### Root cause

`useOverlayPosition` from `@react-aria/overlays` applies `maxHeight` and `maxWidth` via inline styles to keep the overlay within the viewport. The issue was not in React Aria's position calculation (which is correct), but in the fact that the popover CSS had no mechanism to *adapt* to those constraints:

- Without `display: flex` on `.popover`, the dialog could not flex-shrink within the `maxHeight` constraint.
- Without `min-height: 0` on `.popover__dialog`, the flex item keeps its default `min-height: auto` and refuses to shrink below its content height.
- Without `overflow-y: auto` on the dialog, there is no scroll when content exceeds the available space.
- Without `max-width` in CSS, the popover had no predictable upper width bound.

## ⛳️ Current behavior (updates)

This is the current behavior found. This example is reproducible in the official component docs.
<img width="934" height="280" alt="Screenshot 2026-06-25 at 10 18 32" src="https://github.com/user-attachments/assets/586912ea-e4a0-427e-8409-c8044acb1b89" />

## 🚀 New behavior

| Change | Why |
|--------|-----|
| `max-width: min(var(--popover-max-width, 22rem), calc(100vw - 1.5rem))` | Provides a predictable upper bound. Without this, React Aria is the only one applying `maxWidth` inline (only when approaching the edge), which produces inconsistent sizing. The `--popover-max-width` CSS custom property allows per-consumer overrides. |
| `display: flex; flex-direction: column` | Turns the popover into a flex container so the dialog child can be constrained by the `maxHeight` React Aria applies to the popover. |
| `overflow: clip; overflow-clip-margin: 12px` | `overflow: clip` (instead of `overflow: hidden`) clips content at the popover boundary without creating a scroll container on the parent, which preserves the `overflow-y: auto` behavior of the dialog child. `overflow-clip-margin: 12px` gives the `OverlayArrow` room to render its tip outside the popover bounding box. |
| `min-height: 0` on `.popover__dialog` | **Critical for scrolling.** The default flex item value is `min-height: auto`, which prevents the item from shrinking below its content height. With `min-height: 0`, the dialog can flex-shrink to fit within the popover's `maxHeight`. |
| `overflow-y: auto` on `.popover__dialog` | When the dialog flex-shrinks due to the `maxHeight` constraint, content scrolls inside the dialog instead of being clipped. |
| `overflow-wrap: break-word` on `.popover__dialog` | Long unbreakable strings (URLs, emails, technical names) do not escape the container horizontally when it is width-constrained. |

### Known limitation (not addressed in this PR)

The temporary `overlay.style.top = '0px'` reset inside `updatePosition()` from `@react-aria/overlays` (line ~84 of `useOverlayPosition.module.js`) can cause a position flash on the first render in very small viewports if the ResizeObserver fires during the first 150ms of the entrance animation. This is a React Aria upstream bug. Reducing the animation duration would shrink that race window, but eliminating it entirely requires a fix in `@react-aria/overlays`.

<img width="432" height="288" alt="Screenshot 2026-06-25 at 10 39 20" src="https://github.com/user-attachments/assets/90b7a468-4f84-4af7-af80-79dbddd23d51" />

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

## How to reproduce (before the fix)

1. Open Storybook → `Components/Overlays/Popover` → **WithCustomContent** story
2. Reduce the viewport height to minimum possible (~288px)
3. Click the trigger (Zoe's avatar)
4. **Observe**: the popover dialog content is clipped from below / text overflows the container (you may need to scroll and position the trigger to correctly reproduce the bug)

## How to verify the fix

1. Same setup as above
2. After the fix: the dialog shows a scrollbar when `maxHeight` is active; all content remains accessible via scroll
3. At normal (desktop) viewport: behavior is identical to before — no visible regression
4. With `Popover.Arrow`: the arrow tip remains visible thanks to `overflow-clip-margin: 12px`


Thanks!