### PR TITLE
docs(combo-box): remove unsupported props from API reference

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(pickers)/combo-box.mdx
+++ b/apps/docs/content/docs/cn/react/components/(pickers)/combo-box.mdx
@@ -258,9 +258,6 @@ ComboBox 组件使用以下 CSS 类（[查看源码样式](https://github.com/he
 | `selectedKey` | `Key \| null` | - | 当前选中的 key（受控）。 |
 | `defaultSelectedKey` | `Key \| null` | - | 默认选中的 key（非受控）。 |
 | `onSelectionChange` | `(key: Key \| null) => void` | - | 选中变化时调用的事件处理函数。 |
-| `isOpen` | `boolean` | - | Popover 是否打开（受控）。 |
-| `defaultOpen` | `boolean` | - | Popover 默认是否打开（非受控）。 |
-| `onOpenChange` | `(isOpen: boolean) => void` | - | Popover 打开状态变化时调用的事件处理函数。 |
 | `items` | `Iterable<T>` | - | 在 ListBox 中展示的 items。 |
 | `disabledKeys` | `Iterable<Key>` | - | 禁用项的 key。 |
 | `defaultFilter` | `(text: string, inputValue: string) => boolean` | - | 用于过滤 items 的自定义过滤函数。 |

--- a/apps/docs/content/docs/en/react/components/(pickers)/combo-box.mdx
+++ b/apps/docs/content/docs/en/react/components/(pickers)/combo-box.mdx
@@ -258,9 +258,6 @@ The component supports both CSS pseudo-classes and data attributes for flexibili
 | `selectedKey` | `Key \| null` | - | Current selected key (controlled) |
 | `defaultSelectedKey` | `Key \| null` | - | Default selected key (uncontrolled) |
 | `onSelectionChange` | `(key: Key \| null) => void` | - | Handler called when the selection changes |
-| `isOpen` | `boolean` | - | Sets the open state of the popover (controlled) |
-| `defaultOpen` | `boolean` | - | Sets the default open state of the popover (uncontrolled) |
-| `onOpenChange` | `(isOpen: boolean) => void` | - | Handler called when the open state changes |
 | `items` | `Iterable<T>` | - | The items to display in the listbox |
 | `disabledKeys` | `Iterable<Key>` | - | Keys of disabled items |
 | `defaultFilter` | `(text: string, inputValue: string) => boolean` | - | Custom filter function for filtering items |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6702

## 📝 Description

<!--- Add a brief description -->

The ComboBox API reference documented `isOpen`, `defaultOpen`, and `onOpenChange`, but none of these open-state props are functional on HeroUI's ComboBox. This PR removes all three rows from the API reference in both locales so the docs reflect reality.

- Remove `isOpen`, `defaultOpen`, and `onOpenChange` rows from `apps/docs/content/docs/en/react/components/(pickers)/combo-box.mdx`
- Remove the same rows from `apps/docs/content/docs/cn/react/components/(pickers)/combo-box.mdx`


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
