### PR TITLE
feat(docs): order release badges by date, newest first

### DIFF
--- a/apps/docs/src/app/[lang]/(home)/components/release-badges.tsx
+++ b/apps/docs/src/app/[lang]/(home)/components/release-badges.tsx
@@ -3,11 +3,13 @@
 import {Rocket} from "@gravity-ui/icons";
 import LinkRoot from "fumadocs-core/link";
 import {AnimatePresence, animate, motion, useMotionValue, useReducedMotion} from "motion/react";
-import {useEffect, useState} from "react";
+import {useEffect, useMemo, useState} from "react";
 
 interface ReleaseBadge {
   label: string;
   href: string;
+  /** ISO date string (e.g. "2026-06-30") used to order badges newest-first. */
+  date?: string;
 }
 
 interface ReleaseBadgesProps {
@@ -38,7 +40,23 @@ export function ReleaseBadges({badges, intervalMs = 5000}: ReleaseBadgesProps) {
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(false);
   const progress = useMotionValue(0);
-  const count = badges.length;
+
+  // Order badges newest-first so the latest release is shown first. Badges
+  // without a valid date sink to the bottom while preserving their relative
+  // order (stable sort).
+  const sortedBadges = useMemo(() => {
+    const toTime = (badge: ReleaseBadge): number => {
+      if (!badge.date) return Number.NEGATIVE_INFINITY;
+
+      const time = new Date(badge.date).getTime();
+
+      return Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time;
+    };
+
+    return [...badges].sort((a, b) => toTime(b) - toTime(a));
+  }, [badges]);
+
+  const count = sortedBadges.length;
 
   // Autoplay: drive a single progress value (transform-only fill) and advance
   // on completion. Stopping retains the value, so hover/focus pause + resume
@@ -69,13 +87,13 @@ export function ReleaseBadges({badges, intervalMs = 5000}: ReleaseBadgesProps) {
 
   // Single highlight: render the plain badge (no carousel chrome).
   if (count === 1) {
-    const [only] = badges;
+    const [only] = sortedBadges;
 
     return only ? <BadgePill badge={only} /> : null;
   }
 
   const activeIndex = index % count;
-  const active = badges[activeIndex];
+  const active = sortedBadges[activeIndex];
 
   if (!active) return null;
 

--- a/apps/docs/src/lib/dictionaries/cn.json
+++ b/apps/docs/src/lib/dictionaries/cn.json
@@ -3,11 +3,13 @@
     "releaseBadges": [
       {
         "label": "HeroUI React v3.2.1 — 补丁版本",
-        "href": "/docs/react/releases/v3-2-1"
+        "href": "/docs/react/releases/v3-2-1",
+        "date": "2026-06-24"
       },
       {
         "label": "HeroUI Native v1.0.5 — patch release",
-        "href": "/docs/native/releases/v1-0-5"
+        "href": "/docs/native/releases/v1-0-5",
+        "date": "2026-07-02"
       }
     ],
     "titleMain": "开箱即用",

--- a/apps/docs/src/lib/dictionaries/en.json
+++ b/apps/docs/src/lib/dictionaries/en.json
@@ -3,11 +3,13 @@
     "releaseBadges": [
       {
         "label": "HeroUI React v3.2.1 — patch release",
-        "href": "/docs/react/releases/v3-2-1"
+        "href": "/docs/react/releases/v3-2-1",
+        "date": "2026-06-24"
       },
       {
         "label": "HeroUI Native v1.0.5 — patch release",
-        "href": "/docs/native/releases/v1-0-5"
+        "href": "/docs/native/releases/v1-0-5",
+        "date": "2026-07-02"
       }
     ],
     "titleMain": "Beautiful by default.",


### PR DESCRIPTION
## 📝 Description

Adds an optional `date` field to the home page release badges and sorts them newest-first, so the latest release is always shown first. Updates the English and Chinese dictionaries to include release dates.

## ⛳️ Current behavior (updates)

Release badges render in their raw dictionary order regardless of when each release shipped.

## 🚀 New behavior

- Adds an optional ISO `date` field to the `ReleaseBadge` interface
- Sorts badges newest-first using a memoized stable sort
- Badges without a valid date sink to the bottom while keeping relative order
- Populates release dates in `en.json` and `cn.json`

## 💣 Is this a breaking change (Yes/No):

**No** - The `date` field is optional and existing badges without it continue to render.

## 📝 Additional Information

Changes are docs-only (home page badges component and dictionary files). Verified via the sort logic that invalid/missing dates fall back to `NEGATIVE_INFINITY` and are ordered last.