### PR TITLE
Enhance chip label for RTL direction

### DIFF
--- a/packages/styles/components/chip.css
+++ b/packages/styles/components/chip.css
@@ -14,6 +14,10 @@
   @apply px-0.5;
 }
 
+:dir(rtl) .chip__label {
+  unicode-bidi: plaintext;
+}
+
 /* Color variants - set foreground color */
 .chip--accent {
   --chip-fg: var(--accent-soft-foreground);


### PR DESCRIPTION
Add RTL support for Chip label bidi rendering.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #<!-- add issue number -->

## 📝 Description

Fix incorrect bidi ordering for numeric-leading email-like strings inside `Chip` when the document direction is RTL.  
Example: `123@example.com` can render with characters visually reordered in RTL contexts.

This PR adds an RTL-specific CSS rule to the Chip label slot to ensure the browser resolves bidi direction per text run.

## ⛳️ Current behavior (updates)

When `dir="rtl"` is applied at the document/app level, a `Chip` that displays values like:

- `123@example.com`
- `123@domain.co.il`

may appear visually reversed or incorrectly ordered, even though the string contains no Hebrew characters.

This is caused by the Unicode bidirectional algorithm interacting with RTL context + numeric-leading tokens.

## 🚀 New behavior

In RTL context, Chip label text uses `unicode-bidi: plaintext`, which makes the browser determine directionality based on the label’s content, preventing the reorder issue for numeric-leading email-like strings.

Suggested change (in Chip styles, next to `.chip__label`):

```css
:dir(rtl) .chip__label {
  unicode-bidi: plaintext;
}