### PR TITLE
fix(autocomplete): add accessible name to popover dialog and search field demo

### DIFF
--- a/apps/docs/src/demos/cn/autocomplete/allows-empty-collection.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/allows-empty-collection.tsx
@@ -20,7 +20,7 @@ export function AllowsEmptyCollection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/asynchronous-filtering.tsx
@@ -38,7 +38,13 @@ export function AsynchronousFiltering() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="搜索"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索角色…" />

--- a/apps/docs/src/demos/cn/autocomplete/controlled-open-state.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/controlled-open-state.tsx
@@ -41,7 +41,7 @@ export function ControlledOpenState() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/controlled.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/controlled.tsx
@@ -37,7 +37,7 @@ export function Controlled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/custom-indicator.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/custom-indicator.tsx
@@ -37,7 +37,7 @@ export function CustomIndicator() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/default.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/cn/autocomplete/disabled.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/disabled.tsx
@@ -40,7 +40,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />
@@ -73,7 +73,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索国家…" />

--- a/apps/docs/src/demos/cn/autocomplete/email-recipients.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/email-recipients.tsx
@@ -73,7 +73,7 @@ export function EmailRecipients() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索邮箱…" />

--- a/apps/docs/src/demos/cn/autocomplete/full-width.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/full-width.tsx
@@ -44,7 +44,7 @@ export function FullWidth() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/location-search.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/location-search.tsx
@@ -61,7 +61,7 @@ export function LocationSearch() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={customFilter}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索城市…" />

--- a/apps/docs/src/demos/cn/autocomplete/multiple-select.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/multiple-select.tsx
@@ -73,7 +73,7 @@ export function MultipleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/cn/autocomplete/required.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/required.tsx
@@ -63,7 +63,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />
@@ -97,7 +97,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索国家…" />

--- a/apps/docs/src/demos/cn/autocomplete/single-select.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/single-select.tsx
@@ -35,7 +35,7 @@ export default function SingleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索动物…" />

--- a/apps/docs/src/demos/cn/autocomplete/tag-group-selection.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/tag-group-selection.tsx
@@ -75,7 +75,7 @@ export function TagGroupSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索标签…" />

--- a/apps/docs/src/demos/cn/autocomplete/user-selection-multiple.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/user-selection-multiple.tsx
@@ -113,7 +113,7 @@ export function UserSelectionMultiple() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索用户…" />

--- a/apps/docs/src/demos/cn/autocomplete/user-selection.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/user-selection.tsx
@@ -102,7 +102,7 @@ export function UserSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索用户…" />

--- a/apps/docs/src/demos/cn/autocomplete/variants.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/variants.tsx
@@ -57,7 +57,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />
@@ -91,7 +91,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />
@@ -156,7 +156,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />
@@ -216,7 +216,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/cn/autocomplete/virtualization.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/virtualization.tsx
@@ -115,7 +115,13 @@ export function Virtualization() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="搜索"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索用户…" />

--- a/apps/docs/src/demos/cn/autocomplete/with-description.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/with-description.tsx
@@ -42,7 +42,7 @@ export function WithDescription() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/with-disabled-options.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/with-disabled-options.tsx
@@ -26,7 +26,7 @@ export function WithDisabledOptions() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索动物…" />

--- a/apps/docs/src/demos/cn/autocomplete/with-sections.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/with-sections.tsx
@@ -34,7 +34,7 @@ export function WithSections() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索国家…" />

--- a/apps/docs/src/demos/en/autocomplete/allows-empty-collection.tsx
+++ b/apps/docs/src/demos/en/autocomplete/allows-empty-collection.tsx
@@ -20,7 +20,7 @@ export function AllowsEmptyCollection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/en/autocomplete/asynchronous-filtering.tsx
@@ -38,7 +38,13 @@ export function AsynchronousFiltering() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="Search"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search characters..." />

