### PR TITLE
fix(autocomplete): label popover dialog and search field for a11y

### DIFF
--- a/apps/docs/src/demos/cn/autocomplete/default.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/en/autocomplete/default.tsx
+++ b/apps/docs/src/demos/en/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -13,7 +13,7 @@ import {Autocomplete as AutocompletePrimitive} from "react-aria-components/Autoc
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {Dialog as DialogPrimitive} from "react-aria-components/Dialog";
 import {Group as GroupPrimitive} from "react-aria-components/Group";
-import {Popover as PopoverPrimitive} from "react-aria-components/Popover";
+import {PopoverContext, Popover as PopoverPrimitive} from "react-aria-components/Popover";
 import {
   Select as SelectPrimitive,
   SelectStateContext,
@@ -230,6 +230,23 @@ const AutocompletePopover = ({
 
   useResizeObserver({ref: triggerRef, onResize});
 
+  // `Select` (react-aria-components) computes an `aria-labelledby` for its popover content
+  // and provides it through `PopoverContext`, which `PopoverPrimitive` below consumes
+  // automatically. The nested `DialogPrimitive` we render for touch focus containment is a
+  // separate accessible element that `Select` doesn't know about, so it does not inherit that
+  // label automatically. Forward it explicitly so the dialog is labeled by the same field label
+  // as the trigger. `PopoverContext` is unavailable while collection-building performs its
+  // context-free render pass, so fall back to a static label to guarantee the dialog always has
+  // an accessible name, even then.
+  const popoverContext = useContext(PopoverContext);
+  const contextAriaLabelledby =
+    popoverContext && typeof popoverContext === "object" && "aria-labelledby" in popoverContext
+      ? popoverContext["aria-labelledby"]
+      : undefined;
+
+  const dialogAriaLabelledby = props["aria-labelledby"] ?? contextAriaLabelledby;
+  const dialogAriaLabel = props["aria-label"] ?? (dialogAriaLabelledby ? undefined : "Options");
+
   return (
     <SurfaceContext
       value={{
@@ -249,7 +266,12 @@ const AutocompletePopover = ({
           } as React.CSSProperties
         }
       >
-        <DialogPrimitive className={slots?.popoverDialog()} data-slot="autocomplete-popover-dialog">
+        <DialogPrimitive
+          aria-label={dialogAriaLabel}
+          aria-labelledby={dialogAriaLabelledby}
+          className={slots?.popoverDialog()}
+          data-slot="autocomplete-popover-dialog"
+        >
           {children}
         </DialogPrimitive>
       </PopoverPrimitive>


### PR DESCRIPTION
Closes #6691

## Problem

The basic Autocomplete example emits two react-aria a11y warnings:

- On open: `If a Dialog does not contain a <Heading slot="title">, it must have an aria-label or aria-labelledby attribute for accessibility.`
- On typing: `If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility`

Two separate causes:

1. `AutocompletePopover` wraps its content in a `Dialog` (added in #6627 to avoid a stray focus ring on touch) that has no accessible name. `Select` computes an `aria-labelledby` for its popover content and passes it through `PopoverContext`, but that labels the `Popover` element, not the extra `Dialog` nested inside it.
2. The basic usage demo never labels its `SearchField`, so the search input has no accessible name.

## Fix

- `AutocompletePopover` reads the `aria-labelledby` from `PopoverContext` (the same one `Select` uses for the popover) and forwards it to the `Dialog`. During the collection-build render pass that context isn't available yet, so it falls back to a static `aria-label` to guarantee the dialog always has a name.
- Added `aria-label` to the `SearchField` in the en and cn `default` demos.

## Notes

react-aria-components' own ComboBox doesn't nest a `Dialog` inside its popover, which is why `Select` doesn't label one automatically. Forwarding the existing label keeps the dialog announced with the same name as the field.