### PR TITLE
fix(docs): frameworks tabs

### DIFF
--- a/apps/docs/src/components/frameworks-tabs.tsx
+++ b/apps/docs/src/components/frameworks-tabs.tsx
@@ -72,10 +72,12 @@ export function FrameworksTabs({className}: {className?: string}) {
     }
   }, [pathname, currentFramework, selectedKey]);
 
+  // Spacing lives on the wrapper: since @heroui/styles 3.2.2 the ListContainer
+  // is the visible pill (bg + radius), so padding on it distorts the pill.
   return (
-    <div className={cn("ml-auto", className)}>
+    <div className={cn("ml-auto pb-1.5", className)}>
       <Tabs selectedKey={selectedKey} onSelectionChange={handleTabChange}>
-        <Tabs.ListContainer className="pb-1.5">
+        <Tabs.ListContainer>
           <Tabs.List aria-label={dict.ariaLabel}>
             <Tabs.Tab
               className="whitespace-nowrap sm:h-6 data-[selected=true]:[&>svg]:text-sky-400"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

This pull request makes a small UI improvement to the `FrameworksTabs` component. The main change is moving the bottom padding from the `Tabs.ListContainer` to the outer wrapper `div`, which ensures that the visual pill styling is not distorted due to padding.

UI adjustment:

* Moved the `pb-1.5` padding class from `Tabs.ListContainer` to the wrapping `div` in `frameworks-tabs.tsx` to maintain correct pill appearance with `@heroui/styles` 3.2.2.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="345" height="193" alt="image" src="https://github.com/user-attachments/assets/bbf9e88c-8014-435a-be29-7754f82933de" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="478" height="134" alt="image" src="https://github.com/user-attachments/assets/ab7c87e6-ed74-409e-8dcc-6c667ebe2a70" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