--- a/apps/docs/src/demos/en/autocomplete/controlled-open-state.tsx
+++ b/apps/docs/src/demos/en/autocomplete/controlled-open-state.tsx
@@ -41,7 +41,7 @@ export function ControlledOpenState() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/controlled.tsx
+++ b/apps/docs/src/demos/en/autocomplete/controlled.tsx
@@ -37,7 +37,7 @@ export function Controlled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/custom-indicator.tsx
+++ b/apps/docs/src/demos/en/autocomplete/custom-indicator.tsx
@@ -37,7 +37,7 @@ export function CustomIndicator() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/default.tsx
+++ b/apps/docs/src/demos/en/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/en/autocomplete/disabled.tsx
+++ b/apps/docs/src/demos/en/autocomplete/disabled.tsx
@@ -40,7 +40,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -73,7 +73,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />

--- a/apps/docs/src/demos/en/autocomplete/email-recipients.tsx
+++ b/apps/docs/src/demos/en/autocomplete/email-recipients.tsx
@@ -73,7 +73,7 @@ export function EmailRecipients() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search emails..." />

--- a/apps/docs/src/demos/en/autocomplete/full-width.tsx
+++ b/apps/docs/src/demos/en/autocomplete/full-width.tsx
@@ -44,7 +44,7 @@ export function FullWidth() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/location-search.tsx
+++ b/apps/docs/src/demos/en/autocomplete/location-search.tsx
@@ -61,7 +61,7 @@ export function LocationSearch() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={customFilter}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search cities..." />

--- a/apps/docs/src/demos/en/autocomplete/multiple-select.tsx
+++ b/apps/docs/src/demos/en/autocomplete/multiple-select.tsx
@@ -73,7 +73,7 @@ export function MultipleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/en/autocomplete/required.tsx
+++ b/apps/docs/src/demos/en/autocomplete/required.tsx
@@ -63,7 +63,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -97,7 +97,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />

--- a/apps/docs/src/demos/en/autocomplete/single-select.tsx
+++ b/apps/docs/src/demos/en/autocomplete/single-select.tsx
@@ -35,7 +35,7 @@ export default function SingleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search animals..." />

--- a/apps/docs/src/demos/en/autocomplete/tag-group-selection.tsx
+++ b/apps/docs/src/demos/en/autocomplete/tag-group-selection.tsx
@@ -75,7 +75,7 @@ export function TagGroupSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search tags..." />

--- a/apps/docs/src/demos/en/autocomplete/user-selection-multiple.tsx
+++ b/apps/docs/src/demos/en/autocomplete/user-selection-multiple.tsx
@@ -113,7 +113,7 @@ export function UserSelectionMultiple() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/en/autocomplete/user-selection.tsx
+++ b/apps/docs/src/demos/en/autocomplete/user-selection.tsx
@@ -102,7 +102,7 @@ export function UserSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/en/autocomplete/variants.tsx
+++ b/apps/docs/src/demos/en/autocomplete/variants.tsx
@@ -57,7 +57,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -91,7 +91,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -156,7 +156,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -216,7 +216,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/en/autocomplete/virtualization.tsx
+++ b/apps/docs/src/demos/en/autocomplete/virtualization.tsx
@@ -115,7 +115,13 @@ export function Virtualization() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="Search"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/en/autocomplete/with-description.tsx
+++ b/apps/docs/src/demos/en/autocomplete/with-description.tsx
@@ -42,7 +42,7 @@ export function WithDescription() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/with-disabled-options.tsx
+++ b/apps/docs/src/demos/en/autocomplete/with-disabled-options.tsx
@@ -26,7 +26,7 @@ export function WithDisabledOptions() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search animals..." />

