### PR TITLE
refactor(react): migrate to React 19 APIs and fix array-index keys

### DIFF
--- a/packages/react/src/components/accordion/accordion.stories.tsx
+++ b/packages/react/src/components/accordion/accordion.stories.tsx
@@ -38,8 +38,8 @@ const Wrapper = ({children, className}: {children: React.ReactNode; className?: 
 const Template = (props: Accordion["RootProps"]) => (
   <Wrapper>
     <Accordion {...props}>
-      {items.map((item, index) => (
-        <Accordion.Item key={index}>
+      {items.map((item) => (
+        <Accordion.Item key={item.title}>
           <Accordion.Heading>
             <Accordion.Trigger>
               {item.icon ? (
@@ -75,8 +75,8 @@ const CustomTemplate = (props: Accordion["RootProps"]) => (
             <p className="text-md mb-2 font-medium text-muted">{category.title}</p>
             <div key={category.title}>
               <Accordion {...props} className="w-full" variant="surface">
-                {category.items.map((item, index) => (
-                  <Accordion.Item key={index}>
+                {category.items.map((item) => (
+                  <Accordion.Item key={item.title}>
                     <Accordion.Heading>
                       <Accordion.Trigger>
                         {item.title}
@@ -135,8 +135,8 @@ export const Custom = {
 const WithoutSeparatorTemplate = ({hideSeparator = true, ...props}: Accordion["RootProps"]) => (
   <Wrapper>
     <Accordion hideSeparator={hideSeparator} {...props}>
-      {items.map((item, index) => (
-        <Accordion.Item key={index}>
+      {items.map((item) => (
+        <Accordion.Item key={item.title}>
           <Accordion.Heading>
             <Accordion.Trigger>
               {item.icon ? (

--- a/packages/react/src/components/accordion/accordion.tsx
+++ b/packages/react/src/components/accordion/accordion.tsx
@@ -6,7 +6,7 @@ import type {AccordionVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {accordionVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button} from "react-aria-components/Button";
 import {
   Disclosure,
@@ -72,7 +72,7 @@ const AccordionRoot = ({
 interface AccordionItemProps extends ComponentPropsWithRef<typeof Disclosure> {}
 
 const AccordionItem = ({className, ...props}: AccordionItemProps) => {
-  const {hideSeparator, slots} = useContext(AccordionContext);
+  const {hideSeparator, slots} = use(AccordionContext);
 
   return (
     <Disclosure
@@ -102,8 +102,8 @@ const AccordionIndicator = <E extends keyof React.JSX.IntrinsicElements = "svg">
   ...props
 }: AccordionIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof AccordionIndicatorProps<E>>) => {
-  const {slots} = useContext(AccordionContext);
-  const {isExpanded} = useContext(DisclosureStateContext)!;
+  const {slots} = use(AccordionContext);
+  const {isExpanded} = use(DisclosureStateContext)!;
 
   if (children && React.isValidElement(children)) {
     return React.cloneElement(
@@ -139,7 +139,7 @@ interface AccordionHeadingProps extends ComponentPropsWithRef<typeof DisclosureH
 }
 
 const AccordionHeading = ({className, ...props}: AccordionHeadingProps) => {
-  const {slots} = useContext(AccordionContext);
+  const {slots} = use(AccordionContext);
 
   return (
     <DisclosureHeading
@@ -156,7 +156,7 @@ const AccordionHeading = ({className, ...props}: AccordionHeadingProps) => {
 interface AccordionTriggerProps extends ComponentPropsWithRef<typeof Button> {}
 
 const AccordionTrigger = ({className, ...props}: AccordionTriggerProps) => {
-  const {slots} = useContext(AccordionContext);
+  const {slots} = use(AccordionContext);
 
   return (
     <Button
@@ -187,7 +187,7 @@ const AccordionBody = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: AccordionBodyProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof AccordionBodyProps<E>>) => {
-  const {slots} = useContext(AccordionContext);
+  const {slots} = use(AccordionContext);
 
   return (
     <dom.div className={slots?.body({})} data-slot="accordion-body" {...(props as any)}>
@@ -202,8 +202,8 @@ const AccordionBody = <E extends keyof React.JSX.IntrinsicElements = "div">({
 interface AccordionPanelProps extends ComponentPropsWithRef<typeof DisclosurePanel> {}
 
 const AccordionPanel = ({children, className, ...props}: AccordionPanelProps) => {
-  const {slots} = useContext(AccordionContext);
-  const {isExpanded} = useContext(DisclosureStateContext)!;
+  const {slots} = use(AccordionContext);
+  const {isExpanded} = use(DisclosureStateContext)!;
 
   return (
     <DisclosurePanel

--- a/packages/react/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/alert-dialog/alert-dialog.tsx
@@ -7,7 +7,7 @@ import type {ButtonProps as ButtonPrimitiveProps} from "react-aria-components/Bu
 import type {DialogProps as DialogPrimitiveProps} from "react-aria-components/Dialog";
 
 import {alertDialogVariants} from "@heroui/styles";
-import {createContext, useContext, useMemo} from "react";
+import {createContext, use, useMemo} from "react";
 import {
   DialogTrigger as AlertDialogTriggerPrimitive,
   Dialog as DialogPrimitive,
@@ -64,7 +64,7 @@ const AlertDialogRoot = ({children, ...props}: AlertDialogRootProps) => {
 interface AlertDialogTriggerProps extends HTMLAttributes<HTMLDivElement> {}
 
 const AlertDialogTrigger = ({children, className, ...props}: AlertDialogTriggerProps) => {
-  const {slots} = useContext(AlertDialogContext);
+  const {slots} = use(AlertDialogContext);
 
   return (
     <PressablePrimitive>
@@ -108,7 +108,7 @@ const AlertDialogBackdrop = ({
   variant,
   ...props
 }: AlertDialogBackdropProps) => {
-  const {slots: contextSlots} = useContext(AlertDialogContext);
+  const {slots: contextSlots} = use(AlertDialogContext);
 
   const updatedSlots = useMemo(() => alertDialogVariants({variant}), [variant]);
 
@@ -160,7 +160,7 @@ const AlertDialogContainer = ({
   size,
   ...props
 }: AlertDialogContainerProps) => {
-  const {slots: contextSlots} = useContext(AlertDialogContext);
+  const {slots: contextSlots} = use(AlertDialogContext);
 
   const updatedSlots = useMemo(() => alertDialogVariants({size}), [size]);
 
@@ -191,7 +191,7 @@ const AlertDialogContainer = ({
 interface AlertDialogDialogProps extends DialogPrimitiveProps {}
 
 const AlertDialogDialog = ({children, className, ...props}: AlertDialogDialogProps) => {
-  const {placement, slots} = useContext(AlertDialogContext);
+  const {placement, slots} = use(AlertDialogContext);
 
   return (
     <DialogPrimitive
@@ -212,7 +212,7 @@ const AlertDialogDialog = ({children, className, ...props}: AlertDialogDialogPro
 interface AlertDialogHeaderProps extends HTMLAttributes<HTMLDivElement> {}
 
 const AlertDialogHeader = ({children, className, ...props}: AlertDialogHeaderProps) => {
-  const {slots} = useContext(AlertDialogContext);
+  const {slots} = use(AlertDialogContext);
 
   return (
     <div
@@ -231,7 +231,7 @@ const AlertDialogHeader = ({children, className, ...props}: AlertDialogHeaderPro
 interface AlertDialogHeadingProps extends ComponentPropsWithRef<typeof HeadingPrimitive> {}
 
 const AlertDialogHeading = ({children, className, ...props}: AlertDialogHeadingProps) => {
-  const {slots} = useContext(AlertDialogContext);
+  const {slots} = use(AlertDialogContext);
 
   return (
     <HeadingPrimitive
@@ -251,7 +251,7 @@ const AlertDialogHeading = ({children, className, ...props}: AlertDialogHeadingP
 interface AlertDialogBodyProps extends HTMLAttributes<HTMLDivElement> {}
 
 const AlertDialogBody = ({children, className, ...props}: AlertDialogBodyProps) => {
-  const {slots} = useContext(AlertDialogContext);
+  const {slots} = use(AlertDialogContext);
 
   return (
     <div
@@ -270,7 +270,7 @@ const AlertDialogBody = ({children, className, ...props}: AlertDialogBodyProps) 
 interface AlertDialogFooterProps extends HTMLAttributes<HTMLDivElement> {}
 
 const AlertDialogFooter = ({children, className, ...props}: AlertDialogFooterProps) => {
-  const {slots} = useContext(AlertDialogContext);
+  const {slots} = use(AlertDialogContext);
 
   return (
     <div
@@ -337,7 +337,7 @@ const AlertDialogIcon = <E extends keyof React.JSX.IntrinsicElements = "div">({
 interface AlertDialogCloseTriggerProps extends ButtonPrimitiveProps {}
 
 const AlertDialogCloseTrigger = ({className, ...rest}: AlertDialogCloseTriggerProps) => {
-  const {slots} = useContext(AlertDialogContext);
+  const {slots} = use(AlertDialogContext);
 
   return (
     <CloseButton

--- a/packages/react/src/components/alert/alert.tsx
+++ b/packages/react/src/components/alert/alert.tsx
@@ -6,7 +6,7 @@ import type {AlertVariants} from "@heroui/styles";
 import type {ReactNode} from "react";
 
 import {alertVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 
 import {composeSlotClassName} from "../../utils/compose";
 import {dom} from "../../utils/dom";
@@ -73,7 +73,7 @@ const AlertIndicator = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...rest
 }: AlertIndicatorProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof AlertIndicatorProps<E>>) => {
-  const {slots, status} = useContext(AlertContext);
+  const {slots, status} = use(AlertContext);
 
   // Map status to default icons
   const getDefaultIcon = () => {
@@ -117,7 +117,7 @@ const AlertContent = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...rest
 }: AlertContentProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof AlertContentProps<E>>) => {
-  const {slots} = useContext(AlertContext);
+  const {slots} = use(AlertContext);
 
   return (
     <dom.div
@@ -146,7 +146,7 @@ const AlertTitle = <E extends keyof React.JSX.IntrinsicElements = "p">({
   className,
   ...rest
 }: AlertTitleProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof AlertTitleProps<E>>) => {
-  const {slots} = useContext(AlertContext);
+  const {slots} = use(AlertContext);
 
   return (
     <dom.p
@@ -175,7 +175,7 @@ const AlertDescription = <E extends keyof React.JSX.IntrinsicElements = "span">(
   ...rest
 }: AlertDescriptionProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof AlertDescriptionProps<E>>) => {
-  const {slots} = useContext(AlertContext);
+  const {slots} = use(AlertContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -8,7 +8,7 @@ import type {ComponentPropsWithRef, ReactNode, RefObject} from "react";
 
 import {autocompleteVariants} from "@heroui/styles";
 import {mergeRefs, useResizeObserver} from "@react-aria/utils";
-import React, {createContext, useCallback, useContext, useRef, useState} from "react";
+import React, {createContext, use, useCallback, useRef, useState} from "react";
 import {Autocomplete as AutocompletePrimitive} from "react-aria-components/Autocomplete";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Dialog as DialogPrimitive} from "react-aria-components/Dialog";
@@ -88,51 +88,51 @@ const AutocompleteRoot = <T extends object = object, M extends "single" | "multi
  * -----------------------------------------------------------------------------------------------*/
 interface AutocompleteTriggerProps extends ComponentPropsWithRef<typeof GroupPrimitive> {}
 
-const AutocompleteTrigger = React.forwardRef<HTMLDivElement, AutocompleteTriggerProps>(
-  ({children, className, isDisabled: isDisabledProp, onClick, ...props}, ref) => {
-    const {
-      clearButtonRef,
-      isDisabled: rootDisabled,
-      slots,
-      triggerRef,
-    } = useContext(AutocompleteContext);
-    const state = useContext(SelectStateContext);
-    const isDisabled = isDisabledProp ?? rootDisabled ?? false;
+const AutocompleteTrigger = ({
+  children,
+  className,
+  isDisabled: isDisabledProp,
+  onClick,
+  ref,
+  ...props
+}: AutocompleteTriggerProps) => {
+  const {clearButtonRef, isDisabled: rootDisabled, slots, triggerRef} = use(AutocompleteContext);
+  const state = use(SelectStateContext);
+  const isDisabled = isDisabledProp ?? rootDisabled ?? false;
 
-    // Callback ref to update context ref
-    const contextRefCallback = React.useCallback(
-      (node: HTMLDivElement | null) => {
-        triggerRef.current = node;
-      },
-      [triggerRef],
-    );
+  // Callback ref to update context ref
+  const contextRefCallback = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      triggerRef.current = node;
+    },
+    [triggerRef],
+  );
 
-    // Merge context ref callback with user-provided ref
-    const mergedRef = mergeRefs(contextRefCallback, ref);
+  // Merge context ref callback with user-provided ref
+  const mergedRef = mergeRefs(contextRefCallback, ref);
 
-    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-      // Don't toggle if clicking the clear button
-      if (clearButtonRef.current?.contains(e.target as Node)) {
-        return;
-      }
-      onClick?.(e);
-      state?.toggle();
-    };
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Don't toggle if clicking the clear button
+    if (clearButtonRef.current?.contains(e.target as Node)) {
+      return;
+    }
+    onClick?.(e);
+    state?.toggle();
+  };
 
-    return (
-      <GroupPrimitive
-        ref={mergedRef}
-        className={composeTwRenderProps(className, slots?.trigger())}
-        data-slot="autocomplete-trigger"
-        isDisabled={isDisabled}
-        onClick={handleClick}
-        {...props}
-      >
-        {(values) => <>{typeof children === "function" ? children(values) : children}</>}
-      </GroupPrimitive>
-    );
-  },
-);
+  return (
+    <GroupPrimitive
+      ref={mergedRef}
+      className={composeTwRenderProps(className, slots?.trigger())}
+      data-slot="autocomplete-trigger"
+      isDisabled={isDisabled}
+      onClick={handleClick}
+      {...props}
+    >
+      {(values) => <>{typeof children === "function" ? children(values) : children}</>}
+    </GroupPrimitive>
+  );
+};
 
 AutocompleteTrigger.displayName = "AutocompleteTrigger";
 
@@ -142,7 +142,7 @@ AutocompleteTrigger.displayName = "AutocompleteTrigger";
 interface AutocompleteValueProps extends ComponentPropsWithRef<typeof SelectValuePrimitive> {}
 
 const AutocompleteValue = ({children, className, ...props}: AutocompleteValueProps) => {
-  const {slots} = useContext(AutocompleteContext);
+  const {slots} = use(AutocompleteContext);
 
   return (
     <SelectValuePrimitive
@@ -171,8 +171,8 @@ const AutocompleteIndicator = <E extends keyof React.JSX.IntrinsicElements = "sv
   ...props
 }: AutocompleteIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof AutocompleteIndicatorProps<E>>) => {
-  const {slots} = useContext(AutocompleteContext);
-  const state = useContext(SelectStateContext);
+  const {slots} = use(AutocompleteContext);
+  const state = use(SelectStateContext);
 
   if (children && React.isValidElement(children)) {
     return React.cloneElement(
@@ -219,7 +219,7 @@ const AutocompletePopover = ({
   style,
   ...props
 }: AutocompletePopoverProps) => {
-  const {slots, triggerRef} = useContext(AutocompleteContext);
+  const {slots, triggerRef} = use(AutocompleteContext);
   const [triggerWidth, setTriggerWidth] = useState<string | null>(null);
 
   const onResize = useCallback(() => {
@@ -287,8 +287,8 @@ const AutocompleteClearButton = <E extends keyof React.JSX.IntrinsicElements = "
   ...props
 }: AutocompleteClearButtonProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof AutocompleteClearButtonProps<E>>) => {
-  const {clearButtonRef, isDisabled, onClear, slots} = useContext(AutocompleteContext);
-  const state = useContext(SelectStateContext);
+  const {clearButtonRef, isDisabled, onClear, slots} = use(AutocompleteContext);
+  const state = use(SelectStateContext);
 
   const clearButtonRefCallback = React.useCallback(
     (node: HTMLButtonElement | null) => {

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -52,7 +52,7 @@ const AvatarImage = ({
   srcSet,
   ...props
 }: AvatarImageProps) => {
-  const {slots} = React.useContext(AvatarContext);
+  const {slots} = React.use(AvatarContext);
 
   return (
     <AvatarPrimitive.Image
@@ -77,7 +77,7 @@ interface AvatarFallbackProps extends ComponentPropsWithRef<typeof AvatarPrimiti
 }
 
 const AvatarFallback = ({className, color, ...props}: AvatarFallbackProps) => {
-  const {slots} = React.useContext(AvatarContext);
+  const {slots} = React.use(AvatarContext);
 
   return (
     <AvatarPrimitive.Fallback

--- a/packages/react/src/components/badge/badge.tsx
+++ b/packages/react/src/components/badge/badge.tsx
@@ -5,7 +5,7 @@ import type {BadgeVariants} from "@heroui/styles";
 import type {ReactNode} from "react";
 
 import {badgeVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {cx} from "tailwind-variants";
 
 import {composeSlotClassName} from "../../utils/compose";
@@ -114,7 +114,7 @@ const BadgeLabel = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: BadgeLabelProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof BadgeLabelProps<E>>) => {
-  const {slots} = useContext(BadgeContext);
+  const {slots} = use(BadgeContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/react/src/components/breadcrumbs/breadcrumbs.tsx
@@ -5,7 +5,7 @@ import type {BreadcrumbsVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {breadcrumbsVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   Breadcrumb as BreadcrumbPrimitive,
   Breadcrumbs as BreadcrumbsPrimitive,
@@ -59,7 +59,7 @@ const BreadcrumbsItem = ({
   className,
   ...props
 }: BreadcrumbsItemProps & Omit<LinkProps, "className">) => {
-  const {separator, slots} = useContext(BreadcrumbsContext);
+  const {separator, slots} = use(BreadcrumbsContext);
 
   const renderSeparator = () => {
     if (!separator)

--- a/packages/react/src/components/button-group/button-group.tsx
+++ b/packages/react/src/components/button-group/button-group.tsx
@@ -6,7 +6,7 @@ import type {ButtonGroupVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {buttonGroupVariants} from "@heroui/styles";
-import React, {Children, createContext, isValidElement, useContext} from "react";
+import React, {Children, createContext, isValidElement, use} from "react";
 import {Group} from "react-aria-components/Group";
 import {useSlottedContext} from "react-aria-components/slots";
 import {ToggleButtonGroupContext as RACToggleButtonGroupContext} from "react-aria-components/ToggleButtonGroup";
@@ -101,7 +101,7 @@ const ButtonGroupSeparator = <E extends keyof React.JSX.IntrinsicElements = "spa
   ...props
 }: ButtonGroupSeparatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ButtonGroupSeparatorProps<E>>) => {
-  const {slots} = useContext(ButtonGroupContext);
+  const {slots} = use(ButtonGroupContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -4,7 +4,7 @@ import type {ButtonVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {buttonVariants} from "@heroui/styles";
-import {useContext} from "react";
+import {use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 
 import {composeTwRenderProps} from "../../utils";
@@ -30,7 +30,7 @@ const ButtonRoot = ({
   [BUTTON_GROUP_CHILD]: isButtonGroupChild,
   ...rest
 }: ButtonRootProps) => {
-  const buttonGroupContext = useContext(ButtonGroupContext);
+  const buttonGroupContext = use(ButtonGroupContext);
 
   // Only use context if this button is a direct child of ButtonGroup
   const shouldUseContext = isButtonGroupChild === true;

--- a/packages/react/src/components/calendar-year-picker/calendar-year-picker.tsx
+++ b/packages/react/src/components/calendar-year-picker/calendar-year-picker.tsx
@@ -64,7 +64,7 @@ const CalendarYearPickerTriggerContext =
   React.createContext<CalendarYearPickerTriggerContextValue | null>(null);
 
 function useCalendarYearPickerTriggerContext(): CalendarYearPickerTriggerContextValue {
-  const context = React.useContext(CalendarYearPickerTriggerContext);
+  const context = React.use(CalendarYearPickerTriggerContext);
 
   if (!context) {
     throw new Error(
@@ -255,7 +255,7 @@ const CalendarYearPickerGridContext =
   React.createContext<CalendarYearPickerGridContextValue | null>(null);
 
 function useCalendarYearPickerGridContext(): CalendarYearPickerGridContextValue {
-  const context = React.useContext(CalendarYearPickerGridContext);
+  const context = React.use(CalendarYearPickerGridContext);
 
   if (!context) {
     throw new Error("CalendarYearPicker components must be used within <CalendarYearPicker.Grid>.");

--- a/packages/react/src/components/calendar-year-picker/use-calendar-state.ts
+++ b/packages/react/src/components/calendar-year-picker/use-calendar-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import {useContext} from "react";
+import {use} from "react";
 import {CalendarStateContext} from "react-aria-components/Calendar";
 import {RangeCalendarStateContext} from "react-aria-components/RangeCalendar";
 
@@ -9,8 +9,8 @@ import {RangeCalendarStateContext} from "react-aria-components/RangeCalendar";
  * Must be used inside <Calendar> or <RangeCalendar>.
  */
 function useCalendarOrRangeState() {
-  const calendarState = useContext(CalendarStateContext);
-  const rangeCalendarState = useContext(RangeCalendarStateContext);
+  const calendarState = use(CalendarStateContext);
+  const rangeCalendarState = use(RangeCalendarStateContext);
   const state = calendarState ?? rangeCalendarState;
 
   if (!state) {

--- a/packages/react/src/components/calendar-year-picker/year-picker-context.ts
+++ b/packages/react/src/components/calendar-year-picker/year-picker-context.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import {createContext, useContext} from "react";
+import {createContext, use} from "react";
 
 /* -------------------------------------------------------------------------------------------------
  * YearPickerContext
@@ -23,7 +23,7 @@ const YearPickerContext = createContext<YearPickerContextValue | null>(null);
  * Must be used inside Calendar or RangeCalendar.
  */
 function useYearPicker(): YearPickerContextValue {
-  const context = useContext(YearPickerContext);
+  const context = use(YearPickerContext);
 
   if (!context) {
     throw new Error("useYearPicker must be used within a <Calendar> or <RangeCalendar> component.");

--- a/packages/react/src/components/calendar/calendar.tsx
+++ b/packages/react/src/components/calendar/calendar.tsx
@@ -13,7 +13,7 @@ import type {
 import {calendarVariants} from "@heroui/styles";
 import {CalendarDate, DateFormatter, createCalendar} from "@internationalized/date";
 import {useControlledState} from "@react-stately/utils";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {
   CalendarCell as CalendarCellPrimitive,
@@ -169,7 +169,7 @@ const CalendarHeader = <E extends keyof React.JSX.IntrinsicElements = "header">(
   className,
   ...props
 }: CalendarHeaderProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof CalendarHeaderProps<E>>) => {
-  const {slots} = useContext(CalendarContext);
+  const {slots} = use(CalendarContext);
 
   return (
     <dom.header
@@ -190,7 +190,7 @@ CalendarHeader.displayName = "HeroUI.Calendar.Header";
 interface CalendarHeadingProps extends ComponentPropsWithRef<typeof CalendarHeadingPrimitive> {}
 
 const CalendarHeading = ({className, ...props}: CalendarHeadingProps) => {
-  const {slots} = useContext(CalendarContext);
+  const {slots} = use(CalendarContext);
 
   return (
     <CalendarHeadingPrimitive
@@ -211,7 +211,7 @@ interface CalendarNavButtonProps extends ComponentPropsWithRef<typeof ButtonPrim
 }
 
 const CalendarNavButton = ({children, className, slot, ...props}: CalendarNavButtonProps) => {
-  const {slots} = useContext(CalendarContext);
+  const {slots} = use(CalendarContext);
 
   return (
     <ButtonPrimitive
@@ -249,7 +249,7 @@ const CalendarGrid = ({
   weekdayStyle = "short",
   ...props
 }: CalendarGridProps) => {
-  const calendarContext = useContext(CalendarContext);
+  const calendarContext = use(CalendarContext);
   const {dayView, slots} = calendarContext;
   const contextValue = React.useMemo(
     () => ({
@@ -283,7 +283,7 @@ interface CalendarGridHeaderProps extends ComponentPropsWithRef<
 > {}
 
 const CalendarGridHeader = ({children, className, ...props}: CalendarGridHeaderProps) => {
-  const {dayView, slots} = useContext(CalendarContext);
+  const {dayView, slots} = use(CalendarContext);
 
   if (dayView && dayView.days >= 7 && typeof children === "function") {
     return (
@@ -319,7 +319,7 @@ CalendarGridHeader.displayName = "HeroUI.Calendar.GridHeader";
 interface CalendarGridBodyProps extends ComponentPropsWithRef<typeof CalendarGridBodyPrimitive> {}
 
 const CalendarGridBody = ({children, className, ...props}: CalendarGridBodyProps) => {
-  const {dayView, slots} = useContext(CalendarContext);
+  const {dayView, slots} = use(CalendarContext);
 
   if (dayView && dayView.days >= 7 && typeof children === "function") {
     return (
@@ -355,7 +355,7 @@ interface CalendarHeaderCellProps extends ComponentPropsWithRef<
 > {}
 
 const CalendarHeaderCell = ({className, ...props}: CalendarHeaderCellProps) => {
-  const {slots} = useContext(CalendarContext);
+  const {slots} = use(CalendarContext);
 
   return (
     <CalendarHeaderCellPrimitive
@@ -374,7 +374,7 @@ CalendarHeaderCell.displayName = "HeroUI.Calendar.HeaderCell";
 interface CalendarCellProps extends ComponentPropsWithRef<typeof CalendarCellPrimitive> {}
 
 const CalendarCell = ({children, className, ...props}: CalendarCellProps) => {
-  const {slots} = useContext(CalendarContext);
+  const {slots} = use(CalendarContext);
 
   return (
     <CalendarCellPrimitive
@@ -408,7 +408,7 @@ const CalendarCellIndicator = <E extends keyof React.JSX.IntrinsicElements = "sp
   ...props
 }: CalendarCellIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof CalendarCellIndicatorProps<E>>) => {
-  const {slots} = useContext(CalendarContext);
+  const {slots} = use(CalendarContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/card/card.tsx
+++ b/packages/react/src/components/card/card.tsx
@@ -6,7 +6,7 @@ import type {CardVariants} from "@heroui/styles";
 import type {ReactNode} from "react";
 
 import {cardVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 
 import {composeSlotClassName} from "../../utils/compose";
 import {dom} from "../../utils/dom";
@@ -80,7 +80,7 @@ const CardHeader = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: CardHeaderProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof CardHeaderProps<E>>) => {
-  const {slots} = useContext(CardContext);
+  const {slots} = use(CardContext);
 
   return (
     <dom.div
@@ -107,7 +107,7 @@ const CardTitle = <E extends keyof React.JSX.IntrinsicElements = "h3">({
   className,
   ...props
 }: CardTitleProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof CardTitleProps<E>>) => {
-  const {slots} = useContext(CardContext);
+  const {slots} = use(CardContext);
 
   return (
     <dom.h3
@@ -136,7 +136,7 @@ const CardDescription = <E extends keyof React.JSX.IntrinsicElements = "p">({
   ...props
 }: CardDescriptionProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof CardDescriptionProps<E>>) => {
-  const {slots} = useContext(CardContext);
+  const {slots} = use(CardContext);
 
   return (
     <dom.p
@@ -163,7 +163,7 @@ const CardContent = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: CardContentProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof CardContentProps<E>>) => {
-  const {slots} = useContext(CardContext);
+  const {slots} = use(CardContext);
 
   return (
     <dom.div
@@ -188,7 +188,7 @@ const CardFooter = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: CardFooterProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof CardFooterProps<E>>) => {
-  const {slots} = useContext(CardContext);
+  const {slots} = use(CardContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -9,7 +9,7 @@ import type {
 } from "react-aria-components/Checkbox";
 
 import {checkboxVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   CheckboxButton as CheckboxButtonPrimitive,
   CheckboxField as CheckboxFieldPrimitive,
@@ -36,7 +36,7 @@ interface CheckboxRootProps
 }
 
 const CheckboxRoot = ({children, className, variant, ...props}: CheckboxRootProps) => {
-  const checkboxGroupContext = useContext(CheckboxGroupContext);
+  const checkboxGroupContext = use(CheckboxGroupContext);
   const effectiveVariant = variant ?? checkboxGroupContext.variant;
   const slots = React.useMemo(
     () => checkboxVariants({variant: effectiveVariant}),
@@ -67,7 +67,7 @@ CheckboxRoot.displayName = "HeroUI.Checkbox";
 interface CheckboxContentProps extends ComponentPropsWithRef<typeof CheckboxButtonPrimitive> {}
 
 const CheckboxContent = ({children, className, ...props}: CheckboxContentProps) => {
-  const {slots} = useContext(CheckboxContext);
+  const {slots} = use(CheckboxContext);
 
   return (
     <CheckboxButtonPrimitive
@@ -97,7 +97,7 @@ const CheckboxControl = <E extends keyof React.JSX.IntrinsicElements = "span">({
   ...props
 }: CheckboxControlProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof CheckboxControlProps<E>>) => {
-  const {slots} = useContext(CheckboxContext);
+  const {slots} = use(CheckboxContext);
 
   return (
     <dom.span
@@ -127,7 +127,7 @@ const CheckboxIndicator = <E extends keyof React.JSX.IntrinsicElements = "span">
   ...props
 }: CheckboxIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof CheckboxIndicatorProps<E>>) => {
-  const {slots, state} = useContext(CheckboxContext);
+  const {slots, state} = use(CheckboxContext);
 
   const isSelected = state?.isSelected;
   const isIndeterminate = state?.isIndeterminate;

--- a/packages/react/src/components/chip/chip.tsx
+++ b/packages/react/src/components/chip/chip.tsx
@@ -5,7 +5,7 @@ import type {ChipVariants} from "@heroui/styles";
 import type {ReactNode} from "react";
 
 import {chipVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 
 import {composeSlotClassName} from "../../utils/compose";
 import {dom} from "../../utils/dom";
@@ -81,7 +81,7 @@ const ChipLabel = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: ChipLabelProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ChipLabelProps<E>>) => {
-  const {slots} = useContext(ChipContext);
+  const {slots} = use(ChipContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/color-area/color-area.tsx
+++ b/packages/react/src/components/color-area/color-area.tsx
@@ -4,7 +4,7 @@ import type {ColorAreaVariants} from "@heroui/styles";
 import type {CSSProperties, ComponentPropsWithRef} from "react";
 
 import {colorAreaVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   ColorArea as ColorAreaPrimitive,
   ColorThumb as ColorThumbPrimitive,
@@ -57,7 +57,7 @@ const ColorAreaRoot = ({children, className, showDots, style, ...props}: ColorAr
 interface ColorAreaThumbProps extends ComponentPropsWithRef<typeof ColorThumbPrimitive> {}
 
 const ColorAreaThumb = ({className, style, ...props}: ColorAreaThumbProps) => {
-  const {slots} = useContext(ColorAreaContext);
+  const {slots} = use(ColorAreaContext);
 
   return (
     <ColorThumbPrimitive

--- a/packages/react/src/components/color-input-group/color-input-group.tsx
+++ b/packages/react/src/components/color-input-group/color-input-group.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {InputProps as InputPrimitiveProps} from "react-aria-components/Input";
 
 import {colorInputGroupVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
 import {Input as InputPrimitive} from "react-aria-components/Input";
 
@@ -69,7 +69,7 @@ const ColorInputGroupPrefix = <E extends keyof React.JSX.IntrinsicElements = "di
   ...props
 }: ColorInputGroupPrefixProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ColorInputGroupPrefixProps<E>>) => {
-  const {slots} = useContext(ColorInputGroupContext);
+  const {slots} = use(ColorInputGroupContext);
 
   return (
     <dom.div
@@ -90,7 +90,7 @@ interface ColorInputGroupInputProps extends InputPrimitiveProps {
 }
 
 const ColorInputGroupInput = ({className, ...props}: ColorInputGroupInputProps) => {
-  const {slots} = useContext(ColorInputGroupContext);
+  const {slots} = use(ColorInputGroupContext);
 
   return (
     <InputPrimitive
@@ -117,7 +117,7 @@ const ColorInputGroupSuffix = <E extends keyof React.JSX.IntrinsicElements = "di
   ...props
 }: ColorInputGroupSuffixProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ColorInputGroupSuffixProps<E>>) => {
-  const {slots} = useContext(ColorInputGroupContext);
+  const {slots} = use(ColorInputGroupContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/color-picker/color-picker.tsx
+++ b/packages/react/src/components/color-picker/color-picker.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef} from "react";
 import type {ColorPickerProps as ColorPickerPrimitiveProps} from "react-aria-components/ColorPicker";
 
 import {colorPickerVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {ColorPicker as ColorPickerPrimitive} from "react-aria-components/ColorPicker";
 import {
@@ -59,7 +59,7 @@ const ColorPickerRoot = ({children, className, ...props}: ColorPickerRootProps) 
 interface ColorPickerTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
 const ColorPickerTrigger = ({children, className, ...props}: ColorPickerTriggerProps) => {
-  const {slots} = useContext(ColorPickerContext);
+  const {slots} = use(ColorPickerContext);
 
   return (
     <ButtonPrimitive
@@ -88,7 +88,7 @@ const ColorPickerPopover = ({
   placement = "bottom left",
   ...props
 }: ColorPickerPopoverProps) => {
-  const {slots} = useContext(ColorPickerContext);
+  const {slots} = use(ColorPickerContext);
 
   return (
     <SurfaceContext

--- a/packages/react/src/components/color-slider/color-slider.tsx
+++ b/packages/react/src/components/color-slider/color-slider.tsx
@@ -5,7 +5,7 @@ import type {ComponentPropsWithRef} from "react";
 import type {ColorSliderRenderProps, ColorSpace} from "react-aria-components/ColorSlider";
 
 import {colorSliderVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   ColorSlider as ColorSliderPrimitive,
   ColorThumb as ColorThumbPrimitive,
@@ -152,7 +152,7 @@ const ColorSliderRoot = ({
 interface ColorSliderOutputProps extends ComponentPropsWithRef<typeof SliderOutputPrimitive> {}
 
 const ColorSliderOutput = ({children, className, ...props}: ColorSliderOutputProps) => {
-  const {slots} = useContext(ColorSliderContext);
+  const {slots} = use(ColorSliderContext);
 
   return (
     <SliderOutputPrimitive
@@ -173,7 +173,7 @@ const ColorSliderOutput = ({children, className, ...props}: ColorSliderOutputPro
 interface ColorSliderTrackProps extends ComponentPropsWithRef<typeof SliderTrackPrimitive> {}
 
 const ColorSliderTrack = ({children, className, style, ...props}: ColorSliderTrackProps) => {
-  const {channel, slots, state} = useContext(ColorSliderContext);
+  const {channel, slots, state} = use(ColorSliderContext);
   // Calculate start and end colors for the gradient edge caps
   const displayColor = state?.state?.getDisplayColor();
 
@@ -228,7 +228,7 @@ const ColorSliderTrack = ({children, className, style, ...props}: ColorSliderTra
 interface ColorSliderThumbProps extends ComponentPropsWithRef<typeof ColorThumbPrimitive> {}
 
 const ColorSliderThumb = ({children, className, style, ...props}: ColorSliderThumbProps) => {
-  const {slots} = useContext(ColorSliderContext);
+  const {slots} = use(ColorSliderContext);
 
   return (
     <ColorThumbPrimitive

--- a/packages/react/src/components/color-swatch-picker/color-swatch-picker.tsx
+++ b/packages/react/src/components/color-swatch-picker/color-swatch-picker.tsx
@@ -6,7 +6,7 @@ import type {CSSProperties, ComponentPropsWithRef} from "react";
 import type {ColorSwatchPickerItemRenderProps} from "react-aria-components/ColorSwatchPicker";
 
 import {colorSwatchPickerVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   ColorSwatchPickerItem as ColorSwatchPickerItemPrimitive,
   ColorSwatchPicker as ColorSwatchPickerPrimitive,
@@ -74,7 +74,7 @@ interface ColorSwatchPickerItemProps extends ComponentPropsWithRef<
 > {}
 
 const ColorSwatchPickerItem = ({children, className, ...props}: ColorSwatchPickerItemProps) => {
-  const {slots} = useContext(ColorSwatchPickerContext);
+  const {slots} = use(ColorSwatchPickerContext);
 
   return (
     <ColorSwatchPickerItemPrimitive
@@ -102,7 +102,7 @@ const ColorSwatchPickerItem = ({children, className, ...props}: ColorSwatchPicke
 interface ColorSwatchPickerSwatchProps extends ComponentPropsWithRef<typeof ColorSwatchPrimitive> {}
 
 const ColorSwatchPickerSwatch = ({className, ...props}: ColorSwatchPickerSwatchProps) => {
-  const {slots} = useContext(ColorSwatchPickerContext);
+  const {slots} = use(ColorSwatchPickerContext);
 
   return (
     <ColorSwatchPrimitive
@@ -144,8 +144,8 @@ const ColorSwatchPickerIndicator = <E extends keyof React.JSX.IntrinsicElements 
   ...props
 }: ColorSwatchPickerIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ColorSwatchPickerIndicatorProps<E>>) => {
-  const {slots} = useContext(ColorSwatchPickerContext);
-  const {state} = useContext(ColorSwatchPickerItemContext);
+  const {slots} = use(ColorSwatchPickerContext);
+  const {state} = use(ColorSwatchPickerItemContext);
 
   // Determine if the background color is light (luminance > 0.5)
   // Use white checkmark on dark backgrounds, black on light backgrounds

--- a/packages/react/src/components/combo-box/combo-box.tsx
+++ b/packages/react/src/components/combo-box/combo-box.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {ButtonProps} from "react-aria-components/Button";
 
 import {comboBoxVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button} from "react-aria-components/Button";
 import {
   ComboBox as ComboBoxPrimitive,
@@ -72,7 +72,7 @@ const ComboBoxRoot = <T extends object = object>({
 interface ComboBoxInputGroupProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 const ComboBoxInputGroup = ({children, className, ...props}: ComboBoxInputGroupProps) => {
-  const {slots} = useContext(ComboBoxContext);
+  const {slots} = use(ComboBoxContext);
   const inputGroupClassName = composeSlotClassName(slots?.inputGroup, className);
 
   return (
@@ -91,8 +91,8 @@ interface ComboBoxTriggerProps extends ButtonProps {
 }
 
 const ComboBoxTrigger = ({children, className, ...rest}: ComboBoxTriggerProps) => {
-  const {slots} = useContext(ComboBoxContext);
-  const state = useContext(ComboBoxStateContext);
+  const {slots} = use(ComboBoxContext);
+  const state = use(ComboBoxStateContext);
 
   return (
     <Button
@@ -122,7 +122,7 @@ const ComboBoxPopover = ({
   placement = "bottom",
   ...props
 }: ComboBoxPopoverProps) => {
-  const {slots} = useContext(ComboBoxContext);
+  const {slots} = use(ComboBoxContext);
 
   return (
     <SurfaceContext

--- a/packages/react/src/components/date-input-group/date-input-group.tsx
+++ b/packages/react/src/components/date-input-group/date-input-group.tsx
@@ -11,7 +11,7 @@ import type {
 } from "react-aria-components/DateField";
 
 import {dateInputGroupVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   DateInput as DateInputPrimitive,
   DateSegment as DateSegmentPrimitive,
@@ -77,7 +77,7 @@ const DateInputGroupPrefix = <E extends keyof React.JSX.IntrinsicElements = "div
   ...props
 }: DateInputGroupPrefixProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DateInputGroupPrefixProps<E>>) => {
-  const {slots} = useContext(DateInputGroupContext);
+  const {slots} = use(DateInputGroupContext);
 
   return (
     <dom.div
@@ -99,7 +99,7 @@ interface DateInputGroupInputProps
     Partial<Omit<TimeInputPrimitiveProps, keyof DateInputPrimitiveProps>> {}
 
 const DateInputGroupInput = ({className, ...props}: DateInputGroupInputProps) => {
-  const {slots} = useContext(DateInputGroupContext);
+  const {slots} = use(DateInputGroupContext);
 
   // TimeInput and DateInput have compatible interfaces
   // React Aria Components will handle the correct primitive based on parent context (TimeField vs DateField)
@@ -125,7 +125,7 @@ interface DateInputGroupSegmentProps
 }
 
 const DateInputGroupSegment = ({className, segment, ...props}: DateInputGroupSegmentProps) => {
-  const {slots} = useContext(DateInputGroupContext);
+  const {slots} = use(DateInputGroupContext);
 
   // TimeSegment and DateSegment have compatible interfaces
   // React Aria Components will handle the correct primitive based on parent context
@@ -156,7 +156,7 @@ const DateInputGroupInputContainer = <E extends keyof React.JSX.IntrinsicElement
   ...props
 }: DateInputGroupInputContainerProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DateInputGroupInputContainerProps<E>>) => {
-  const {slots} = useContext(DateInputGroupContext);
+  const {slots} = use(DateInputGroupContext);
 
   return (
     <dom.div
@@ -185,7 +185,7 @@ const DateInputGroupSuffix = <E extends keyof React.JSX.IntrinsicElements = "div
   ...props
 }: DateInputGroupSuffixProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DateInputGroupSuffixProps<E>>) => {
-  const {slots} = useContext(DateInputGroupContext);
+  const {slots} = use(DateInputGroupContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -8,7 +8,7 @@ import type {DateValue} from "react-aria-components/Calendar";
 
 import {datePickerVariants} from "@heroui/styles";
 import {mergeRefs} from "@react-aria/utils";
-import React, {createContext, useContext, useEffect, useRef} from "react";
+import React, {createContext, use, useEffect, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {
   DatePicker as DatePickerPrimitive,
@@ -101,30 +101,28 @@ DatePickerRoot.displayName = "HeroUI.DatePicker";
  * -----------------------------------------------------------------------------------------------*/
 interface DatePickerTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
-const DatePickerTrigger = React.forwardRef<HTMLButtonElement, DatePickerTriggerProps>(
-  ({children, className, ...props}, ref) => {
-    const {slots, triggerRef} = useContext(DatePickerContext);
+const DatePickerTrigger = ({children, className, ref, ...props}: DatePickerTriggerProps) => {
+  const {slots, triggerRef} = use(DatePickerContext);
 
-    const contextRefCallback = React.useCallback(
-      (node: HTMLButtonElement | null) => {
-        triggerRef.current = node;
-      },
-      [triggerRef],
-    );
-    const mergedRef = mergeRefs(contextRefCallback, ref);
+  const contextRefCallback = React.useCallback(
+    (node: HTMLButtonElement | null) => {
+      triggerRef.current = node;
+    },
+    [triggerRef],
+  );
+  const mergedRef = mergeRefs(contextRefCallback, ref);
 
-    return (
-      <ButtonPrimitive
-        ref={mergedRef}
-        className={composeTwRenderProps(className, slots?.trigger())}
-        data-slot="date-picker-trigger"
-        {...props}
-      >
-        {(values) => <>{typeof children === "function" ? children(values) : children}</>}
-      </ButtonPrimitive>
-    );
-  },
-);
+  return (
+    <ButtonPrimitive
+      ref={mergedRef}
+      className={composeTwRenderProps(className, slots?.trigger())}
+      data-slot="date-picker-trigger"
+      {...props}
+    >
+      {(values) => <>{typeof children === "function" ? children(values) : children}</>}
+    </ButtonPrimitive>
+  );
+};
 
 DatePickerTrigger.displayName = "HeroUI.DatePicker.Trigger";
 
@@ -144,7 +142,7 @@ const DatePickerTriggerIndicator = <E extends keyof React.JSX.IntrinsicElements 
   ...props
 }: DatePickerTriggerIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DatePickerTriggerIndicatorProps<E>>) => {
-  const {slots} = useContext(DatePickerContext);
+  const {slots} = use(DatePickerContext);
 
   return (
     <dom.span
@@ -176,7 +174,7 @@ const DatePickerPopover = ({
   placement = "bottom",
   ...props
 }: DatePickerPopoverProps) => {
-  const {slots} = useContext(DatePickerContext);
+  const {slots} = use(DatePickerContext);
 
   return (
     <SurfaceContext

--- a/packages/react/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/react/src/components/date-range-picker/date-range-picker.tsx
@@ -8,7 +8,7 @@ import type {DateValue} from "react-aria-components/Calendar";
 
 import {dateRangePickerVariants} from "@heroui/styles";
 import {mergeRefs} from "@react-aria/utils";
-import React, {createContext, useContext, useEffect, useRef} from "react";
+import React, {createContext, use, useEffect, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {
   DateRangePicker as DateRangePickerPrimitive,
@@ -101,30 +101,33 @@ DateRangePickerRoot.displayName = "HeroUI.DateRangePicker";
  * -----------------------------------------------------------------------------------------------*/
 interface DateRangePickerTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
-const DateRangePickerTrigger = React.forwardRef<HTMLButtonElement, DateRangePickerTriggerProps>(
-  ({children, className, ...props}, ref) => {
-    const {slots, triggerRef} = useContext(DateRangePickerContext);
+const DateRangePickerTrigger = ({
+  children,
+  className,
+  ref,
+  ...props
+}: DateRangePickerTriggerProps) => {
+  const {slots, triggerRef} = use(DateRangePickerContext);
 
-    const contextRefCallback = React.useCallback(
-      (node: HTMLButtonElement | null) => {
-        triggerRef.current = node;
-      },
-      [triggerRef],
-    );
-    const mergedRef = mergeRefs(contextRefCallback, ref);
+  const contextRefCallback = React.useCallback(
+    (node: HTMLButtonElement | null) => {
+      triggerRef.current = node;
+    },
+    [triggerRef],
+  );
+  const mergedRef = mergeRefs(contextRefCallback, ref);
 
-    return (
-      <ButtonPrimitive
-        ref={mergedRef}
-        className={composeTwRenderProps(className, slots?.trigger())}
-        data-slot="date-range-picker-trigger"
-        {...props}
-      >
-        {(values) => <>{typeof children === "function" ? children(values) : children}</>}
-      </ButtonPrimitive>
-    );
-  },
-);
+  return (
+    <ButtonPrimitive
+      ref={mergedRef}
+      className={composeTwRenderProps(className, slots?.trigger())}
+      data-slot="date-range-picker-trigger"
+      {...props}
+    >
+      {(values) => <>{typeof children === "function" ? children(values) : children}</>}
+    </ButtonPrimitive>
+  );
+};
 
 DateRangePickerTrigger.displayName = "HeroUI.DateRangePicker.Trigger";
 
@@ -144,7 +147,7 @@ const DateRangePickerTriggerIndicator = <E extends keyof React.JSX.IntrinsicElem
   ...props
 }: DateRangePickerTriggerIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DateRangePickerTriggerIndicatorProps<E>>) => {
-  const {slots} = useContext(DateRangePickerContext);
+  const {slots} = use(DateRangePickerContext);
 
   return (
     <dom.span
@@ -176,7 +179,7 @@ const DateRangePickerRangeSeparator = <E extends keyof React.JSX.IntrinsicElemen
   ...props
 }: DateRangePickerRangeSeparatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DateRangePickerRangeSeparatorProps<E>>) => {
-  const {slots} = useContext(DateRangePickerContext);
+  const {slots} = use(DateRangePickerContext);
 
   return (
     <dom.span
@@ -208,7 +211,7 @@ const DateRangePickerPopover = ({
   placement = "bottom",
   ...props
 }: DateRangePickerPopoverProps) => {
-  const {slots} = useContext(DateRangePickerContext);
+  const {slots} = use(DateRangePickerContext);
 
   return (
     <SurfaceContext

--- a/packages/react/src/components/disclosure/disclosure.tsx
+++ b/packages/react/src/components/disclosure/disclosure.tsx
@@ -7,7 +7,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {ButtonProps} from "react-aria-components/Button";
 
 import {disclosureVariants} from "@heroui/styles";
-import React, {createContext, useContext, useRef} from "react";
+import React, {createContext, use, useRef} from "react";
 import {Button} from "react-aria-components/Button";
 import {
   DisclosurePanel,
@@ -60,7 +60,7 @@ interface DisclosureHeadingProps extends ComponentPropsWithRef<typeof Disclosure
 }
 
 const DisclosureHeading = ({className, ...props}: DisclosureHeadingProps) => {
-  const {slots} = useContext(DisclosureContext);
+  const {slots} = use(DisclosureContext);
 
   return (
     <DisclosureHeadingPrimitive
@@ -77,7 +77,7 @@ const DisclosureHeading = ({className, ...props}: DisclosureHeadingProps) => {
 interface DisclosureTriggerProps extends ButtonProps {}
 
 const DisclosureTrigger = ({className, ...props}: DisclosureTriggerProps) => {
-  const {slots} = useContext(DisclosureContext);
+  const {slots} = use(DisclosureContext);
 
   return (
     <Button
@@ -99,9 +99,9 @@ const DisclosureTrigger = ({className, ...props}: DisclosureTriggerProps) => {
 interface DisclosureContentProps extends ComponentPropsWithRef<typeof DisclosurePanel> {}
 
 const DisclosureContent = ({children, className, ...props}: DisclosureContentProps) => {
-  const {slots} = useContext(DisclosureContext);
+  const {slots} = use(DisclosureContext);
   const contentRef = useRef<HTMLDivElement>(null);
-  const {isExpanded} = useContext(DisclosureStateContext)!;
+  const {isExpanded} = use(DisclosureStateContext)!;
 
   return (
     <DisclosurePanel
@@ -132,7 +132,7 @@ const DisclosureBody = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...props
 }: DisclosureBodyContentProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DisclosureBodyContentProps<E>>) => {
-  const {slots} = useContext(DisclosureContext);
+  const {slots} = use(DisclosureContext);
 
   return (
     <dom.div className={slots?.body({})} data-slot="disclosure-body" {...(props as any)}>
@@ -157,8 +157,8 @@ const DisclosureIndicator = <E extends keyof React.JSX.IntrinsicElements = "svg"
   ...props
 }: DisclosureIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof DisclosureIndicatorProps<E>>) => {
-  const {isExpanded} = useContext(DisclosureStateContext)!;
-  const {slots} = useContext(DisclosureContext);
+  const {isExpanded} = use(DisclosureStateContext)!;
+  const {slots} = use(DisclosureContext);
 
   if (children && React.isValidElement(children)) {
     return React.cloneElement(

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -10,7 +10,7 @@ import type {DialogProps as DialogPrimitiveProps} from "react-aria-components/Di
 
 import {drawerVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
-import React, {createContext, useCallback, useContext, useMemo, useRef} from "react";
+import React, {createContext, use, useCallback, useMemo, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {
   Dialog as DialogPrimitive,
@@ -41,7 +41,7 @@ const DISMISS_FRACTION = 0.3; // dismiss if dragged > 30% of dimension
 const VELOCITY_THRESHOLD = 0.5; // px/ms — dismiss on fast flick
 
 function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: boolean) {
-  const overlayState = useContext(OverlayTriggerStateContext);
+  const overlayState = use(OverlayTriggerStateContext);
   const dialogRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const isActive = useRef(false);
@@ -247,7 +247,7 @@ DrawerRoot.displayName = "HeroUI.Drawer";
 interface DrawerTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
 const DrawerTrigger = ({children, className, ...props}: DrawerTriggerProps) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <ButtonPrimitive
@@ -281,7 +281,7 @@ const DrawerBackdrop = ({
   variant,
   ...props
 }: DrawerBackdropProps) => {
-  const {slots: contextSlots} = useContext(DrawerContext);
+  const {slots: contextSlots} = use(DrawerContext);
 
   const updatedSlots = useMemo(() => drawerVariants({variant}), [variant]);
 
@@ -324,7 +324,7 @@ const DrawerContent = ({
   placement = "bottom",
   ...props
 }: DrawerContentProps) => {
-  const {isDismissable, slots: contextSlots} = useContext(DrawerContext);
+  const {isDismissable, slots: contextSlots} = use(DrawerContext);
 
   const updatedSlots = useMemo(() => drawerVariants({placement}), [placement]);
 
@@ -357,7 +357,7 @@ DrawerContent.displayName = "HeroUI.Drawer.Content";
 interface DrawerDialogProps extends DialogPrimitiveProps {}
 
 const DrawerDialog = ({children, className, ...props}: DrawerDialogProps) => {
-  const {isDismissable = true, placement, slots} = useContext(DrawerContext);
+  const {isDismissable = true, placement, slots} = use(DrawerContext);
   const {dialogRef, dragHandlers} = useDrawerDrag(placement, isDismissable);
 
   return (
@@ -394,7 +394,7 @@ const DrawerHeader = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: DrawerHeaderProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof DrawerHeaderProps<E>>) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <dom.div
@@ -424,7 +424,7 @@ const DrawerBody = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: DrawerBodyProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof DrawerBodyProps<E>>) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <dom.div
@@ -455,7 +455,7 @@ const DrawerFooter = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: DrawerFooterProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof DrawerFooterProps<E>>) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <dom.div
@@ -476,7 +476,7 @@ DrawerFooter.displayName = "HeroUI.Drawer.Footer";
 interface DrawerHeadingProps extends ComponentPropsWithRef<typeof HeadingPrimitive> {}
 
 const DrawerHeading = ({children, className, ...props}: DrawerHeadingProps) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <HeadingPrimitive
@@ -506,7 +506,7 @@ const DrawerHandle = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: DrawerHandleProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof DrawerHandleProps<E>>) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <dom.div
@@ -531,7 +531,7 @@ interface DrawerCloseTriggerProps extends ButtonPrimitiveProps {
 }
 
 const DrawerCloseTrigger = ({className, ...rest}: DrawerCloseTriggerProps) => {
-  const {slots} = useContext(DrawerContext);
+  const {slots} = use(DrawerContext);
 
   return (
     <CloseButton

--- a/packages/react/src/components/dropdown/dropdown.tsx
+++ b/packages/react/src/components/dropdown/dropdown.tsx
@@ -5,7 +5,7 @@ import type {DropdownVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {dropdownVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button} from "react-aria-components/Button";
 import {
   Menu as MenuPrimitive,
@@ -52,7 +52,7 @@ const DropdownRoot = ({children, ...props}: DropdownRootProps) => {
 interface DropdownTriggerProps extends ComponentPropsWithRef<typeof Button> {}
 
 const DropdownTrigger = ({children, className, ...props}: DropdownTriggerProps) => {
-  const {slots} = useContext(DropdownContext);
+  const {slots} = use(DropdownContext);
 
   return (
     <Button
@@ -74,7 +74,7 @@ interface DropdownPopoverProps
 }
 
 const DropdownPopover = ({children, className, placement, ...props}: DropdownPopoverProps) => {
-  const {slots} = useContext(DropdownContext);
+  const {slots} = use(DropdownContext);
 
   return (
     <SurfaceContext
@@ -103,7 +103,7 @@ interface DropdownMenuProps<T extends object>
 }
 
 function DropdownMenu<T extends object>({className, ...props}: DropdownMenuProps<T>) {
-  const {slots} = useContext(DropdownContext);
+  const {slots} = use(DropdownContext);
 
   return (
     <MenuPrimitive

--- a/packages/react/src/components/fieldset/fieldset.tsx
+++ b/packages/react/src/components/fieldset/fieldset.tsx
@@ -4,7 +4,7 @@ import type {DOMRenderProps} from "../../utils/dom";
 import type {ReactNode} from "react";
 
 import {fieldsetVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   ButtonContext,
   CheckboxGroupContext,
@@ -109,7 +109,7 @@ const FieldsetLegend = <E extends keyof React.JSX.IntrinsicElements = "legend">(
   className,
   ...props
 }: FieldsetLegendProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof FieldsetLegendProps<E>>) => {
-  const {slots} = useContext(FieldsetContext);
+  const {slots} = use(FieldsetContext);
 
   return (
     <dom.legend
@@ -134,7 +134,7 @@ const FieldGroup = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...rest
 }: FieldGroupProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof FieldGroupProps<E>>) => {
-  const {slots} = useContext(FieldsetContext);
+  const {slots} = use(FieldsetContext);
 
   return (
     <dom.div
@@ -161,7 +161,7 @@ const FieldsetActions = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...rest
 }: FieldsetActionsProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof FieldsetActionsProps<E>>) => {
-  const {slots} = useContext(FieldsetContext);
+  const {slots} = use(FieldsetContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/input-group/input-group.tsx
+++ b/packages/react/src/components/input-group/input-group.tsx
@@ -4,7 +4,7 @@ import type {InputGroupVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {inputGroupVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
 import {Input as InputPrimitive} from "react-aria-components/Input";
 import {TextArea as TextAreaPrimitive} from "react-aria-components/TextArea";
@@ -35,7 +35,7 @@ const InputGroupRoot = ({
   variant,
   ...props
 }: InputGroupRootProps) => {
-  const textFieldContext = useContext(TextFieldContext);
+  const textFieldContext = use(TextFieldContext);
   const resolvedVariant = variant ?? textFieldContext?.variant;
   const groupRef = React.useRef<HTMLDivElement>(null);
 
@@ -76,7 +76,7 @@ const InputGroupRoot = ({
 interface InputGroupInputProps extends ComponentPropsWithRef<typeof InputPrimitive> {}
 
 const InputGroupInput = ({className, ...props}: InputGroupInputProps) => {
-  const {slots} = useContext(InputGroupContext);
+  const {slots} = use(InputGroupContext);
 
   return (
     <InputPrimitive
@@ -93,7 +93,7 @@ const InputGroupInput = ({className, ...props}: InputGroupInputProps) => {
 interface InputGroupPrefixProps extends ComponentPropsWithRef<"div"> {}
 
 const InputGroupPrefix = ({children, className, ...props}: InputGroupPrefixProps) => {
-  const {slots} = useContext(InputGroupContext);
+  const {slots} = use(InputGroupContext);
 
   return (
     <div
@@ -112,7 +112,7 @@ const InputGroupPrefix = ({children, className, ...props}: InputGroupPrefixProps
 interface InputGroupTextAreaProps extends ComponentPropsWithRef<typeof TextAreaPrimitive> {}
 
 const InputGroupTextArea = ({className, ...props}: InputGroupTextAreaProps) => {
-  const {slots} = useContext(InputGroupContext);
+  const {slots} = use(InputGroupContext);
 
   return (
     <TextAreaPrimitive
@@ -129,7 +129,7 @@ const InputGroupTextArea = ({className, ...props}: InputGroupTextAreaProps) => {
 interface InputGroupSuffixProps extends ComponentPropsWithRef<"div"> {}
 
 const InputGroupSuffix = ({children, className, ...props}: InputGroupSuffixProps) => {
-  const {slots} = useContext(InputGroupContext);
+  const {slots} = use(InputGroupContext);
 
   return (
     <div

--- a/packages/react/src/components/input-otp/input-otp.tsx
+++ b/packages/react/src/components/input-otp/input-otp.tsx
@@ -6,7 +6,7 @@ import type {ValidationResult} from "react-aria-components/CheckboxGroup";
 
 import {inputOTPVariants} from "@heroui/styles";
 import {OTPInput, OTPInputContext} from "input-otp";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {FieldErrorContext} from "react-aria-components/FieldError";
 
 import {dataAttr} from "../../utils/assertion";
@@ -88,7 +88,7 @@ const InputOTPRoot = ({
 interface InputOTPGroupProps extends ComponentPropsWithRef<"div"> {}
 
 const InputOTPGroup = ({className, ...props}: InputOTPGroupProps) => {
-  const {slots} = useContext(InputOTPContext);
+  const {slots} = use(InputOTPContext);
 
   return (
     <div
@@ -107,9 +107,9 @@ interface InputOTPSlotProps extends ComponentPropsWithRef<"div"> {
 }
 
 const InputOTPSlot = ({className, index, ...props}: InputOTPSlotProps) => {
-  const {isDisabled, isInvalid, slots} = useContext(InputOTPContext);
+  const {isDisabled, isInvalid, slots} = use(InputOTPContext);
 
-  const inputOTPContext = useContext(OTPInputContext);
+  const inputOTPContext = use(OTPInputContext);
   const {char, hasFakeCaret, isActive} = inputOTPContext?.slots[index] ?? {};
 
   return (
@@ -142,7 +142,7 @@ interface InputOTPSeparatorProps extends ComponentPropsWithRef<"div"> {
 }
 
 const InputOTPSeparator = ({className, ...props}: InputOTPSeparatorProps) => {
-  const {slots} = useContext(InputOTPContext);
+  const {slots} = use(InputOTPContext);
 
   return (
     <div

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -4,7 +4,7 @@ import type {InputVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {inputVariants} from "@heroui/styles";
-import React, {useContext} from "react";
+import React, {use} from "react";
 import {Input as InputPrimitive} from "react-aria-components/Input";
 
 import {composeTwRenderProps} from "../../utils";
@@ -17,8 +17,8 @@ import {TextFieldContext} from "../textfield";
 interface InputRootProps extends ComponentPropsWithRef<typeof InputPrimitive>, InputVariants {}
 
 const InputRoot = ({className, fullWidth, variant: variantProp, ...rest}: InputRootProps) => {
-  const textFieldContext = useContext(TextFieldContext);
-  const comboBoxContext = useContext(ComboBoxContext);
+  const textFieldContext = use(TextFieldContext);
+  const comboBoxContext = use(ComboBoxContext);
 
   // Use variant from context if not explicitly provided
   const variant = variantProp ?? textFieldContext.variant ?? comboBoxContext.variant;

--- a/packages/react/src/components/kbd/kbd.tsx
+++ b/packages/react/src/components/kbd/kbd.tsx
@@ -6,7 +6,7 @@ import type {KbdVariants} from "@heroui/styles";
 import type {ReactNode} from "react";
 
 import {kbdVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 
 import {composeSlotClassName} from "../../utils/compose";
 import {dom} from "../../utils/dom";
@@ -69,7 +69,7 @@ const KbdAbbr = <E extends keyof React.JSX.IntrinsicElements = "abbr">({
   keyValue,
   ...props
 }: KbdAbbrProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof KbdAbbrProps<E>>) => {
-  const {slots} = useContext(KbdContext);
+  const {slots} = use(KbdContext);
 
   return (
     <dom.abbr
@@ -97,7 +97,7 @@ const KbdContent = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: KbdContentProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof KbdContentProps<E>>) => {
-  const {slots} = useContext(KbdContext);
+  const {slots} = use(KbdContext);
 
   return (
     <dom.span className={composeSlotClassName(slots?.content, className)} {...(props as any)}>

--- a/packages/react/src/components/link/link.tsx
+++ b/packages/react/src/components/link/link.tsx
@@ -5,7 +5,7 @@ import type {LinkVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {linkVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Link as LinkPrimitive} from "react-aria-components/Link";
 
 import {dataAttr} from "../../utils/assertion";
@@ -54,7 +54,7 @@ const LinkIcon = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...rest
 }: LinkIconProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof LinkIconProps<E>>) => {
-  const {slots} = useContext(LinkContext);
+  const {slots} = use(LinkContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/list-box-item/list-box-item.tsx
+++ b/packages/react/src/components/list-box-item/list-box-item.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef} from "react";
 import type {ListBoxItemRenderProps} from "react-aria-components/ListBox";
 
 import {listboxItemVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {ListBoxItem as ListBoxItemPrimitive} from "react-aria-components/ListBox";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils";
@@ -64,7 +64,7 @@ const ListBoxItemIndicator = <E extends keyof React.JSX.IntrinsicElements = "spa
   ...props
 }: ListBoxItemIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ListBoxItemIndicatorProps<E>>) => {
-  const {slots, state} = useContext(ListBoxItemContext);
+  const {slots, state} = use(ListBoxItemContext);
   const isSelected = state?.isSelected;
 
   const content =

--- a/packages/react/src/components/menu-item/menu-item.tsx
+++ b/packages/react/src/components/menu-item/menu-item.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef} from "react";
 import type {MenuItemRenderProps} from "react-aria-components/Menu";
 
 import {menuItemVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {MenuItem as MenuItemPrimitive} from "react-aria-components/Menu";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils";
@@ -67,7 +67,7 @@ const MenuItemIndicator = <E extends keyof React.JSX.IntrinsicElements = "span">
   ...props
 }: MenuItemIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof MenuItemIndicatorProps<E>>) => {
-  const {slots, state} = useContext(MenuItemContext);
+  const {slots, state} = use(MenuItemContext);
   const isSelected = state?.isSelected;
 
   const content =
@@ -135,7 +135,7 @@ const MenuItemSubmenuIndicator = <E extends keyof React.JSX.IntrinsicElements = 
   ...props
 }: MenuItemSubmenuIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof MenuItemSubmenuIndicatorProps<E>>) => {
-  const {slots, state} = useContext(MenuItemContext);
+  const {slots, state} = use(MenuItemContext);
   const hasSubmenu = state?.hasSubmenu;
 
   if (!hasSubmenu) {

--- a/packages/react/src/components/meter/meter.tsx
+++ b/packages/react/src/components/meter/meter.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {MeterRenderProps} from "react-aria-components/Meter";
 
 import {meterVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Meter as MeterPrimitive} from "react-aria-components/Meter";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
@@ -62,7 +62,7 @@ const MeterOutput = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: MeterOutputProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof MeterOutputProps<E>>) => {
-  const {slots, state} = useContext(MeterContext);
+  const {slots, state} = use(MeterContext);
 
   return (
     <dom.span
@@ -92,7 +92,7 @@ const MeterTrack = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: MeterTrackProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof MeterTrackProps<E>>) => {
-  const {slots} = useContext(MeterContext);
+  const {slots} = use(MeterContext);
 
   return (
     <dom.div
@@ -123,7 +123,7 @@ const MeterFill = <E extends keyof React.JSX.IntrinsicElements = "div">({
   style,
   ...props
 }: MeterFillProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof MeterFillProps<E>>) => {
-  const {slots, state} = useContext(MeterContext);
+  const {slots, state} = use(MeterContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/modal/modal.tsx
+++ b/packages/react/src/components/modal/modal.tsx
@@ -10,7 +10,7 @@ import type {DialogProps as DialogPrimitiveProps} from "react-aria-components/Di
 
 import {modalVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
-import {createContext, useContext, useMemo} from "react";
+import {createContext, use, useMemo} from "react";
 import {
   Dialog as DialogPrimitive,
   Heading as HeadingPrimitive,
@@ -81,7 +81,7 @@ const ModalTrigger = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: ModalTriggerProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ModalTriggerProps<E>>) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <PressablePrimitive>
@@ -117,7 +117,7 @@ const ModalBackdrop = ({
   variant,
   ...props
 }: ModalBackdropProps) => {
-  const {slots: contextSlots} = useContext(ModalContext);
+  const {slots: contextSlots} = use(ModalContext);
 
   const updatedSlots = useMemo(() => modalVariants({variant}), [variant]);
 
@@ -166,7 +166,7 @@ const ModalContainer = ({
   size,
   ...props
 }: ModalContainerProps) => {
-  const {slots: contextSlots} = useContext(ModalContext);
+  const {slots: contextSlots} = use(ModalContext);
 
   const updatedSlots = useMemo(() => modalVariants({scroll, size}), [scroll, size]);
 
@@ -197,7 +197,7 @@ const ModalContainer = ({
 interface ModalDialogProps extends DialogPrimitiveProps {}
 
 const ModalDialog = ({children, className, ...props}: ModalDialogProps) => {
-  const {placement, slots} = useContext(ModalContext);
+  const {placement, slots} = use(ModalContext);
 
   return (
     <SurfaceContext value={{variant: "default" as SurfaceVariants["variant"]}}>
@@ -228,7 +228,7 @@ const ModalHeader = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: ModalHeaderProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ModalHeaderProps<E>>) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <dom.div
@@ -256,7 +256,7 @@ const ModalBody = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: ModalBodyProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ModalBodyProps<E>>) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <dom.div
@@ -284,7 +284,7 @@ const ModalFooter = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: ModalFooterProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ModalFooterProps<E>>) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <dom.div
@@ -303,7 +303,7 @@ const ModalFooter = <E extends keyof React.JSX.IntrinsicElements = "div">({
 interface ModalHeadingProps extends ComponentPropsWithRef<typeof HeadingPrimitive> {}
 
 const ModalHeading = ({children, className, ...props}: ModalHeadingProps) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <HeadingPrimitive
@@ -332,7 +332,7 @@ const ModalIcon = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: ModalIconProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ModalIconProps<E>>) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <dom.div
@@ -354,7 +354,7 @@ interface ModalCloseTriggerProps extends ComponentPropsWithRef<typeof ButtonPrim
 }
 
 const ModalCloseTrigger = ({className, ...rest}: ModalCloseTriggerProps) => {
-  const {slots} = useContext(ModalContext);
+  const {slots} = use(ModalContext);
 
   return (
     <CloseButton

--- a/packages/react/src/components/number-field/number-field.tsx
+++ b/packages/react/src/components/number-field/number-field.tsx
@@ -4,7 +4,7 @@ import type {NumberFieldVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {numberFieldVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
 import {Input as InputPrimitive} from "react-aria-components/Input";
@@ -59,7 +59,7 @@ const NumberFieldRoot = ({
 interface NumberFieldGroupProps extends ComponentPropsWithRef<typeof GroupPrimitive> {}
 
 const NumberFieldGroup = ({children, className, ...props}: NumberFieldGroupProps) => {
-  const {slots} = useContext(NumberFieldContext);
+  const {slots} = use(NumberFieldContext);
 
   return (
     <GroupPrimitive
@@ -78,7 +78,7 @@ const NumberFieldGroup = ({children, className, ...props}: NumberFieldGroupProps
 interface NumberFieldInputProps extends ComponentPropsWithRef<typeof InputPrimitive> {}
 
 const NumberFieldInput = ({className, ...props}: NumberFieldInputProps) => {
-  const {slots} = useContext(NumberFieldContext);
+  const {slots} = use(NumberFieldContext);
 
   return (
     <InputPrimitive
@@ -99,7 +99,7 @@ const NumberFieldIncrementButton = ({
   className,
   ...props
 }: NumberFieldIncrementButtonProps) => {
-  const {slots} = useContext(NumberFieldContext);
+  const {slots} = use(NumberFieldContext);
 
   return (
     <ButtonPrimitive
@@ -127,7 +127,7 @@ const NumberFieldDecrementButton = ({
   className,
   ...props
 }: NumberFieldDecrementButtonProps) => {
-  const {slots} = useContext(NumberFieldContext);
+  const {slots} = use(NumberFieldContext);
 
   return (
     <ButtonPrimitive

--- a/packages/react/src/components/pagination/pagination.stories.tsx
+++ b/packages/react/src/components/pagination/pagination.stories.tsx
@@ -289,7 +289,7 @@ const ControlledTemplate = (props: PaginationProps) => {
   const totalItems = 120;
 
   const getPageNumbers = () => {
-    const pages: (number | "ellipsis")[] = [];
+    const pages: (number | "start-ellipsis" | "end-ellipsis")[] = [];
 
     if (totalPages <= 7) {
       for (let i = 1; i <= totalPages; i++) {
@@ -299,7 +299,7 @@ const ControlledTemplate = (props: PaginationProps) => {
       pages.push(1);
 
       if (page > 3) {
-        pages.push("ellipsis");
+        pages.push("start-ellipsis");
       }
 
       const start = Math.max(2, page - 1);
@@ -310,7 +310,7 @@ const ControlledTemplate = (props: PaginationProps) => {
       }
 
       if (page < totalPages - 2) {
-        pages.push("ellipsis");
+        pages.push("end-ellipsis");
       }
 
       pages.push(totalPages);
@@ -335,9 +335,9 @@ const ControlledTemplate = (props: PaginationProps) => {
               <span>Previous</span>
             </Pagination.Previous>
           </Pagination.Item>
-          {getPageNumbers().map((p, i) =>
-            p === "ellipsis" ? (
-              <Pagination.Item key={`ellipsis-${i}`}>
+          {getPageNumbers().map((p) =>
+            p === "start-ellipsis" || p === "end-ellipsis" ? (
+              <Pagination.Item key={p}>
                 <Pagination.Ellipsis />
               </Pagination.Item>
             ) : (

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -5,7 +5,7 @@ import type {PaginationVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {paginationVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 
 import {composeTwRenderProps} from "../../utils";
@@ -75,7 +75,7 @@ const PaginationSummary = <E extends keyof React.JSX.IntrinsicElements = "div">(
   ...props
 }: PaginationSummaryProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof PaginationSummaryProps<E>>) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
 
   return (
     <dom.div
@@ -106,7 +106,7 @@ const PaginationContent = <E extends keyof React.JSX.IntrinsicElements = "ul">({
   ...props
 }: PaginationContentProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof PaginationContentProps<E>>) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
 
   return (
     <dom.ul
@@ -136,7 +136,7 @@ const PaginationItem = <E extends keyof React.JSX.IntrinsicElements = "li">({
   className,
   ...props
 }: PaginationItemProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof PaginationItemProps<E>>) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
 
   return (
     <dom.li
@@ -161,7 +161,7 @@ interface PaginationLinkProps extends ComponentPropsWithRef<typeof ButtonPrimiti
 }
 
 const PaginationLink = ({children, className, isActive, ...props}: PaginationLinkProps) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
 
   return (
     <ButtonPrimitive
@@ -187,7 +187,7 @@ interface PaginationPreviousProps extends ComponentPropsWithRef<typeof ButtonPri
 }
 
 const PaginationPrevious = ({children, className, ...props}: PaginationPreviousProps) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
   const baseClass = `${slots?.link() ?? ""} pagination__link--nav`.trim();
 
   return (
@@ -242,7 +242,7 @@ interface PaginationNextProps extends ComponentPropsWithRef<typeof ButtonPrimiti
 }
 
 const PaginationNext = ({children, className, ...props}: PaginationNextProps) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
   const baseClass = `${slots?.link() ?? ""} pagination__link--nav`.trim();
 
   return (
@@ -302,7 +302,7 @@ const PaginationEllipsis = <E extends keyof React.JSX.IntrinsicElements = "span"
   ...props
 }: PaginationEllipsisProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof PaginationEllipsisProps<E>>) => {
-  const {slots} = useContext(PaginationContext);
+  const {slots} = use(PaginationContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -6,7 +6,7 @@ import type {PopoverVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {popoverVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   Dialog as DialogPrimitive,
   Heading as HeadingPrimitive,
@@ -60,7 +60,7 @@ interface PopoverContentProps
 }
 
 const PopoverContent = ({children, className, ...props}: PopoverContentProps) => {
-  const {slots} = useContext(PopoverContext);
+  const {slots} = use(PopoverContext);
 
   return (
     <PopoverContext value={{slots}}>
@@ -125,7 +125,7 @@ type PopoverDialogProps = Omit<ComponentPropsWithRef<typeof DialogPrimitive>, "c
 };
 
 const PopoverDialog = ({children, className, ...props}: PopoverDialogProps) => {
-  const {slots} = useContext(PopoverContext);
+  const {slots} = use(PopoverContext);
 
   return (
     <DialogPrimitive
@@ -153,7 +153,7 @@ const PopoverTrigger = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: PopoverTriggerProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof PopoverTriggerProps<E>>) => {
-  const {slots} = useContext(PopoverContext);
+  const {slots} = use(PopoverContext);
 
   return (
     <PressablePrimitive>
@@ -175,7 +175,7 @@ const PopoverTrigger = <E extends keyof React.JSX.IntrinsicElements = "div">({
 type PopoverHeadingProps = ComponentPropsWithRef<typeof HeadingPrimitive> & {};
 
 const PopoverHeading = ({children, className, ...props}: PopoverHeadingProps) => {
-  const {slots} = useContext(PopoverContext);
+  const {slots} = use(PopoverContext);
 
   return (
     <HeadingPrimitive

--- a/packages/react/src/components/progress-bar/progress-bar.tsx
+++ b/packages/react/src/components/progress-bar/progress-bar.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {ProgressBarRenderProps} from "react-aria-components/ProgressBar";
 
 import {progressBarVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {ProgressBar as ProgressBarPrimitive} from "react-aria-components/ProgressBar";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
@@ -64,7 +64,7 @@ const ProgressBarOutput = <E extends keyof React.JSX.IntrinsicElements = "span">
   ...props
 }: ProgressBarOutputProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ProgressBarOutputProps<E>>) => {
-  const {slots, state} = useContext(ProgressBarContext);
+  const {slots, state} = use(ProgressBarContext);
 
   return (
     <dom.span
@@ -95,7 +95,7 @@ const ProgressBarTrack = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...props
 }: ProgressBarTrackProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ProgressBarTrackProps<E>>) => {
-  const {slots} = useContext(ProgressBarContext);
+  const {slots} = use(ProgressBarContext);
 
   return (
     <dom.div
@@ -127,7 +127,7 @@ const ProgressBarFill = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...props
 }: ProgressBarFillProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ProgressBarFillProps<E>>) => {
-  const {slots, state} = useContext(ProgressBarContext);
+  const {slots, state} = use(ProgressBarContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/progress-circle/progress-circle.tsx
+++ b/packages/react/src/components/progress-circle/progress-circle.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {ProgressBarRenderProps} from "react-aria-components/ProgressBar";
 
 import {progressCircleVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {ProgressBar as ProgressBarPrimitive} from "react-aria-components/ProgressBar";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
@@ -78,7 +78,7 @@ const ProgressCircleTrack = <E extends keyof React.JSX.IntrinsicElements = "svg"
   ...props
 }: ProgressCircleTrackProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ProgressCircleTrackProps<E>>) => {
-  const {slots} = useContext(ProgressCircleContext);
+  const {slots} = use(ProgressCircleContext);
 
   return (
     <dom.svg
@@ -110,7 +110,7 @@ const ProgressCircleTrackCircle = <E extends keyof React.JSX.IntrinsicElements =
   ...props
 }: ProgressCircleTrackCircleProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ProgressCircleTrackCircleProps<E>>) => {
-  const {slots} = useContext(ProgressCircleContext);
+  const {slots} = use(ProgressCircleContext);
 
   return (
     <dom.circle
@@ -142,7 +142,7 @@ const ProgressCircleFillCircle = <E extends keyof React.JSX.IntrinsicElements = 
   ...props
 }: ProgressCircleFillCircleProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ProgressCircleFillCircleProps<E>>) => {
-  const {slots, state} = useContext(ProgressCircleContext);
+  const {slots, state} = use(ProgressCircleContext);
   const percentage = state?.percentage ?? 0;
   const isIndeterminate = state?.isIndeterminate ?? false;
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;

--- a/packages/react/src/components/radio/radio.tsx
+++ b/packages/react/src/components/radio/radio.tsx
@@ -5,7 +5,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {RadioButtonRenderProps, RadioFieldRenderProps} from "react-aria-components/RadioGroup";
 
 import {radioVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   RadioButton as RadioButtonPrimitive,
   RadioField as RadioFieldPrimitive,
@@ -56,7 +56,7 @@ RadioRoot.displayName = "HeroUI.Radio";
 interface RadioContentProps extends ComponentPropsWithRef<typeof RadioButtonPrimitive> {}
 
 const RadioContent = ({children, className, ...props}: RadioContentProps) => {
-  const {slots} = useContext(RadioContext);
+  const {slots} = use(RadioContext);
 
   return (
     <RadioButtonPrimitive
@@ -85,7 +85,7 @@ const RadioControl = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: RadioControlProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof RadioControlProps<E>>) => {
-  const {slots} = useContext(RadioContext);
+  const {slots} = use(RadioContext);
 
   return (
     <dom.span
@@ -114,7 +114,7 @@ const RadioIndicator = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: RadioIndicatorProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof RadioIndicatorProps<E>>) => {
-  const {slots, state} = useContext(RadioContext);
+  const {slots, state} = use(RadioContext);
 
   const content =
     typeof children === "function" ? children(state ?? ({} as RadioFieldRenderProps)) : children;

--- a/packages/react/src/components/range-calendar/range-calendar.tsx
+++ b/packages/react/src/components/range-calendar/range-calendar.tsx
@@ -9,7 +9,7 @@ import type {DateValue} from "react-aria-components/Calendar";
 import {rangeCalendarVariants} from "@heroui/styles";
 import {CalendarDate, DateFormatter, createCalendar} from "@internationalized/date";
 import {useControlledState} from "@react-stately/utils";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {useLocale} from "react-aria-components/I18nProvider";
 import {
@@ -167,7 +167,7 @@ const RangeCalendarHeader = <E extends keyof React.JSX.IntrinsicElements = "head
   ...props
 }: RangeCalendarHeaderProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof RangeCalendarHeaderProps<E>>) => {
-  const {slots} = useContext(RangeCalendarContext);
+  const {slots} = use(RangeCalendarContext);
 
   return (
     <dom.header
@@ -190,7 +190,7 @@ interface RangeCalendarHeadingProps extends ComponentPropsWithRef<
 > {}
 
 const RangeCalendarHeading = ({className, ...props}: RangeCalendarHeadingProps) => {
-  const {slots} = useContext(RangeCalendarContext);
+  const {slots} = use(RangeCalendarContext);
 
   return (
     <CalendarHeadingPrimitive
@@ -216,7 +216,7 @@ const RangeCalendarNavButton = ({
   slot,
   ...props
 }: RangeCalendarNavButtonProps) => {
-  const {slots} = useContext(RangeCalendarContext);
+  const {slots} = use(RangeCalendarContext);
 
   return (
     <ButtonPrimitive
@@ -254,7 +254,7 @@ const RangeCalendarGrid = ({
   weekdayStyle = "short",
   ...props
 }: RangeCalendarGridProps) => {
-  const rangeCalendarContext = useContext(RangeCalendarContext);
+  const rangeCalendarContext = use(RangeCalendarContext);
   const {dayView, slots} = rangeCalendarContext;
   const contextValue = React.useMemo(
     () => ({
@@ -288,7 +288,7 @@ interface RangeCalendarGridHeaderProps extends ComponentPropsWithRef<
 > {}
 
 const RangeCalendarGridHeader = ({children, className, ...props}: RangeCalendarGridHeaderProps) => {
-  const {dayView, slots} = useContext(RangeCalendarContext);
+  const {dayView, slots} = use(RangeCalendarContext);
 
   if (dayView && dayView.days >= 7 && typeof children === "function") {
     return (
@@ -326,7 +326,7 @@ interface RangeCalendarGridBodyProps extends ComponentPropsWithRef<
 > {}
 
 const RangeCalendarGridBody = ({children, className, ...props}: RangeCalendarGridBodyProps) => {
-  const {dayView, slots} = useContext(RangeCalendarContext);
+  const {dayView, slots} = use(RangeCalendarContext);
 
   if (dayView && dayView.days >= 7 && typeof children === "function") {
     return (
@@ -362,7 +362,7 @@ interface RangeCalendarHeaderCellProps extends ComponentPropsWithRef<
 > {}
 
 const RangeCalendarHeaderCell = ({className, ...props}: RangeCalendarHeaderCellProps) => {
-  const {slots} = useContext(RangeCalendarContext);
+  const {slots} = use(RangeCalendarContext);
 
   return (
     <CalendarHeaderCellPrimitive
@@ -381,7 +381,7 @@ RangeCalendarHeaderCell.displayName = "HeroUI.RangeCalendar.HeaderCell";
 interface RangeCalendarCellProps extends ComponentPropsWithRef<typeof CalendarCellPrimitive> {}
 
 const RangeCalendarCell = ({children, className, ...props}: RangeCalendarCellProps) => {
-  const {slots} = useContext(RangeCalendarContext);
+  const {slots} = use(RangeCalendarContext);
 
   return (
     <CalendarCellPrimitive
@@ -429,7 +429,7 @@ const RangeCalendarCellIndicator = <E extends keyof React.JSX.IntrinsicElements 
   ...props
 }: RangeCalendarCellIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof RangeCalendarCellIndicatorProps<E>>) => {
-  const {slots} = useContext(RangeCalendarContext);
+  const {slots} = use(RangeCalendarContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/search-field/search-field.tsx
+++ b/packages/react/src/components/search-field/search-field.tsx
@@ -5,7 +5,7 @@ import type {SearchFieldVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {searchFieldVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
 import {Input as InputPrimitive} from "react-aria-components/Input";
 import {SearchField as SearchFieldPrimitive} from "react-aria-components/SearchField";
@@ -60,7 +60,7 @@ const SearchFieldRoot = ({
 interface SearchFieldGroupProps extends ComponentPropsWithRef<typeof GroupPrimitive> {}
 
 const SearchFieldGroup = ({children, className, ...props}: SearchFieldGroupProps) => {
-  const {slots} = useContext(SearchFieldContext);
+  const {slots} = use(SearchFieldContext);
 
   return (
     <GroupPrimitive
@@ -79,7 +79,7 @@ const SearchFieldGroup = ({children, className, ...props}: SearchFieldGroupProps
 interface SearchFieldInputProps extends ComponentPropsWithRef<typeof InputPrimitive> {}
 
 const SearchFieldInput = ({className, ...props}: SearchFieldInputProps) => {
-  const {slots} = useContext(SearchFieldContext);
+  const {slots} = use(SearchFieldContext);
 
   return (
     <InputPrimitive
@@ -106,7 +106,7 @@ const SearchFieldSearchIcon = <E extends keyof React.JSX.IntrinsicElements = "sv
   ...props
 }: SearchFieldSearchIconProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof SearchFieldSearchIconProps<E>>) => {
-  const {slots} = useContext(SearchFieldContext);
+  const {slots} = use(SearchFieldContext);
 
   if (children && React.isValidElement(children)) {
     return React.cloneElement(
@@ -137,7 +137,7 @@ const SearchFieldSearchIcon = <E extends keyof React.JSX.IntrinsicElements = "sv
 interface SearchFieldClearButtonProps extends ComponentPropsWithRef<typeof CloseButton> {}
 
 const SearchFieldClearButton = ({className, ...props}: SearchFieldClearButtonProps) => {
-  const {slots} = useContext(SearchFieldContext);
+  const {slots} = use(SearchFieldContext);
 
   return (
     <CloseButton

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -7,7 +7,7 @@ import type {SelectVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {selectVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
 import {
@@ -66,7 +66,7 @@ const SelectRoot = <T extends object = object, M extends "single" | "multiple" =
 interface SelectTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
 const SelectTrigger = ({children, className, ...props}: SelectTriggerProps) => {
-  const {slots} = useContext(SelectContext);
+  const {slots} = use(SelectContext);
 
   return (
     <ButtonPrimitive
@@ -85,7 +85,7 @@ const SelectTrigger = ({children, className, ...props}: SelectTriggerProps) => {
 interface SelectValueProps extends ComponentPropsWithRef<typeof SelectValuePrimitive> {}
 
 const SelectValue = ({children, className, ...props}: SelectValueProps) => {
-  const {slots} = useContext(SelectContext);
+  const {slots} = use(SelectContext);
 
   return (
     <SelectValuePrimitive
@@ -114,8 +114,8 @@ const SelectIndicator = <E extends keyof React.JSX.IntrinsicElements = "svg">({
   ...props
 }: SelectIndicatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof SelectIndicatorProps<E>>) => {
-  const {slots} = useContext(SelectContext);
-  const state = useContext(SelectStateContext);
+  const {slots} = use(SelectContext);
+  const state = use(SelectStateContext);
 
   if (children && React.isValidElement(children)) {
     return React.cloneElement(
@@ -159,7 +159,7 @@ const SelectPopover = ({
   placement = "bottom",
   ...props
 }: SelectPopoverProps) => {
-  const {slots} = useContext(SelectContext);
+  const {slots} = use(SelectContext);
 
   return (
     <SurfaceContext

--- a/packages/react/src/components/separator/separator.stories.tsx
+++ b/packages/react/src/components/separator/separator.stories.tsx
@@ -75,7 +75,7 @@ export const WithContent: Story = {
   render: () => (
     <div className="max-w-md space-y-4 rounded-3xl bg-surface p-4 shadow-surface">
       {items.map((item, index) => (
-        <div key={index}>
+        <div key={item.title}>
           <div className="flex items-center gap-3">
             <img alt={item.title} className="size-12" src={item.iconUrl} />
             <div className="flex-1 space-y-0">

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef} from "react";
 import type {SliderRenderProps} from "react-aria-components/Slider";
 
 import {sliderVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   SliderOutput as SliderOutputPrimitive,
   Slider as SliderPrimitive,
@@ -71,7 +71,7 @@ const SliderRoot = ({
 interface SliderOutputProps extends ComponentPropsWithRef<typeof SliderOutputPrimitive> {}
 
 const SliderOutput = ({children, className, ...props}: SliderOutputProps) => {
-  const {slots} = useContext(SliderContext);
+  const {slots} = use(SliderContext);
 
   return (
     <SliderOutputPrimitive
@@ -92,7 +92,7 @@ const SliderOutput = ({children, className, ...props}: SliderOutputProps) => {
 interface SliderTrackProps extends ComponentPropsWithRef<typeof SliderTrackPrimitive> {}
 
 const SliderTrack = ({children, className, ...props}: SliderTrackProps) => {
-  const {slots, state} = useContext(SliderContext);
+  const {slots, state} = use(SliderContext);
 
   const {getThumbPercent, values} = state?.state || {};
 
@@ -140,7 +140,7 @@ const SliderFill = <E extends keyof React.JSX.IntrinsicElements = "div">({
   style,
   ...props
 }: SliderFillProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof SliderFillProps<E>>) => {
-  const {slots, state} = useContext(SliderContext);
+  const {slots, state} = use(SliderContext);
 
   const {getThumbPercent, orientation, values} = state?.state || {};
 
@@ -179,7 +179,7 @@ const SliderFill = <E extends keyof React.JSX.IntrinsicElements = "div">({
 interface SliderThumbProps extends ComponentPropsWithRef<typeof SliderThumbPrimitive> {}
 
 const SliderThumb = ({children, className, ...props}: SliderThumbProps) => {
-  const {slots} = useContext(SliderContext);
+  const {slots} = use(SliderContext);
 
   return (
     <SliderThumbPrimitive
@@ -205,7 +205,7 @@ const SliderMarks = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: SliderMarksProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof SliderMarksProps<E>>) => {
-  const {slots} = useContext(SliderContext);
+  const {slots} = use(SliderContext);
 
   return (
     <dom.div

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 import type {SwitchButtonRenderProps, SwitchFieldRenderProps} from "react-aria-components/Switch";
 
 import {switchVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   SwitchButton as SwitchButtonPrimitive,
   SwitchField as SwitchFieldPrimitive,
@@ -55,7 +55,7 @@ SwitchRoot.displayName = "HeroUI.Switch";
 interface SwitchContentProps extends ComponentPropsWithRef<typeof SwitchButtonPrimitive> {}
 
 const SwitchContent = ({children, className, ...props}: SwitchContentProps) => {
-  const {slots} = useContext(SwitchContext);
+  const {slots} = use(SwitchContext);
 
   return (
     <SwitchButtonPrimitive
@@ -84,7 +84,7 @@ const SwitchControl = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: SwitchControlProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof SwitchControlProps<E>>) => {
-  const {slots} = useContext(SwitchContext);
+  const {slots} = use(SwitchContext);
 
   return (
     <dom.span
@@ -113,7 +113,7 @@ const SwitchThumb = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: SwitchThumbProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof SwitchThumbProps<E>>) => {
-  const {slots} = useContext(SwitchContext);
+  const {slots} = use(SwitchContext);
 
   return (
     <dom.span
@@ -142,7 +142,7 @@ const SwitchIcon = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: SwitchIconProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof SwitchIconProps<E>>) => {
-  const {slots} = useContext(SwitchContext);
+  const {slots} = use(SwitchContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -5,7 +5,7 @@ import type {TableVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {tableVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {
   Cell as CellPrimitive,
   Collection as CollectionPrimitive,
@@ -77,7 +77,7 @@ const TableScrollContainer = <E extends keyof React.JSX.IntrinsicElements = "div
   ...props
 }: TableScrollContainerProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof TableScrollContainerProps<E>>) => {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <dom.div
@@ -101,7 +101,7 @@ interface TableContentProps extends Omit<
 }
 
 function TableContent({className, ...props}: TableContentProps) {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <TablePrimitive
@@ -122,7 +122,7 @@ interface TableHeaderProps<T extends object> extends ComponentPropsWithRef<
 > {}
 
 function TableHeader<T extends object>({className, ...props}: TableHeaderProps<T>) {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <TableHeaderPrimitive
@@ -140,20 +140,18 @@ function TableHeader<T extends object>({className, ...props}: TableHeaderProps<T
  * -----------------------------------------------------------------------------------------------*/
 interface TableColumnProps extends ComponentPropsWithRef<typeof ColumnPrimitive> {}
 
-const TableColumn = React.forwardRef<HTMLTableCellElement, TableColumnProps>(
-  ({className, ...props}, ref) => {
-    const {slots} = useContext(TableContext);
+const TableColumn = ({className, ref, ...props}: TableColumnProps) => {
+  const {slots} = use(TableContext);
 
-    return (
-      <ColumnPrimitive
-        ref={ref}
-        className={composeTwRenderProps(className, slots?.column())}
-        data-slot="table-column"
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <ColumnPrimitive
+      ref={ref}
+      className={composeTwRenderProps(className, slots?.column())}
+      data-slot="table-column"
+      {...props}
+    />
+  );
+};
 
 TableColumn.displayName = "HeroUI.Table.Column";
 
@@ -165,7 +163,7 @@ interface TableBodyProps<T extends object> extends ComponentPropsWithRef<
 > {}
 
 function TableBody<T extends object>({className, ...props}: TableBodyProps<T>) {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <TableBodyPrimitive
@@ -184,7 +182,7 @@ function TableBody<T extends object>({className, ...props}: TableBodyProps<T>) {
 interface TableRowProps<T extends object> extends ComponentPropsWithRef<typeof RowPrimitive<T>> {}
 
 function TableRow<T extends object>({className, ...props}: TableRowProps<T>) {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <RowPrimitive
@@ -202,20 +200,18 @@ function TableRow<T extends object>({className, ...props}: TableRowProps<T>) {
  * -----------------------------------------------------------------------------------------------*/
 interface TableCellProps extends ComponentPropsWithRef<typeof CellPrimitive> {}
 
-const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
-  ({className, ...props}, ref) => {
-    const {slots} = useContext(TableContext);
+const TableCell = ({className, ref, ...props}: TableCellProps) => {
+  const {slots} = use(TableContext);
 
-    return (
-      <CellPrimitive
-        ref={ref}
-        className={composeTwRenderProps(className, slots?.cell())}
-        data-slot="table-cell"
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <CellPrimitive
+      ref={ref}
+      className={composeTwRenderProps(className, slots?.cell())}
+      data-slot="table-cell"
+      {...props}
+    />
+  );
+};
 
 TableCell.displayName = "HeroUI.Table.Cell";
 
@@ -233,7 +229,7 @@ const TableFooter = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: TableFooterProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof TableFooterProps<E>>) => {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <dom.div
@@ -253,18 +249,16 @@ interface TableResizableContainerProps extends ComponentPropsWithRef<
   typeof ResizableTableContainerPrimitive
 > {}
 
-const TableResizableContainer = React.forwardRef<HTMLDivElement, TableResizableContainerProps>(
-  ({className, ...props}, ref) => {
-    return (
-      <ResizableTableContainerPrimitive
-        ref={ref}
-        className={cx("table__resizable-container", className)}
-        data-slot="table-resizable-container"
-        {...props}
-      />
-    );
-  },
-);
+const TableResizableContainer = ({className, ref, ...props}: TableResizableContainerProps) => {
+  return (
+    <ResizableTableContainerPrimitive
+      ref={ref}
+      className={cx("table__resizable-container", className)}
+      data-slot="table-resizable-container"
+      {...props}
+    />
+  );
+};
 
 TableResizableContainer.displayName = "HeroUI.Table.ResizableContainer";
 
@@ -273,20 +267,18 @@ TableResizableContainer.displayName = "HeroUI.Table.ResizableContainer";
  * -----------------------------------------------------------------------------------------------*/
 interface TableColumnResizerProps extends ComponentPropsWithRef<typeof ColumnResizerPrimitive> {}
 
-const TableColumnResizer = React.forwardRef<HTMLDivElement, TableColumnResizerProps>(
-  ({className, ...props}, ref) => {
-    const {slots} = useContext(TableContext);
+const TableColumnResizer = ({className, ref, ...props}: TableColumnResizerProps) => {
+  const {slots} = use(TableContext);
 
-    return (
-      <ColumnResizerPrimitive
-        ref={ref}
-        className={composeTwRenderProps(className, slots?.columnResizer())}
-        data-slot="table-column-resizer"
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <ColumnResizerPrimitive
+      ref={ref}
+      className={composeTwRenderProps(className, slots?.columnResizer())}
+      data-slot="table-column-resizer"
+      {...props}
+    />
+  );
+};
 
 TableColumnResizer.displayName = "HeroUI.Table.ColumnResizer";
 
@@ -295,20 +287,18 @@ TableColumnResizer.displayName = "HeroUI.Table.ColumnResizer";
  * -----------------------------------------------------------------------------------------------*/
 interface TableLoadMoreItemProps extends ComponentPropsWithRef<typeof TableLoadMoreItemPrimitive> {}
 
-const TableLoadMoreItem = React.forwardRef<HTMLTableRowElement, TableLoadMoreItemProps>(
-  ({className, ...props}, ref) => {
-    const {slots} = useContext(TableContext);
+const TableLoadMoreItem = ({className, ref, ...props}: TableLoadMoreItemProps) => {
+  const {slots} = use(TableContext);
 
-    return (
-      <TableLoadMoreItemPrimitive
-        ref={ref}
-        className={composeSlotClassName(slots?.loadMore, className)}
-        data-slot="table-load-more"
-        {...props}
-      />
-    );
-  },
-);
+  return (
+    <TableLoadMoreItemPrimitive
+      ref={ref}
+      className={composeSlotClassName(slots?.loadMore, className)}
+      data-slot="table-load-more"
+      {...props}
+    />
+  );
+};
 
 TableLoadMoreItem.displayName = "HeroUI.Table.LoadMore";
 
@@ -327,7 +317,7 @@ const TableLoadMoreContent = <E extends keyof React.JSX.IntrinsicElements = "div
   ...props
 }: TableLoadMoreContentProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof TableLoadMoreContentProps<E>>) => {
-  const {slots} = useContext(TableContext);
+  const {slots} = use(TableContext);
 
   return (
     <dom.div
@@ -346,7 +336,7 @@ TableLoadMoreContent.displayName = "HeroUI.Table.LoadMoreContent";
 type TableSortDirection = "ascending" | "descending";
 
 interface TableSortableColumnHeaderProps extends Omit<
-  React.ComponentPropsWithoutRef<"span">,
+  React.ComponentPropsWithRef<"span">,
   "children"
 > {
   /** Label content of the column header. */
@@ -369,54 +359,60 @@ interface TableSortableColumnHeaderProps extends Omit<
   indicator?: ReactNode;
 }
 
-const TableSortableColumnHeader = React.forwardRef<HTMLSpanElement, TableSortableColumnHeaderProps>(
-  ({children, className, indicator, showIndicator = true, sortDirection, ...props}, ref) => {
-    const {slots} = useContext(TableContext);
+const TableSortableColumnHeader = ({
+  children,
+  className,
+  indicator,
+  ref,
+  showIndicator = true,
+  sortDirection,
+  ...props
+}: TableSortableColumnHeaderProps) => {
+  const {slots} = use(TableContext);
 
-    const shouldRenderIndicator = showIndicator && !!sortDirection;
+  const shouldRenderIndicator = showIndicator && !!sortDirection;
 
-    let indicatorElement: ReactNode = null;
+  let indicatorElement: ReactNode = null;
 
-    if (shouldRenderIndicator) {
-      if (indicator === undefined) {
-        indicatorElement = (
-          <IconChevronUp
-            className={slots?.sortableColumnIndicator()}
-            data-direction={sortDirection}
-            data-slot="table-sortable-column-indicator"
-          />
-        );
-      } else if (React.isValidElement(indicator)) {
-        const element = indicator as React.ReactElement<{
-          className?: string;
-          "data-direction"?: TableSortDirection;
-          "data-slot"?: "table-sortable-column-indicator";
-        }>;
+  if (shouldRenderIndicator) {
+    if (indicator === undefined) {
+      indicatorElement = (
+        <IconChevronUp
+          className={slots?.sortableColumnIndicator()}
+          data-direction={sortDirection}
+          data-slot="table-sortable-column-indicator"
+        />
+      );
+    } else if (React.isValidElement(indicator)) {
+      const element = indicator as React.ReactElement<{
+        className?: string;
+        "data-direction"?: TableSortDirection;
+        "data-slot"?: "table-sortable-column-indicator";
+      }>;
 
-        indicatorElement = React.cloneElement(element, {
-          className: composeSlotClassName(slots?.sortableColumnIndicator, element.props.className),
-          "data-direction": sortDirection,
-          "data-slot": "table-sortable-column-indicator",
-        });
-      } else {
-        indicatorElement = indicator;
-      }
+      indicatorElement = React.cloneElement(element, {
+        className: composeSlotClassName(slots?.sortableColumnIndicator, element.props.className),
+        "data-direction": sortDirection,
+        "data-slot": "table-sortable-column-indicator",
+      });
+    } else {
+      indicatorElement = indicator;
     }
+  }
 
-    return (
-      <span
-        ref={ref}
-        className={composeSlotClassName(slots?.sortableColumnHeader, className)}
-        data-direction={sortDirection}
-        data-slot="table-sortable-column-header"
-        {...props}
-      >
-        {children}
-        {indicatorElement}
-      </span>
-    );
-  },
-);
+  return (
+    <span
+      ref={ref}
+      className={composeSlotClassName(slots?.sortableColumnHeader, className)}
+      data-direction={sortDirection}
+      data-slot="table-sortable-column-header"
+      {...props}
+    >
+      {children}
+      {indicatorElement}
+    </span>
+  );
+};
 
 TableSortableColumnHeader.displayName = "HeroUI.Table.SortableColumnHeader";
 

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -5,7 +5,7 @@ import type {TabsVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {tabsVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {SelectionIndicator as SelectionIndicatorPrimitive} from "react-aria-components/SelectionIndicator";
 import {
   TabList as TabListPrimitive,
@@ -74,7 +74,7 @@ const TabListContainer = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...props
 }: TabListContainerProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof TabListContainerProps<E>>) => {
-  const {slots} = useContext(TabsContext);
+  const {slots} = use(TabsContext);
 
   return (
     <dom.div
@@ -96,7 +96,7 @@ interface TabListProps extends ComponentPropsWithRef<typeof TabListPrimitive<obj
 }
 
 const TabList = ({children, className, ...props}: TabListProps) => {
-  const {slots} = useContext(TabsContext);
+  const {slots} = use(TabsContext);
 
   return (
     <TabListPrimitive
@@ -117,7 +117,7 @@ interface TabProps extends ComponentPropsWithRef<typeof TabPrimitive> {
 }
 
 const Tab = ({children, className, ...props}: TabProps) => {
-  const {slots} = useContext(TabsContext);
+  const {slots} = use(TabsContext);
 
   return (
     <TabPrimitive
@@ -138,7 +138,7 @@ interface TabIndicatorProps extends ComponentPropsWithRef<typeof SelectionIndica
 }
 
 const TabIndicator = ({className, ...props}: TabIndicatorProps) => {
-  const {slots} = useContext(TabsContext);
+  const {slots} = use(TabsContext);
 
   return (
     <SelectionIndicatorPrimitive
@@ -158,7 +158,7 @@ interface TabPanelProps extends Omit<ComponentPropsWithRef<typeof TabPanelPrimit
 }
 
 const TabPanel = ({children, className, ...props}: TabPanelProps) => {
-  const {slots} = useContext(TabsContext);
+  const {slots} = use(TabsContext);
 
   return (
     <TabPanelPrimitive
@@ -184,7 +184,7 @@ const TabSeparator = <E extends keyof React.JSX.IntrinsicElements = "span">({
   className,
   ...props
 }: TabSeparatorProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof TabSeparatorProps<E>>) => {
-  const {slots} = useContext(TabsContext);
+  const {slots} = use(TabsContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/tag-group/tag-group.tsx
+++ b/packages/react/src/components/tag-group/tag-group.tsx
@@ -4,7 +4,7 @@ import type {TagVariants} from "../tag";
 import type {ComponentPropsWithRef} from "react";
 
 import {tagGroupVariants} from "@heroui/styles";
-import React, {createContext, useContext, useMemo} from "react";
+import React, {createContext, use, useMemo} from "react";
 import {
   TagGroup as TagGroupPrimitive,
   TagList as TagListPrimitive,
@@ -59,7 +59,7 @@ const TagGroupList = <T extends object>({
   className,
   ...restProps
 }: TagGroupListProps<T>) => {
-  const {slots} = useContext(TagGroupContext);
+  const {slots} = use(TagGroupContext);
 
   return (
     <TagListPrimitive

--- a/packages/react/src/components/tag/tag.tsx
+++ b/packages/react/src/components/tag/tag.tsx
@@ -5,7 +5,7 @@ import type {ComponentPropsWithRef} from "react";
 import type {Button as ButtonPrimitive} from "react-aria-components/Button";
 
 import {tagVariants} from "@heroui/styles";
-import React, {Children, createContext, useContext, useMemo} from "react";
+import React, {Children, createContext, use, useMemo} from "react";
 import {Tag as TagPrimitive} from "react-aria-components/TagGroup";
 
 import {pickChildren} from "../../utils/children";
@@ -28,7 +28,7 @@ const TagContext = createContext<TagContext>({});
 interface TagRootProps extends ComponentPropsWithRef<typeof TagPrimitive>, TagVariants {}
 
 const TagRoot = ({children, className, ...restProps}: TagRootProps) => {
-  const {size, variant} = useContext(TagGroupContext);
+  const {size, variant} = use(TagGroupContext);
 
   const slots = useMemo(() => tagVariants({size, variant}), [size, variant]);
 
@@ -91,7 +91,7 @@ type TagRemoveButtonProps = ComponentPropsWithRef<typeof ButtonPrimitive> & {
 };
 
 const TagRemoveButton = ({children, className, ...restProps}: TagRemoveButtonProps) => {
-  const {slots} = useContext(TagContext);
+  const {slots} = use(TagContext);
 
   return (
     <CloseButton

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -4,7 +4,7 @@ import type {TextAreaVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {textAreaVariants} from "@heroui/styles";
-import React, {useContext} from "react";
+import React, {use} from "react";
 import {TextArea as TextAreaPrimitive} from "react-aria-components/TextArea";
 
 import {composeTwRenderProps} from "../../utils";
@@ -17,7 +17,7 @@ interface TextAreaRootProps
   extends ComponentPropsWithRef<typeof TextAreaPrimitive>, TextAreaVariants {}
 
 const TextAreaRoot = ({className, fullWidth, variant, ...rest}: TextAreaRootProps) => {
-  const textFieldContext = useContext(TextFieldContext);
+  const textFieldContext = use(TextFieldContext);
   const resolvedVariant = variant ?? textFieldContext?.variant;
 
   return (

--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -9,8 +9,8 @@ import type {QueuedToast, ToastProps as ToastPrimitiveProps} from "react-aria-co
 import {toastVariants} from "@heroui/styles";
 import React, {
   createContext,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -84,12 +84,12 @@ const Toast = <T extends object = ToastContentValue>({
     placement: contextPlacement,
     scaleFactor: contextScaleFactor,
     slots,
-  } = useContext(ToastContext);
+  } = use(ToastContext);
 
   const finalPlacement = placement ?? contextPlacement;
   const finalScaleFactor = scaleFactor ?? contextScaleFactor;
 
-  const state = useContext(ToastStateContext)!;
+  const state = use(ToastStateContext)!;
   const visibleToasts = state.visibleToasts;
   const index = visibleToasts.indexOf(toast);
   const isFrontmost = index <= 0;
@@ -193,7 +193,7 @@ Toast.displayName = "HeroUI.Toast";
 interface ToastContentProps extends ComponentPropsWithRef<typeof ToastContentPrimitive> {}
 
 const ToastContent = ({children, className, ...rest}: ToastContentProps) => {
-  const {slots} = useContext(ToastContext);
+  const {slots} = use(ToastContext);
 
   return (
     <ToastContentPrimitive
@@ -223,7 +223,7 @@ const ToastIndicator = <E extends keyof React.JSX.IntrinsicElements = "div">({
   variant,
   ...rest
 }: ToastIndicatorProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof ToastIndicatorProps<E>>) => {
-  const {slots} = useContext(ToastContext);
+  const {slots} = use(ToastContext);
 
   const getDefaultIcon = useCallback(() => {
     switch (variant) {
@@ -259,7 +259,7 @@ ToastIndicator.displayName = "HeroUI.ToastIndicator";
 interface ToastTitleProps extends ComponentPropsWithRef<typeof TextPrimitive> {}
 
 const ToastTitle = ({children, className, ...rest}: ToastTitleProps) => {
-  const {slots} = useContext(ToastContext);
+  const {slots} = use(ToastContext);
 
   return (
     <TextPrimitive
@@ -281,7 +281,7 @@ ToastTitle.displayName = "HeroUI.ToastTitle";
 interface ToastDescriptionProps extends ComponentPropsWithRef<typeof TextPrimitive> {}
 
 const ToastDescription = ({children, className, ...rest}: ToastDescriptionProps) => {
-  const {slots} = useContext(ToastContext);
+  const {slots} = use(ToastContext);
 
   return (
     <TextPrimitive
@@ -303,7 +303,7 @@ ToastDescription.displayName = "HeroUI.ToastDescription";
 interface ToastCloseButtonProps extends ComponentPropsWithRef<typeof CloseButton> {}
 
 const ToastCloseButton = ({className, ...rest}: ToastCloseButtonProps) => {
-  const {slots} = useContext(ToastContext);
+  const {slots} = use(ToastContext);
 
   return (
     <CloseButton
@@ -323,7 +323,7 @@ ToastCloseButton.displayName = "HeroUI.ToastCloseButton";
 interface ToastActionButtonProps extends ComponentPropsWithRef<typeof Button> {}
 
 const ToastActionButton = ({children, className, ...rest}: ToastActionButtonProps) => {
-  const {slots} = useContext(ToastContext);
+  const {slots} = use(ToastContext);
 
   return (
     <Button

--- a/packages/react/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/packages/react/src/components/toggle-button-group/toggle-button-group.tsx
@@ -5,7 +5,7 @@ import type {ToggleButtonGroupVariants, ToggleButtonVariants} from "@heroui/styl
 import type {ComponentPropsWithRef} from "react";
 
 import {toggleButtonGroupVariants} from "@heroui/styles";
-import React, {createContext, useContext} from "react";
+import React, {createContext, use} from "react";
 import {useSlottedContext} from "react-aria-components/slots";
 import {
   ToggleButtonGroupContext as RACToggleButtonGroupContext,
@@ -87,7 +87,7 @@ const ToggleButtonGroupSeparator = <E extends keyof React.JSX.IntrinsicElements 
   ...props
 }: ToggleButtonGroupSeparatorProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof ToggleButtonGroupSeparatorProps<E>>) => {
-  const {slots} = useContext(ToggleButtonGroupContext);
+  const {slots} = use(ToggleButtonGroupContext);
 
   return (
     <dom.span

--- a/packages/react/src/components/toggle-button/toggle-button.tsx
+++ b/packages/react/src/components/toggle-button/toggle-button.tsx
@@ -4,7 +4,7 @@ import type {ToggleButtonVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef} from "react";
 
 import {toggleButtonVariants} from "@heroui/styles";
-import {useContext} from "react";
+import {use} from "react";
 import {ToggleButton as ToggleButtonPrimitive} from "react-aria-components/ToggleButton";
 
 import {composeTwRenderProps} from "../../utils";
@@ -25,7 +25,7 @@ const ToggleButtonRoot = ({
   variant,
   ...rest
 }: ToggleButtonRootProps) => {
-  const groupContext = useContext(ToggleButtonGroupContext);
+  const groupContext = use(ToggleButtonGroupContext);
 
   // Merge props with precedence: direct props > context props
   const finalSize = size ?? groupContext?.size;

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -6,7 +6,7 @@ import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {tooltipVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
-import React, {createContext, useContext, useRef} from "react";
+import React, {createContext, use, useRef} from "react";
 import {useFocusable} from "react-aria/useFocusable";
 import {
   OverlayArrow,
@@ -77,7 +77,7 @@ const TooltipContent = ({
   showArrow = false,
   ...props
 }: TooltipContentProps) => {
-  const {slots} = useContext(TooltipContext);
+  const {slots} = use(TooltipContext);
   const offset = offsetProp ? offsetProp : showArrow ? 7 : 3;
 
   return (
@@ -146,7 +146,7 @@ const TooltipTrigger = <E extends keyof React.JSX.IntrinsicElements = "div">({
   className,
   ...props
 }: TooltipTriggerProps<E> & Omit<React.JSX.IntrinsicElements[E], keyof TooltipTriggerProps<E>>) => {
-  const {slots} = useContext(TooltipContext);
+  const {slots} = use(TooltipContext);
   const triggerRef = useRef<HTMLElement | null>(null);
   // Use the `useFocusable` hook directly rather than the `<Focusable>` wrapper component.
   // Both consume the FocusableContext provided by TooltipTriggerPrimitive's internal

--- a/packages/react/src/utils/dom.tsx
+++ b/packages/react/src/utils/dom.tsx
@@ -6,10 +6,10 @@
  * Remove it and import directly from react-aria-components when they export it.
  */
 
-import type {AllHTMLAttributes, ForwardedRef, ReactElement} from "react";
+import type {AllHTMLAttributes, ReactElement} from "react";
 
 import {mergeRefs, useLayoutEffect} from "@react-aria/utils";
-import React, {forwardRef, useMemo, useRef} from "react";
+import React, {useMemo, useRef} from "react";
 
 export type DOMRenderFunction<E extends keyof React.JSX.IntrinsicElements, T> = (
   props: React.JSX.IntrinsicElements[E],
@@ -33,10 +33,9 @@ export interface DOMRenderProps<E extends keyof React.JSX.IntrinsicElements, T> 
 // eslint-disable-next-line react-refresh/only-export-components
 function DOMElement(
   ElementType: string,
-  props: DOMRenderProps<any, any> & AllHTMLAttributes<HTMLElement>,
-  forwardedRef: ForwardedRef<HTMLElement>,
+  props: DOMRenderProps<any, any> & AllHTMLAttributes<HTMLElement> & {ref?: React.Ref<HTMLElement>},
 ) {
-  const {render, ...otherProps} = props;
+  const {ref: forwardedRef, render, ...otherProps} = props;
   const elementRef = useRef<HTMLElement | null>(null);
   const ref = useMemo(() => mergeRefs(forwardedRef, elementRef), [forwardedRef, elementRef]);
 
@@ -79,7 +78,7 @@ export const dom = new Proxy(
       let res = domComponentCache[elementType];
 
       if (!res) {
-        res = forwardRef(DOMElement.bind(null, elementType));
+        res = DOMElement.bind(null, elementType);
         domComponentCache[elementType] = res;
       }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Catering part of react-doctor scan issues

This pull request updates several React components (`Accordion`, `AlertDialog`, `Alert`, and `Autocomplete`) to use the new React `use` hook for context consumption instead of the older `useContext` API. Additionally, it improves key handling in `Accordion` story files to use more stable keys. These changes modernize the codebase, improve performance, and help prepare for future React features.

**React Context API Modernization:**

* Replaced all usages of `useContext` with the new React `use` hook for context consumption in `accordion.tsx`, `alert-dialog.tsx`, `alert.tsx`, and `autocomplete.tsx`. This affects all context consumers in these files, making the code compatible with future React features and improving performance. [[1]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL9-R9) [[2]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL75-R75) [[3]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL105-R106) [[4]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL142-R142) [[5]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL159-R159) [[6]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL190-R190) [[7]](diffhunk://#diff-827d6c90a6456bb1e552adabb2a5419a287991ef71a9a27a49d56c4dbeddfa2eL205-R206) [[8]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL10-R10) [[9]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL67-R67) [[10]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL111-R111) [[11]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL163-R163) [[12]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL194-R194) [[13]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL215-R215) [[14]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL234-R234) [[15]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL254-R254) [[16]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL273-R273) [[17]](diffhunk://#diff-d7401f0f887b31476c8d495fc8d6ac44edf1398349fd6cfd4f5e8d26f3c24d3aL340-R340) [[18]](diffhunk://#diff-7e7f14058de8134f4d0ec328e58138ce9f9269a045d59d58be030cf60e29e917L9-R9) [[19]](diffhunk://#diff-7e7f14058de8134f4d0ec328e58138ce9f9269a045d59d58be030cf60e29e917L76-R76) [[20]](diffhunk://#diff-7e7f14058de8134f4d0ec328e58138ce9f9269a045d59d58be030cf60e29e917L120-R120) [[21]](diffhunk://#diff-7e7f14058de8134f4d0ec328e58138ce9f9269a045d59d58be030cf60e29e917L149-R149) [[22]](diffhunk://#diff-7e7f14058de8134f4d0ec328e58138ce9f9269a045d59d58be030cf60e29e917L178-R178) [[23]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L11-R11) [[24]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L91-R100) [[25]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L134-R135) [[26]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L145-R145) [[27]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L174-R175) [[28]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L222-R222)

**Component Improvements:**

* Refactored `AutocompleteTrigger` from a `forwardRef` component to a regular function component, as context now provides refs directly and a callback ref is used for updates. [[1]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L91-R100) [[2]](diffhunk://#diff-c004f85dfcbe9f4e09ad14bdfec035b56c6c196dedbee7af94c75b98a6d60386L134-R135)

**Storybook Key Handling:**

* Updated `Accordion` story files to use `item.title` as the key instead of the array index, making keys more stable and preventing potential rendering issues. [[1]](diffhunk://#diff-80dfc5a36be53a1f5f6d6d12f623774e89fdbb0af8b0d7371f0d135598d0b56fL41-R42) [[2]](diffhunk://#diff-80dfc5a36be53a1f5f6d6d12f623774e89fdbb0af8b0d7371f0d135598d0b56fL78-R79) [[3]](diffhunk://#diff-80dfc5a36be53a1f5f6d6d12f623774e89fdbb0af8b0d7371f0d135598d0b56fL138-R139)

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
