### PR TITLE
fix(react): declare react-aria & react-aria-components to caret ranges to dedupe with Pro

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,8 +64,8 @@
     "@react-types/color": "3.2.0",
     "@react-stately/utils": "3.12.1",
     "input-otp": "1.4.2",
-    "react-aria": "3.50.0",
-    "react-aria-components": "1.19.0",
+    "react-aria": "^3.50.0",
+    "react-aria-components": "^1.19.0",
     "tailwind-merge": "3.4.0",
     "tailwind-variants": "3.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,10 +383,10 @@ importers:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-aria:
-        specifier: 3.50.0
+        specifier: ^3.50.0
         version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-aria-components:
-        specifier: 1.19.0
+        specifier: ^1.19.0
         version: 1.19.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
         specifier: 3.4.0
@@ -9547,7 +9547,7 @@ snapshots:
       react: 19.2.6
       react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
   '@react-spectrum/color@3.2.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -9555,7 +9555,7 @@ snapshots:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
   '@react-spectrum/provider@3.11.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -9569,21 +9569,21 @@ snapshots:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
   '@react-stately/data@3.16.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
   '@react-stately/utils@3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-stately: 3.47.0(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
 
   '@react-types/color@3.2.0(@react-spectrum/provider@3.11.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported by Pro user in Support Center

`@heroui/react` pinned `react-aria` and `react-aria-components` as **exact** versions (`3.50.0` / `1.19.0`), while `@heroui-pro/react` declares `react-aria-components` as a range/peer. When both packages are installed together, the exact pin forces `@heroui/react` to nest its own copy while Pro resolves the hoisted one, so **two
instances** of react-aria / react-aria-components load at once.

react-aria-components matches its overlay contexts by object identity, so with two instances a `Select.Popover` (OSS) opened inside a `Sheet.Dialog` (Pro) reads a different `OverlayTriggerStateContext` / `ModalContext` / `PopoverContext` / `DialogContext` than the Sheet provides. The popover can't register in the Sheet's modal scope, so the outside-press logic treats it as an outside click and closes it immediately; `onChange` fires unreliably.
This PR widens `react-aria` (`^3.50.0`) and `react-aria-components` (`^1.19.0`) from exact pins to **caret ranges**, still as regular dependencies. Overlapping ranges let package managers collapse to a single shared instance across `@heroui/react` and `@heroui-pro/react`, while `@heroui/react` continues to ship the primitives itself — so standalone installs keep working with no new peer-dependency or `auto-install-peers` requirement.

Note: a peer-dependency approach was evaluated and rejected — it broke standalone/older consumers at runtime (e.g. an app resolving `react-aria-components@1.17.0` crashed on the missing `CheckboxButton` export). Caret regular dependencies fix the dedupe (the exact pin was the real cause) without that risk.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

```
npm ls react-aria-components react-aria react-stately

├─┬ @heroui-pro/react@1.0.0-beta.6 -> ./node_modules/.pnpm/@heroui-pro+react@1.0.0-beta.6/node_modules/@heroui-pro/react
│ ├─┬ @react-aria/utils@3.34.1 -> ./node_modules/.pnpm/@react-aria+utils@3.34.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/utils
│ │ ├─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-stately/utils@3.12.1 -> ./node_modules/.pnpm/@react-stately+utils@3.12.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-stately/utils
│ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ └── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
├─┬ @heroui/react@3.2.1 -> ./node_modules/.pnpm/@heroui+react@3.2.1_@react-spectrum+provider@3.11.1_react-dom@19.2.4_react@19.2.4__reac_cc4328ea5e9bb257c3a4afc305100228/node_modules/@heroui/react
│ ├─┬ @react-aria/i18n@3.13.1 -> ./node_modules/.pnpm/@react-aria+i18n@3.13.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/i18n
│ │ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-aria/ssr@3.10.1 -> ./node_modules/.pnpm/@react-aria+ssr@3.10.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/ssr
│ │ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-aria/utils@3.34.1 -> ./node_modules/.pnpm/@react-aria+utils@3.34.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/utils
│ │ ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-stately/utils@3.12.1 -> ./node_modules/.pnpm/@react-stately+utils@3.12.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-stately/utils
│ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-types/color@3.2.0 -> ./node_modules/.pnpm/@react-types+color@3.2.0_@react-spectrum+provider@3.11.1_react-dom@19.2.4_react@19.2.4__5d99e43099cafe519812ae398858fafd/node_modules/@react-types/color
│ │ ├─┬ @react-aria/color@3.2.1 -> ./node_modules/.pnpm/@react-aria+color@3.2.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/color
│ │ │ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ ├─┬ @react-spectrum/color@3.2.1 -> ./node_modules/.pnpm/@react-spectrum+color@3.2.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-spectrum/color
│ │ │ ├─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │ │ ├─┬ @spectrum-icons/ui@3.7.1 -> ./node_modules/.pnpm/@spectrum-icons+ui@3.7.1_@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__re_13ed4baabb17fb598a0c8057493d9d60/node_modules/@spectrum-icons/ui
│ │ │ │ │ └─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │ │ │   ├── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │ │ │   ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ ├─┬ @spectrum-icons/workflow@4.3.1 -> ./node_modules/.pnpm/@spectrum-icons+workflow@4.3.1_@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2_81d4762b4c8ab0c211107214c9a95eb9/node_modules/@spectrum-icons/workflow
│ │ │ │ │ └─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │ │ │   ├── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │ │ │   ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ ├─┬ react-aria-components@1.19.0 -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │ │ │ ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ ├─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ ├─┬ @react-spectrum/provider@3.11.1 -> ./node_modules/.pnpm/@react-spectrum+provider@3.11.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-spectrum/provider
│ │ │ └─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │   ├── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │   ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ └─┬ @react-stately/color@3.10.1 -> ./node_modules/.pnpm/@react-stately+color@3.10.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-stately/color
│ │   └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ react-aria-components@1.18.0 -> ./node_modules/.pnpm/react-aria-components@1.18.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ ├─┬ react-aria@3.49.0 -> ./node_modules/.pnpm/react-aria@3.49.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ └── react-stately@3.47.0 deduped -> ./node_modules/.pnpm/react-stately@3.47.0_react@19.2.4/node_modules/react-stately
│ │ └── react-stately@3.47.0 -> ./node_modules/.pnpm/react-stately@3.47.0_react@19.2.4/node_modules/react-stately
│ └─┬ react-aria@3.49.0 -> ./node_modules/.pnpm/react-aria@3.49.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│   └── react-stately@3.47.0 -> ./node_modules/.pnpm/react-stately@3.47.0_react@19.2.4/node_modules/react-stately
└─┬ react-aria-components@1.19.0 -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
  ├─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
  │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
  └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
```

