### PR TITLE
feat(tabs): add tabs scroller to handle overflow

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(navigation)/tabs.mdx
+++ b/apps/docs/content/docs/cn/react/components/(navigation)/tabs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tabs 标签页
 description: Tabs 将内容组织为多个区块，并允许用户在它们之间导航。
+icon: new
 links:
   rac: Tabs
   source: tabs/tabs.tsx
@@ -49,6 +50,15 @@ export default () => (
 <ComponentPreview
   isBgSolid
   name="tabs-vertical"
+/>
+
+### 溢出
+
+当标签列表超出可用空间时，`Tabs.ListContainer` 会自动渲染滚动箭头与渐隐边缘，使用户可以导航到被隐藏的标签。水平与垂直方向均支持此行为。
+
+<ComponentPreview
+  isBgSolid
+  name="tabs-overflow"
 />
 
 ### 禁用 Tab
@@ -147,6 +157,9 @@ Tabs 使用以下 CSS 类：
 #### 基础类
 - `.tabs` — Tabs 根容器
 - `.tabs__list-container` — 标签列表容器外层包裹
+- `.tabs__list-container__scroller` — 标签列表的可滚动容器（处理溢出与渐隐边缘）
+- `.tabs__list-container__scroll-prev` — 向前（左 / 上）滚动的箭头按钮
+- `.tabs__list-container__scroll-next` — 向后（右 / 下）滚动的箭头按钮
 - `.tabs__list` — 标签列表容器
 - `.tabs__tab` — 单个标签按钮
 - `.tabs__separator` — 标签之间的分隔线

--- a/apps/docs/content/docs/en/react/components/(navigation)/tabs.mdx
+++ b/apps/docs/content/docs/en/react/components/(navigation)/tabs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tabs
 description: Tabs organize content into multiple sections and allow users to navigate between them.
+icon: new
 links:
   rac: Tabs
   source: tabs/tabs.tsx
@@ -49,6 +50,15 @@ export default () => (
 <ComponentPreview
   isBgSolid
   name="tabs-vertical"
+/>
+
+### Overflow
+
+When the tab list exceeds the available space, `Tabs.ListContainer` automatically renders scroll chevrons and fading edges so users can navigate the hidden tabs. This works the same way for both horizontal and vertical orientations.
+
+<ComponentPreview
+  isBgSolid
+  name="tabs-overflow"
 />
 
 ### Disabled Tab
@@ -147,6 +157,9 @@ The Tabs component uses these CSS classes:
 #### Base Classes
 - `.tabs` - Base tabs container
 - `.tabs__list-container` - Tab list container wrapper
+- `.tabs__list-container__scroller` - Scrollable wrapper around the tab list (handles overflow and fading edges)
+- `.tabs__list-container__scroll-prev` - Scroll chevron button for the previous (left / up) direction
+- `.tabs__list-container__scroll-next` - Scroll chevron button for the next (right / down) direction
 - `.tabs__list` - Tab list container
 - `.tabs__tab` - Individual tab button
 - `.tabs__separator` - Separator between tabs

--- a/apps/docs/src/demos/cn/index.ts
+++ b/apps/docs/src/demos/cn/index.ts
@@ -1649,6 +1649,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./tabs/vertical").then((m) => m.Vertical),
     file: "cn/tabs/vertical.tsx",
   },
+  "tabs-overflow": {
+    component: TabsDemos.Overflow,
+    file: "cn/tabs/overflow.tsx",
+  },
   "tabs-disabled": {
     loader: () => import("./tabs/disabled").then((m) => m.Disabled),
     file: "cn/tabs/disabled.tsx",

--- a/apps/docs/src/demos/cn/tabs/index.ts
+++ b/apps/docs/src/demos/cn/tabs/index.ts
@@ -1,5 +1,6 @@
 export {Basic} from "./basic";
 export {Vertical} from "./vertical";
+export {Overflow} from "./overflow";
 export {Disabled} from "./disabled";
 export {CustomStyles} from "./custom-styles";
 export {WithSeparator} from "./with-separator";

--- a/apps/docs/src/demos/cn/tabs/overflow.tsx
+++ b/apps/docs/src/demos/cn/tabs/overflow.tsx
@@ -1,0 +1,37 @@
+import {Tabs} from "@heroui/react";
+
+const items = [
+  {id: "overview", label: "概览"},
+  {id: "analytics", label: "分析"},
+  {id: "reports", label: "报告"},
+  {id: "performance", label: "性能"},
+  {id: "engagement", label: "互动"},
+  {id: "audience", label: "受众"},
+  {id: "acquisition", label: "获取"},
+  {id: "retention", label: "留存"},
+  {id: "settings", label: "设置"},
+];
+
+export function Overflow() {
+  return (
+    <div className="w-[400px]">
+      <Tabs>
+        <Tabs.ListContainer>
+          <Tabs.List aria-label="溢出选项">
+            {items.map((item) => (
+              <Tabs.Tab key={item.id} id={item.id}>
+                {item.label}
+                <Tabs.Indicator />
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs.ListContainer>
+        {items.map((item) => (
+          <Tabs.Panel key={item.id} className="pt-4" id={item.id}>
+            <p>{item.label} 面板内容。</p>
+          </Tabs.Panel>
+        ))}
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/docs/src/demos/en/index.ts
+++ b/apps/docs/src/demos/en/index.ts
@@ -1648,6 +1648,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./tabs/vertical").then((m) => m.Vertical),
     file: "en/tabs/vertical.tsx",
   },
+  "tabs-overflow": {
+    component: TabsDemos.Overflow,
+    file: "en/tabs/overflow.tsx",
+  },
   "tabs-disabled": {
     loader: () => import("./tabs/disabled").then((m) => m.Disabled),
     file: "en/tabs/disabled.tsx",

--- a/apps/docs/src/demos/en/tabs/index.ts
+++ b/apps/docs/src/demos/en/tabs/index.ts
@@ -1,5 +1,6 @@
 export {Basic} from "./basic";
 export {Vertical} from "./vertical";
+export {Overflow} from "./overflow";
 export {Disabled} from "./disabled";
 export {CustomStyles} from "./custom-styles";
 export {WithSeparator} from "./with-separator";

--- a/apps/docs/src/demos/en/tabs/overflow.tsx
+++ b/apps/docs/src/demos/en/tabs/overflow.tsx
@@ -1,0 +1,37 @@
+import {Tabs} from "@heroui/react";
+
+const items = [
+  {id: "overview", label: "Overview"},
+  {id: "analytics", label: "Analytics"},
+  {id: "reports", label: "Reports"},
+  {id: "performance", label: "Performance"},
+  {id: "engagement", label: "Engagement"},
+  {id: "audience", label: "Audience"},
+  {id: "acquisition", label: "Acquisition"},
+  {id: "retention", label: "Retention"},
+  {id: "settings", label: "Settings"},
+];
+
+export function Overflow() {
+  return (
+    <div className="w-[400px]">
+      <Tabs>
+        <Tabs.ListContainer>
+          <Tabs.List aria-label="Overflow options">
+            {items.map((item) => (
+              <Tabs.Tab key={item.id} id={item.id}>
+                {item.label}
+                <Tabs.Indicator />
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs.ListContainer>
+        {items.map((item) => (
+          <Tabs.Panel key={item.id} className="pt-4" id={item.id}>
+            <p>{item.label} panel content.</p>
+          </Tabs.Panel>
+        ))}
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/react/src/components/tabs/tabs.stories.tsx
+++ b/packages/react/src/components/tabs/tabs.stories.tsx
@@ -53,6 +53,42 @@ const DefaultTemplate = (args: Story["args"]) => {
   );
 };
 
+const overflowItems = [
+  {id: "overview", label: "Overview"},
+  {id: "analytics", label: "Analytics"},
+  {id: "reports", label: "Reports"},
+  {id: "performance", label: "Performance"},
+  {id: "engagement", label: "Engagement"},
+  {id: "audience", label: "Audience"},
+  {id: "acquisition", label: "Acquisition"},
+  {id: "retention", label: "Retention"},
+  {id: "settings", label: "Settings"},
+];
+
+const OverflowTemplate = (args: Story["args"]) => {
+  return (
+    <div className="w-[400px]">
+      <Tabs {...args}>
+        <Tabs.ListContainer>
+          <Tabs.List aria-label="Overflow options">
+            {overflowItems.map((item) => (
+              <Tabs.Tab key={item.id} id={item.id}>
+                {item.label}
+                <Tabs.Indicator />
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs.ListContainer>
+        {overflowItems.map((item) => (
+          <Tabs.Panel key={item.id} className="pt-4" id={item.id}>
+            <p>{item.label} panel content.</p>
+          </Tabs.Panel>
+        ))}
+      </Tabs>
+    </div>
+  );
+};
+
 const VerticalTemplate = (args: Story["args"]) => {
   return (
     <div className="w-[600px]">
@@ -404,7 +440,7 @@ const Showcase1Template = (args: Story["args"]) => {
           ))}
         </div>
         <Tabs {...args} defaultSelectedKey={DEFAULT_ZOOM} onSelectionChange={setSelectedZoom}>
-          <Tabs.ListContainer className="scrollbar-hide my-4 w-full max-w-full overflow-x-auto sm:my-6">
+          <Tabs.ListContainer className="scrollbar-hide my-4 w-full max-w-full overflow-x-auto bg-transparent sm:my-6">
             <Tabs.List
               aria-label="Options"
               className="w-fit min-w-min rounded-full bg-[#333336] *:h-8 *:w-fit *:px-3 *:text-xs *:font-normal *:text-white *:opacity-80 *:hover:opacity-100 *:data-[selected=true]:text-black sm:*:h-9 sm:*:px-4 sm:*:text-sm"
@@ -454,6 +490,13 @@ export const Default: Story = {
     children: null,
   },
   render: DefaultTemplate,
+};
+
+export const Overflow: Story = {
+  args: {
+    children: null,
+  },
+  render: OverflowTemplate,
 };
 
 export const Vertical: Story = {

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -5,7 +5,7 @@ import type {TabsVariants} from "@heroui/styles";
 import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {tabsVariants} from "@heroui/styles";
-import React, {createContext, use} from "react";
+import React, {createContext, use, useRef} from "react";
 import {SelectionIndicator as SelectionIndicatorPrimitive} from "react-aria-components/SelectionIndicator";
 import {
   TabList as TabListPrimitive,
@@ -16,6 +16,8 @@ import {
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {dom} from "../../utils/dom";
+import {IconChevronDown, IconChevronLeft, IconChevronRight, IconChevronUp} from "../icons";
+import {ScrollShadow} from "../scroll-shadow";
 
 /* -------------------------------------------------------------------------------------------------
  * Tabs Context
@@ -74,7 +76,18 @@ const TabListContainer = <E extends keyof React.JSX.IntrinsicElements = "div">({
   ...props
 }: TabListContainerProps<E> &
   Omit<React.JSX.IntrinsicElements[E], keyof TabListContainerProps<E>>) => {
-  const {slots} = use(TabsContext);
+  const {orientation = "horizontal", slots} = use(TabsContext);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const isVertical = orientation === "vertical";
+
+  const scrollBy = (direction: 1 | -1) => {
+    const el = scrollerRef.current;
+
+    if (!el) return;
+    const size = isVertical ? el.clientHeight : el.clientWidth;
+
+    el.scrollBy({behavior: "smooth", [isVertical ? "top" : "left"]: direction * size * 0.8});
+  };
 
   return (
     <dom.div
@@ -82,7 +95,33 @@ const TabListContainer = <E extends keyof React.JSX.IntrinsicElements = "div">({
       data-slot="tabs-list-container"
       {...(props as any)}
     >
-      {children}
+      <ScrollShadow
+        ref={scrollerRef}
+        hideScrollBar
+        className={composeSlotClassName(slots?.scroller)}
+        orientation={orientation}
+        size={64}
+      >
+        {children}
+      </ScrollShadow>
+      <button
+        aria-label={isVertical ? "Scroll tabs up" : "Scroll tabs left"}
+        className={composeSlotClassName(slots?.scrollPrev)}
+        tabIndex={-1}
+        type="button"
+        onClick={() => scrollBy(-1)}
+      >
+        {isVertical ? <IconChevronUp /> : <IconChevronLeft />}
+      </button>
+      <button
+        aria-label={isVertical ? "Scroll tabs down" : "Scroll tabs right"}
+        className={composeSlotClassName(slots?.scrollNext)}
+        tabIndex={-1}
+        type="button"
+        onClick={() => scrollBy(1)}
+      >
+        {isVertical ? <IconChevronDown /> : <IconChevronRight />}
+      </button>
     </dom.div>
   );
 };

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -14,18 +14,94 @@
 
 /* Tab list container */
 .tabs__list-container {
-  @apply relative;
+  @apply relative bg-default;
+
+  border-radius: calc(var(--radius) * 2.5);
+
+  /* Vertical scroller fills the container height so overflow detection
+     engages when the wrapper height is constrained (e.g. h-[240px]) */
+  > .tabs__list-container__scroller[data-orientation="vertical"] {
+    @apply h-full;
+  }
+
+  /* Overflow chevron buttons */
+  > .tabs__list-container__scroll-prev,
+  > .tabs__list-container__scroll-next {
+    @apply absolute z-2 hidden size-4 cursor-(--cursor-interactive) items-center justify-center rounded-full border-0 bg-transparent p-0 text-foreground outline-none;
+
+    /**
+    * Transitions
+    * CRITICAL: motion-reduce must be AFTER transition for correct override specificity
+    */
+    transition: opacity 150ms var(--ease-smooth);
+    @apply motion-reduce:transition-none;
+
+    @media (hover: hover) {
+      &:hover {
+        @apply opacity-70;
+      }
+    }
+
+    &:focus-visible {
+      @apply status-focused;
+    }
+  }
+
+  /* Chevron position - horizontal orientation */
+  &:has([data-orientation="horizontal"]) {
+    > .tabs__list-container__scroll-prev {
+      @apply top-1/2 left-1 -translate-y-1/2;
+    }
+
+    > .tabs__list-container__scroll-next {
+      @apply top-1/2 right-1 -translate-y-1/2;
+    }
+  }
+
+  /* Chevron position - vertical orientation */
+  &:has([data-orientation="vertical"]) {
+    > .tabs__list-container__scroll-prev {
+      @apply top-1 left-1/2 -translate-x-1/2;
+    }
+
+    > .tabs__list-container__scroll-next {
+      @apply bottom-1 left-1/2 -translate-x-1/2;
+    }
+  }
+
+  /* Show chevrons only when ScrollShadow reports scrolling is possible */
+  &:has(
+      > :is(
+        [data-left-scroll="true"],
+        [data-left-right-scroll="true"],
+        [data-top-scroll="true"],
+        [data-top-bottom-scroll="true"]
+      )
+    )
+    > .tabs__list-container__scroll-prev {
+    @apply inline-flex;
+  }
+
+  &:has(
+      > :is(
+        [data-right-scroll="true"],
+        [data-left-right-scroll="true"],
+        [data-bottom-scroll="true"],
+        [data-top-bottom-scroll="true"]
+      )
+    )
+    > .tabs__list-container__scroll-next {
+    @apply inline-flex;
+  }
 }
 
 /* Tab list */
 .tabs__list {
-  @apply inline-flex bg-default p-1;
+  @apply inline-flex p-1;
 
-  border-radius: calc(var(--radius) * 2.5);
-
-  /* Horizontal orientation */
+  /* Horizontal orientation - grow with content so ScrollShadow can detect overflow */
   &[data-orientation="horizontal"] {
-    @apply w-full flex-row;
+    @apply w-max min-w-full flex-row;
   }
 
   /* Vertical orientation */
@@ -40,11 +116,10 @@
 
 /* Individual tab */
 .tabs__tab {
-  position: relative;
+  @apply relative flex h-8 w-full items-center justify-center rounded-3xl px-4 text-center text-sm font-medium text-muted outline-none no-highlight;
+
   z-index: 1;
   cursor: var(--cursor-interactive);
-
-  @apply flex h-8 w-full items-center justify-center rounded-3xl px-4 text-center text-sm font-medium text-muted outline-none no-highlight;
 
   /**
    * Transitions
@@ -60,16 +135,12 @@
   /* Selected state */
   &[data-selected="true"] {
     @apply text-segment-foreground;
-  }
 
-  /* Hide separator when this tab is selected */
-  &[data-selected="true"] .tabs__separator {
-    opacity: 0;
-  }
-
-  /* Hide separator when previous sibling is selected */
-  &[data-selected="true"] + .tabs__tab .tabs__separator {
-    opacity: 0;
+    /* Hide separator on the selected tab and the one following it */
+    .tabs__separator,
+    & + .tabs__tab .tabs__separator {
+      @apply opacity-0;
+    }
   }
 
   /* Disabled state */
@@ -96,9 +167,7 @@
 
 /* Tab separator */
 .tabs__separator {
-  @apply rounded-sm bg-muted/25;
-  position: absolute;
-  pointer-events: none;
+  @apply pointer-events-none absolute rounded-sm bg-muted/25;
 
   /**
    * Transitions
@@ -109,28 +178,18 @@
 
   /* Horizontal tabs - vertical separator */
   .tabs__list[data-orientation="horizontal"] & {
-    left: 0;
-    top: 25%;
-    width: 1px;
-    height: 50%;
+    @apply top-1/4 left-0 h-1/2 w-px;
   }
 
   /* Vertical tabs - horizontal separator */
   .tabs__list[data-orientation="vertical"] & {
-    top: 0;
-    left: 5%;
-    width: 90%;
-    height: 1px;
+    @apply top-0 left-[5%] h-px w-[90%];
   }
 }
 
 /* Tab panel */
 .tabs__panel {
   @apply w-full p-2 outline-none;
-
-  /* Entering animations */
-  &[data-entering="true"] {
-  }
 
   /* Exiting animations */
   &[data-exiting="true"] {
@@ -149,16 +208,9 @@
 
 /* Tab indicator - React Aria's SelectionIndicator */
 .tabs__indicator {
-  box-shadow: var(--shadow-surface);
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: -1;
-  border-radius: var(--radius-3xl);
-  width: 100%;
-  height: 100%;
+  @apply absolute top-0 left-0 size-full rounded-3xl bg-segment shadow-surface;
 
-  @apply bg-segment;
+  z-index: -1;
 
   /**
    * Transitions
@@ -175,62 +227,52 @@
    ========================================================================== */
 
 .tabs--secondary {
-  /* Tab list - remove background, add bottom/left border */
-  > .tabs__list-container > .tabs__list {
-    @apply bg-transparent p-0;
+  /* Container - flat, no pill. Underline on container (not list) so it stays
+     stable when the inner list scrolls horizontally inside the ScrollShadow. */
+  > .tabs__list-container {
+    @apply rounded-none bg-transparent;
 
-    border-radius: 0;
-
-    /* Horizontal orientation - bottom border, scrollable */
-    &[data-orientation="horizontal"] {
-      @apply border-b border-border scrollbar-none;
-
-      max-width: 100%;
-      overflow-x: auto;
-      overflow-y: clip;
+    /* Tab list - remove padding */
+    .tabs__list {
+      @apply p-0;
     }
 
-    /* Vertical orientation - left border */
-    &[data-orientation="vertical"] {
-      @apply border-l border-border;
+    /* Hide separators in secondary variant */
+    .tabs__separator {
+      @apply hidden;
+    }
+
+    /* Tab - adjust for secondary variant */
+    .tabs__tab {
+      @apply rounded-none;
+
+      /* Selected state - use text-foreground */
+      &[data-selected="true"] {
+        @apply text-foreground;
+      }
+    }
+
+    /* Tab indicator - line style */
+    .tabs__indicator {
+      @apply rounded-none bg-accent shadow-none;
     }
   }
 
-  /* Tab - adjust for secondary variant */
-  > .tabs__list-container .tabs__tab {
-    @apply rounded-none;
+  /* Horizontal orientation - bottom border + bottom line indicator */
+  &[data-orientation="horizontal"] > .tabs__list-container {
+    @apply border-b border-border;
 
-    /* Selected state - use text-foreground */
-    &[data-selected="true"] {
-      @apply text-foreground;
+    .tabs__indicator {
+      @apply top-auto bottom-0 h-0.5;
     }
   }
 
-  /* Hide separators in secondary variant */
-  > .tabs__list-container .tabs__separator {
-    display: none;
-  }
+  /* Vertical orientation - left border + left line indicator */
+  &[data-orientation="vertical"] > .tabs__list-container {
+    @apply border-l border-border;
 
-  /* Tab indicator - line style */
-  > .tabs__list-container .tabs__indicator {
-    @apply bg-accent;
-
-    box-shadow: none;
-    border-radius: 0;
-  }
-
-  /* Horizontal orientation - bottom line indicator */
-  &[data-orientation="horizontal"] > .tabs__list-container .tabs__indicator {
-    top: auto;
-    bottom: 0;
-    height: 2px;
-  }
-
-  /* Vertical orientation - left line indicator */
-  &[data-orientation="vertical"] > .tabs__list-container .tabs__indicator {
-    left: 0;
-    top: 0;
-    width: 2px;
-    height: 100%;
+    .tabs__indicator {
+      @apply top-0 left-0 h-full w-0.5;
+    }
   }
 }

--- a/packages/styles/src/components/tabs/tabs.styles.ts
+++ b/packages/styles/src/components/tabs/tabs.styles.ts
@@ -8,6 +8,9 @@ export const tabsVariants = tv({
   },
   slots: {
     base: "tabs",
+    scrollNext: "tabs__list-container__scroll-next",
+    scrollPrev: "tabs__list-container__scroll-prev",
+    scroller: "tabs__list-container__scroller",
     separator: "tabs__separator",
     tab: "tabs__tab",
     tabIndicator: "tabs__indicator",


### PR DESCRIPTION
## Summary

Re-opens #6633 targeting `v3.2.2` instead of `v3`.

Adds overflow handling to `Tabs.ListContainer` with scroll chevrons, fading edges via `ScrollShadow`, and docs/storybook examples.

Closes #6631

## Context

The original PR (#6633) was merged into `v3` and has been reverted there. This PR cherry-picks the same feature onto the `v3.2.2` release branch, with a conflict resolution in `tabs.tsx` to keep the React 19 `use()` API from `v3.2.2`.

## Test plan

- [ ] Verify horizontal tabs overflow with chevron navigation
- [ ] Verify vertical tabs overflow with chevron navigation
- [ ] Check docs overflow demo renders correctly (EN + CN)
- [ ] Confirm Storybook overflow story works

Made with [Cursor](https://cursor.com)