--- a/apps/docs/src/demos/en/autocomplete/with-sections.tsx
+++ b/apps/docs/src/demos/en/autocomplete/with-sections.tsx
@@ -34,7 +34,7 @@ export function WithSections() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search countries..." />

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -67,7 +67,7 @@ export const Default: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -119,7 +119,7 @@ export const WithClearButton: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -184,7 +184,7 @@ export const WithOnClearCallback: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search animals..." />
@@ -266,7 +266,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -300,7 +300,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -365,7 +365,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -425,7 +425,7 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -510,7 +510,7 @@ export const MultipleSelect: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search..." />
@@ -564,7 +564,7 @@ export const FullWidth: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -617,7 +617,7 @@ export const WithDescription: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -661,7 +661,7 @@ export const WithSections: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />
@@ -758,7 +758,7 @@ export const WithDisabledOptions: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -830,7 +830,7 @@ export const CustomIndicator: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -904,7 +904,7 @@ export const Required: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -938,7 +938,7 @@ export const Required: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search countries..." />
@@ -996,7 +996,7 @@ export const Controlled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1051,7 +1051,7 @@ export const ControlledOpenState: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1111,7 +1111,13 @@ export const AsynchronousFiltering: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-            <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+            <SearchField
+              autoFocus
+              aria-label="Search"
+              className="sticky top-0 z-10"
+              name="search"
+              variant="secondary"
+            >
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search characters..." />
@@ -1246,7 +1252,13 @@ export const Virtualization: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
-            <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+            <SearchField
+              autoFocus
+              aria-label="Search"
+              className="sticky top-0 z-10"
+              name="search"
+              variant="secondary"
+            >
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1315,7 +1327,7 @@ export const Disabled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1348,7 +1360,7 @@ export const Disabled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search countries..." />
@@ -1458,7 +1470,7 @@ export const UserSelection: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1583,7 +1595,7 @@ export const UserSelectionMultiple: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1661,7 +1673,7 @@ export const LocationSearch: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={customFilter}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search cities..." />
@@ -1752,7 +1764,7 @@ export const TagGroupSelection: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search tags..." />
@@ -1833,7 +1845,7 @@ export const EmailRecipients: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search emails..." />

