### PR TITLE
fix(styles): center table sortable column indicator icon

### DIFF
--- a/packages/styles/components/table.css
+++ b/packages/styles/components/table.css
@@ -171,7 +171,7 @@
    Defaults to pointing up (ascending) and rotates 180° for descending.
    -------------------------------------------------------------------------- */
 .table__sortable-column-indicator {
-  @apply size-3 transform transition-transform duration-100 ease-out;
+  @apply size-3 transform transition-transform duration-100 ease-out inline-grid place-content-center;
 
   &[data-direction="descending"] {
     @apply rotate-180;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
Im using a table specificially with only the table css styles. When I add a sorting icon with the sorting indicator classname `table__sortable-column-indicator` the icon doesn't transform well.

## ⛳️ Current behavior (updates)
https://github.com/user-attachments/assets/b5ff49dc-aa5e-45b5-8f15-630cdcfa8927

As you can see the icon doesn't transform in its own place.

## 🚀 New behavior
https://github.com/user-attachments/assets/e93150e7-fd17-4ba7-bb05-e41844ef8449

The icon transforms in its own place

Also tested locally on the V3 branch
https://github.com/user-attachments/assets/e93150e7-fd17-4ba7-bb05-e41844ef8449

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
