### PR TITLE
fix(styles): render separators in-flow so they no longer collapse to a stray line

### DIFF
--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -73,7 +73,7 @@
 
 .button-group__separator {
   @apply rounded-sm bg-current opacity-15;
-  position: absolute;
+  flex: none;
   pointer-events: none;
 
   /**
@@ -85,16 +85,12 @@
 
   /* Horizontal orientation - vertical divider */
   .button-group--horizontal & {
-    left: -1px;
-    top: 25%;
     width: 1px;
     height: 50%;
   }
 
   /* Vertical orientation - horizontal divider */
   .button-group--vertical & {
-    left: 25%;
-    top: -1px;
     width: 50%;
     height: 1px;
   }

--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -85,12 +85,14 @@
 
   /* Horizontal orientation - vertical divider */
   .button-group--horizontal & {
+    margin-inline-start: -1px;
     width: 1px;
     height: 50%;
   }
 
   /* Vertical orientation - horizontal divider */
   .button-group--vertical & {
+    margin-block-start: -1px;
     width: 50%;
     height: 1px;
   }

--- a/packages/styles/components/toggle-button-group.css
+++ b/packages/styles/components/toggle-button-group.css
@@ -90,7 +90,7 @@
 
 .toggle-button-group__separator {
   @apply rounded-sm bg-current opacity-15;
-  position: absolute;
+  flex: none;
   pointer-events: none;
 
   /**
@@ -102,16 +102,12 @@
 
   /* Horizontal orientation - vertical divider */
   .toggle-button-group--horizontal & {
-    left: -1px;
-    top: 25%;
     width: 1px;
     height: 50%;
   }
 
   /* Vertical orientation - horizontal divider */
   .toggle-button-group--vertical & {
-    left: 25%;
-    top: -1px;
     width: 50%;
     height: 1px;
   }

--- a/packages/styles/components/toggle-button-group.css
+++ b/packages/styles/components/toggle-button-group.css
@@ -102,12 +102,14 @@
 
   /* Horizontal orientation - vertical divider */
   .toggle-button-group--horizontal & {
+    margin-inline-start: -1px;
     width: 1px;
     height: 50%;
   }
 
   /* Vertical orientation - horizontal divider */
   .toggle-button-group--vertical & {
+    margin-block-start: -1px;
     width: 50%;
     height: 1px;
   }


### PR DESCRIPTION
Closes #6680

## 📝 Description

`<ButtonGroup.Separator>` / `<ToggleButtonGroup.Separator>` render as a single stray ~1px vertical line on the nearest positioned ancestor instead of as dividers between the buttons. This renders the separator in-flow so it lands in the gap between the buttons.

**Before / after** — `ButtonGroup`/`ToggleButtonGroup` with separators inside a `position: relative` Card:
<img width="816" height="568" alt="图片" src="https://github.com/user-attachments/assets/99b57056-04df-47ae-b000-05cf8011ca05" />

## ⛳️ Current behavior (the bug)

The separator is a `<span data-slot="*-separator">` that is a **sibling** of the buttons inside the group, styled (horizontal orientation):

```css
.button-group__separator {
  position: absolute;
  left: -1px;
  top: 25%;
  width: 1px;
  height: 50%;
}
```

`position: absolute; left: -1px` only lands on the segment boundary if the separator's offset parent is the adjacent button (or a per-segment `position: relative` wrapper). Neither exists:

- The group base (`.button-group` / `.toggle-button-group`) is `inline-flex … gap-0` with **no `position: relative`**, so it is not a positioning context.
- The buttons are `position: relative`, but the separator is their **sibling**, not a descendant, so the buttons' positioning context does not apply to it.

With no anchor, each separator's offset parent bubbles up to the nearest positioned ancestor. When the group sits inside a `position: relative` container (a Card, popover, toolbar — usually positioned), every separator collapses onto that container's left edge at `left: -1px`, stacking into one stray vertical line, and no dividers appear between the buttons.

### Reproduction

Any `ButtonGroup` / `ToggleButtonGroup` with `.Separator` placed inside a positioned ancestor:

```tsx
import { Button, ButtonGroup } from "@heroui/react";

export default function Repro() {
  return (
    // Any `position: relative` ancestor triggers it (Cards/popovers/toolbars usually are).
    <div style={{ position: "relative", padding: 24, border: "1px solid #ccc" }}>
      <ButtonGroup>
        <Button>Light</Button>
        <ButtonGroup.Separator />
        <Button>Dark</Button>
        <ButtonGroup.Separator />
        <Button>System</Button>
      </ButtonGroup>
    </div>
  );
}
```

- **Expected:** thin dividers between `Light │ Dark │ System`.
- **Actual:** no dividers between the buttons; a single ~1px vertical line on the **left edge of the `position: relative` wrapper**.

`ToggleButtonGroup` behaves the same; in vertical orientation the separators collapse onto the wrapper's **top** edge (via `top: -1px`).

## 🚀 New behavior (the fix)

Render the separator as an **in-flow flex item**. It already sits in the gap between the buttons in the DOM, so dropping `position: absolute` (and the `left/top: -1px` offsets) lets flexbox place it there, cross-centered by the group's `items-center`. `width`/`height` keep the 1px × 50% divider (50% × 1px for vertical); `flex: none` keeps it 1px when full-width buttons grow.

Verified across horizontal / vertical / full-width / RTL — the old physical `left: -1px` was also RTL-incorrect, whereas the in-flow version has no physical offset. Applies to both `ButtonGroup` and `ToggleButtonGroup`; `ToggleButtonGroup` detached mode still hides separators.

> Note: adding `position: relative` to the group alone would **not** fix it — all separators (each at `left: -1px`) would then stack on the group's own left edge.

## 💣 Is this a breaking change (Yes/No):

No. Visual-only fix; the `ButtonGroup.Separator` / `ToggleButtonGroup.Separator` API is unchanged. The only layout change is that an attached-mode separator now occupies 1px of in-flow space (the divider itself) instead of being a zero-space overlay.

## 📝 Additional Information

Verified on `@heroui/styles` 3.2.1 / `v3` branch HEAD.
