### PR TITLE
fix(scroll-shadow): tolerate fractional scroll position in end detection

### DIFF
--- a/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
+++ b/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
@@ -37,7 +37,7 @@ export const useScrollShadow = (props: UseScrollShadowProps) => {
     const clientSize = isVertical ? el.clientHeight : el.clientWidth;
 
     const hasScrollBefore = scrollStart > offset;
-    const hasScrollAfter = scrollStart + clientSize + offset < scrollSize;
+    const hasScrollAfter = scrollStart + clientSize + offset < scrollSize - 1;
 
     // Skip DOM updates if state hasn't changed
     const prevState = prevStateRef.current;


### PR DESCRIPTION
Closes #6709

## 📝 Description

`useScrollShadow` decides whether content remains after the current scroll position with an exact comparison:

```ts
const hasScrollAfter = scrollStart + clientSize + offset < scrollSize;
```

On HiDPI displays (Retina, DPR 2), `scrollLeft`/`scrollTop` are subpixel-precise (fractional), while `scrollWidth`/`clientWidth` are rounded integers. At the physical end of scroll the comparison stays `true` (measured: `532.5 + 300 < 833`), so `hasScrollAfter` never turns `false`.

MDN documents this exact pitfall — equality checks "will not work all the time because `scrollTop` can contain decimals" — and recommends a 1px tolerance: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled

This PR applies that 1px tolerance to the end check. The symmetric start check (`scrollStart > offset`) already tolerates fractional values naturally, so only the "after" side changes.

## ⛳️ Current behavior (updates)

On HiDPI displays, the trailing shadow of `ScrollShadow` — and features built on this hook, like the Tabs overflow chevron — never disappear when scrolled fully to the end. DPR 1 displays are unaffected (gap is exactly 0 there).

https://github.com/user-attachments/assets/dbf65af6-d151-41de-b868-e788e2302f54

## 🚀 New behavior

End-of-scroll is detected within a 1px tolerance (MDN-recommended pattern), so the trailing shadow and the Tabs overflow chevron correctly disappear at the end of scroll on any `devicePixelRatio`.

https://github.com/user-attachments/assets/1651c638-46e5-4f43-81d8-acfb66c29429

## 💣 Is this a breaking change (Yes/No):

No. Worst case, the shadow hides 1px before the true end — imperceptible, and the same tolerance MDN recommends for all scroll-end detection.

## 📝 Additional Information

- Validated in production: we ship exactly this one-line change as a pnpm patch (`@heroui/react` 3.2.2) in a production app, verified on Retina hardware (bug reproduces) and DPR 1 (no regression).
- Reproduction requires a physical HiDPI display — DevTools/CDP viewport emulation snaps scroll offsets to integers and hides the bug.
- No unit tests exist for `scroll-shadow` (only stories), and a JSDOM test can't exercise fractional layout-driven scroll positions meaningfully, so no test was added; happy to add one if you have a preferred approach.
- Possibly also fixes the root cause behind #6186 (vertical case, closed as not reproducible — reproduction depends on the reporter's display DPR).