--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -230,14 +230,10 @@ const AutocompletePopover = ({
 
   useResizeObserver({ref: triggerRef, onResize});
 
-  // `Select` (react-aria-components) computes an `aria-labelledby` for its popover content
-  // and provides it through `PopoverContext`, which `PopoverPrimitive` below consumes
-  // automatically. The nested `DialogPrimitive` we render for touch focus containment is a
-  // separate accessible element that `Select` doesn't know about, so it does not inherit that
-  // label automatically. Forward it explicitly so the dialog is labeled by the same field label
-  // as the trigger. `PopoverContext` is unavailable while collection-building performs its
-  // context-free render pass, so fall back to a static label to guarantee the dialog always has
-  // an accessible name, even then.
+  // The nested DialogPrimitive below makes react-aria-components' Popover drop role="dialog" on
+  // its own node (isDialog = shouldBeDialog && !ref.current.querySelector('[role=dialog]')), so
+  // PopoverContext's aria-labelledby lands on a roleless container. DialogPrimitive reads
+  // DialogContext, not PopoverContext, so this forwards the label explicitly (see #6691).
   const popoverContext = useContext(PopoverContext);
   const contextAriaLabelledby =
     popoverContext && typeof popoverContext === "object" && "aria-labelledby" in popoverContext
@@ -245,6 +241,8 @@ const AutocompletePopover = ({
       : undefined;
 
   const dialogAriaLabelledby = props["aria-labelledby"] ?? contextAriaLabelledby;
+  // PopoverContext is unavailable during the context-free collection-building render pass, so
+  // fall back to a static label to keep the dialog's accessible name in that case too.
   const dialogAriaLabel = props["aria-label"] ?? (dialogAriaLabelledby ? undefined : "Options");
 
   return (

--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -13,7 +13,7 @@ import {Autocomplete as AutocompletePrimitive} from "react-aria-components/Autoc
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Dialog as DialogPrimitive} from "react-aria-components/Dialog";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
-import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
+import {PopoverContext, Popover as PopoverPrimitive} from "react-aria-components/Popover";
 import {
   Select as SelectPrimitive,
   SelectStateContext,
@@ -230,6 +230,23 @@ const AutocompletePopover = ({
 
   useResizeObserver({ref: triggerRef, onResize});
 
+  // `Select` (react-aria-components) computes an `aria-labelledby` for its popover content
+  // and provides it through `PopoverContext`, which `PopoverPrimitive` below consumes
+  // automatically. The nested `DialogPrimitive` we render for touch focus containment is a
+  // separate accessible element that `Select` doesn't know about, so it does not inherit that
+  // label automatically. Forward it explicitly so the dialog is labeled by the same field label
+  // as the trigger. `PopoverContext` is unavailable while collection-building performs its
+  // context-free render pass, so fall back to a static label to guarantee the dialog always has
+  // an accessible name, even then.
+  const popoverContext = useContext(PopoverContext);
+  const contextAriaLabelledby =
+    popoverContext && typeof popoverContext === "object" && "aria-labelledby" in popoverContext
+      ? popoverContext["aria-labelledby"]
+      : undefined;
+
+  const dialogAriaLabelledby = props["aria-labelledby"] ?? contextAriaLabelledby;
+  const dialogAriaLabel = props["aria-label"] ?? (dialogAriaLabelledby ? undefined : "Options");
+
   return (
     <SurfaceContext
       value={{
@@ -249,7 +266,12 @@ const AutocompletePopover = ({
           } as React.CSSProperties
         }
       >
-        <DialogPrimitive className={slots?.popoverDialog()} data-slot="autocomplete-popover-dialog">
+        <DialogPrimitive
+          aria-label={dialogAriaLabel}
+          aria-labelledby={dialogAriaLabelledby}
+          className={slots?.popoverDialog()}
+          data-slot="autocomplete-popover-dialog"
+        >
           {children}
         </DialogPrimitive>
       </PopoverPrimitive>

--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -19,6 +19,7 @@ import {
   SelectStateContext,
   SelectValue as SelectValuePrimitive,
 } from "react-aria-components/Select";
+import {useSlottedContext} from "react-aria-components/slots";
 
 import {dataAttr} from "../../utils/assertion";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
@@ -234,11 +235,10 @@ const AutocompletePopover = ({
   // its own node (isDialog = shouldBeDialog && !ref.current.querySelector('[role=dialog]')), so
   // PopoverContext's aria-labelledby lands on a roleless container. DialogPrimitive reads
   // DialogContext, not PopoverContext, so this forwards the label explicitly (see #6691).
-  const popoverContext = useContext(PopoverContext);
-  const contextAriaLabelledby =
-    popoverContext && typeof popoverContext === "object" && "aria-labelledby" in popoverContext
-      ? popoverContext["aria-labelledby"]
-      : undefined;
+  // useSlottedContext resolves PopoverContext the same way react-aria's own Popover does (via
+  // useContextProps), so a slotted provider still yields the labelledby Select computes.
+  const popoverContext = useSlottedContext(PopoverContext);
+  const contextAriaLabelledby = popoverContext?.["aria-labelledby"];
 
   const dialogAriaLabelledby = props["aria-labelledby"] ?? contextAriaLabelledby;
   // PopoverContext is unavailable during the context-free collection-building render pass, so


### PR DESCRIPTION
Closes #6691

## 📝 Description

The popover's internal dialog (added in #6627 to prevent a stray focus ring on touch) had no accessible name, and the docs' basic usage example never labeled the search field either. Both triggered react-aria a11y warnings on open and while typing.

The dialog now reuses the same aria-labelledby Select computes for the popover, falling back to a static label for the collection-build render pass where that context isn't available yet.

## ⛳️ Current behavior (updates)

Opening the basic Autocomplete demo and typing in the search field logs two react-aria dev warnings (missing aria-label/aria-labelledby on the popover dialog and on the search field).

## 🚀 New behavior

No a11y warnings. Dialog inherits the field's label via aria-labelledby (or falls back to "Options"), search field demos have an explicit aria-label.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

packages/react has no test runner wired up yet (empty vitest.config.ts, no test script), so verification here was manual: built the package, ran it against the docs demo, confirmed both warnings are gone in the console before/after. pnpm typecheck and pnpm lint pass.