Select is not able to open

<img width="738" height="447" alt="image" src="https://github.com/user-attachments/assets/c9eb9cf4-659c-4cb6-b82c-ce77022abda8" />


## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

```
npm ls react-aria-components react-aria react-stately    

├─┬ @heroui-pro/react@1.0.0-beta.6 -> ./node_modules/.pnpm/@heroui-pro+react@1.0.0-beta.6/node_modules/@heroui-pro/react
│ ├─┬ @react-aria/utils@3.34.1 -> ./node_modules/.pnpm/@react-aria+utils@3.34.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/utils
│ │ ├─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-stately/utils@3.12.1 -> ./node_modules/.pnpm/@react-stately+utils@3.12.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-stately/utils
│ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ └── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
├─┬ @heroui/react@3.2.1 -> ./node_modules/.pnpm/@heroui+react@file+..+..+Documents+GitHub+heroui+heroui-react-3.2.1.tgz_@react-spectrum_7b97cc6a7b7ae19fa5a606c21b8c1acc/node_modules/@heroui/react
│ ├─┬ @react-aria/i18n@3.13.1 -> ./node_modules/.pnpm/@react-aria+i18n@3.13.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/i18n
│ │ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-aria/ssr@3.10.1 -> ./node_modules/.pnpm/@react-aria+ssr@3.10.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/ssr
│ │ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-aria/utils@3.34.1 -> ./node_modules/.pnpm/@react-aria+utils@3.34.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/utils
│ │ ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-stately/utils@3.12.1 -> ./node_modules/.pnpm/@react-stately+utils@3.12.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-stately/utils
│ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ @react-types/color@3.2.0 -> ./node_modules/.pnpm/@react-types+color@3.2.0_@react-spectrum+provider@3.11.1_react-dom@19.2.4_react@19.2.4__5d99e43099cafe519812ae398858fafd/node_modules/@react-types/color
│ │ ├─┬ @react-aria/color@3.2.1 -> ./node_modules/.pnpm/@react-aria+color@3.2.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-aria/color
│ │ │ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ ├─┬ @react-spectrum/color@3.2.1 -> ./node_modules/.pnpm/@react-spectrum+color@3.2.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-spectrum/color
│ │ │ ├─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │ │ ├─┬ @spectrum-icons/ui@3.7.1 -> ./node_modules/.pnpm/@spectrum-icons+ui@3.7.1_@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__re_13ed4baabb17fb598a0c8057493d9d60/node_modules/@spectrum-icons/ui
│ │ │ │ │ └─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │ │ │   ├── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │ │ │   ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ ├─┬ @spectrum-icons/workflow@4.3.1 -> ./node_modules/.pnpm/@spectrum-icons+workflow@4.3.1_@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2_81d4762b4c8ab0c211107214c9a95eb9/node_modules/@spectrum-icons/workflow
│ │ │ │ │ └─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │ │ │   ├── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │ │ │   ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ ├─┬ react-aria-components@1.19.0 -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │ │ │ ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ ├─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │ │ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ │ └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ ├─┬ @react-spectrum/provider@3.11.1 -> ./node_modules/.pnpm/@react-spectrum+provider@3.11.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-spectrum/provider
│ │ │ └─┬ @adobe/react-spectrum@3.47.2 -> ./node_modules/.pnpm/@adobe+react-spectrum@3.47.2_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@adobe/react-spectrum
│ │ │   ├── react-aria-components@1.19.0 deduped -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ │   ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ │   └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ │ └─┬ @react-stately/color@3.10.1 -> ./node_modules/.pnpm/@react-stately+color@3.10.1_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/@react-stately/color
│ │   └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ ├─┬ react-aria-components@1.19.0 -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
│ │ ├── react-aria@3.50.0 deduped -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│ │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
│ └─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
│   └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
└─┬ react-aria-components@1.19.0 -> ./node_modules/.pnpm/react-aria-components@1.19.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria-components
  ├─┬ react-aria@3.50.0 -> ./node_modules/.pnpm/react-aria@3.50.0_react-dom@19.2.4_react@19.2.4__react@19.2.4/node_modules/react-aria
  │ └── react-stately@3.48.0 deduped -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
  └── react-stately@3.48.0 -> ./node_modules/.pnpm/react-stately@3.48.0_react@19.2.4/node_modules/react-stately
```

Select is able to open. onSelectionChange works as expected.

<img width="749" height="437" alt="image" src="https://github.com/user-attachments/assets/dcfe8d09-7c71-45fe-adba-1cf4bb4d5423" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information

```
// oss 
pnpm build --filter=@heroui/react
pnpm --filter=@heroui/react pack

// pro app
npm install <your_path>/heroui/packages/react/heroui-react-3.2.1.tgz
npm ls react-aria-components react-aria react-stately
```
