### PR TITLE
fix(styles): prevent InputOTP slots from overflowing narrow containers

### DIFF
--- a/packages/styles/components/input-otp.css
+++ b/packages/styles/components/input-otp.css
@@ -1,6 +1,6 @@
 /* Base container */
 .input-otp {
-  @apply relative flex items-center gap-2;
+  @apply relative flex w-full items-center gap-2;
 
   &[data-disabled="true"] {
     @apply cursor-not-allowed opacity-50;
@@ -9,12 +9,12 @@
 
 /* Group - slots separated with gap */
 .input-otp__group {
-  @apply flex items-center gap-2;
+  @apply flex min-w-0 items-center gap-2;
 }
 
 /* Individual slot box - fully rounded, standalone */
 .input-otp__slot {
-  @apply relative flex h-10 w-9.5 flex-1 items-center justify-center;
+  @apply relative flex h-10 w-9.5 min-w-0 flex-1 items-center justify-center;
   @apply border bg-field text-field-foreground shadow-field;
   @apply rounded-field text-sm font-semibold outline-none;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Originally reported in Discord by Pro user.

> Im having so much trouble with inputs and them overflowing the container. I fixed Input.Group by adding w-full but I dont know how to fix InputOTP

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="397" height="207" alt="image" src="https://github.com/user-attachments/assets/73123759-9f4d-4883-9dda-cf0160a5b261" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="386" height="206" alt="image" src="https://github.com/user-attachments/assets/cb3aa136-f660-4d6d-89ef-890e63f75f7f" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
