### PR TITLE
docs(spinner): correct default color to "accent" in API reference

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(feedback)/spinner.mdx
+++ b/apps/docs/content/docs/cn/react/components/(feedback)/spinner.mdx
@@ -92,5 +92,5 @@ Spinner 使用以下 CSS 类（[查看源码样式](https://github.com/heroui-in
 | Prop | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
 | `size` | `"sm" \| "md" \| "lg" \| "xl"` | `"md"` | Spinner 的尺寸 |
-| `color` | `"current" \| "accent" \| "success" \| "warning" \| "danger"` | `"current"` | Spinner 的颜色变体 |
+| `color` | `"current" \| "accent" \| "success" \| "warning" \| "danger"` | `"accent"` | Spinner 的颜色变体 |
 | `className` | `string` | - | 额外的 CSS 类名 |

--- a/apps/docs/content/docs/en/react/components/(feedback)/spinner.mdx
+++ b/apps/docs/content/docs/en/react/components/(feedback)/spinner.mdx
@@ -92,5 +92,5 @@ The Spinner component uses these CSS classes ([View source styles](https://githu
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `size` | `"sm" \| "md" \| "lg" \| "xl"` | `"md"` | Size of the spinner |
-| `color` | `"current" \| "accent" \| "success" \| "warning" \| "danger"` | `"current"` | Color variant of the spinner |
+| `color` | `"current" \| "accent" \| "success" \| "warning" \| "danger"` | `"accent"` | Color variant of the spinner |
 | `className` | `string` | - | Additional CSS classes |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6716

## 📝 Description

<!--- Add a brief description -->

The Spinner API Reference table documented the default `color` as "current", but `spinnerVariants` defaultVariants uses "accent" and the Spinner component does not override it. Updated the en/cn docs tables to match the shipped behavior, consistent with the Button docs and the migration guide.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
