### PR TITLE
fix(docs): correct typos in accordion demo/docs and `bgsurface` class name

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(forms)/text-field.mdx
+++ b/apps/docs/content/docs/cn/react/components/(forms)/text-field.mdx
@@ -103,11 +103,11 @@ import {TextField, Label, Input, Description} from '@heroui/react';
 
 function CustomTextField() {
   return (
-    <TextField className="gap-2 rounded-xl border border-border/60 bgsurface p-4 shadow-sm">
+    <TextField className="gap-2 rounded-xl border border-border/60 bg-surface p-4 shadow-sm">
       <Label className="text-sm font-semibold text-default-700">
         Project name
       </Label>
-      <Input className="rounded-lg border border-border/60 bgsurface px-3 py-2" />
+      <Input className="rounded-lg border border-border/60 bg-surface px-3 py-2" />
       <Description className="text-xs text-default-500">
         Keep it short and memorable.
       </Description>

--- a/apps/docs/content/docs/cn/react/components/(navigation)/accordion.mdx
+++ b/apps/docs/content/docs/cn/react/components/(navigation)/accordion.mdx
@@ -123,7 +123,7 @@ import {Icon} from "@iconify/react";
 const items = [
   {
     content:
-      "Stay informed about your account activity with real-time notifications. You'll receive instant alerts for important events like transactions, new messages, security updates, and system announcements. ",
+      "Stay informed about your account activity with real-time notifications. You'll receive instant alerts for important events like transactions, new messages, security updates, and system announcements.",
     iconUrl: "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/3dicons/bell-small.png",
     title: "Set Up Notifications",
     subtitle: "Receive account activity updates",
@@ -133,7 +133,7 @@ const items = [
       "Enhance your browsing experience by installing our official browser extension. The extension provides seamless integration with your account, allowing you to receive notifications directly in your browser, quickly access your dashboard, and interact with web3 applications securely. Compatible with Chrome, Firefox, Edge, and Brave browsers.",
     iconUrl: "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/3dicons/compass-small.png",
     title: "Set up Browser Extension",
-    subtitle: "Connect you browser to your account",
+    subtitle: "Connect your browser to your account",
   },
   {
     content:

--- a/apps/docs/content/docs/en/react/components/(forms)/text-field.mdx
+++ b/apps/docs/content/docs/en/react/components/(forms)/text-field.mdx
@@ -104,11 +104,11 @@ import {TextField, Label, Input, Description} from '@heroui/react';
 
 function CustomTextField() {
   return (
-    <TextField className="gap-2 rounded-xl border border-border/60 bgsurface p-4 shadow-sm">
+    <TextField className="gap-2 rounded-xl border border-border/60 bg-surface p-4 shadow-sm">
       <Label className="text-sm font-semibold text-default-700">
         Project name
       </Label>
-      <Input className="rounded-lg border border-border/60 bgsurface px-3 py-2" />
+      <Input className="rounded-lg border border-border/60 bg-surface px-3 py-2" />
       <Description className="text-xs text-default-500">
         Keep it short and memorable.
       </Description>

--- a/apps/docs/content/docs/en/react/components/(navigation)/accordion.mdx
+++ b/apps/docs/content/docs/en/react/components/(navigation)/accordion.mdx
@@ -123,7 +123,7 @@ import {Icon} from "@iconify/react";
 const items = [
   {
     content:
-      "Stay informed about your account activity with real-time notifications. You'll receive instant alerts for important events like transactions, new messages, security updates, and system announcements. ",
+      "Stay informed about your account activity with real-time notifications. You'll receive instant alerts for important events like transactions, new messages, security updates, and system announcements.",
     iconUrl: "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/3dicons/bell-small.png",
     title: "Set Up Notifications",
     subtitle: "Receive account activity updates",
@@ -133,7 +133,7 @@ const items = [
       "Enhance your browsing experience by installing our official browser extension. The extension provides seamless integration with your account, allowing you to receive notifications directly in your browser, quickly access your dashboard, and interact with web3 applications securely. Compatible with Chrome, Firefox, Edge, and Brave browsers.",
     iconUrl: "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/3dicons/compass-small.png",
     title: "Set up Browser Extension",
-    subtitle: "Connect you browser to your account",
+    subtitle: "Connect your browser to your account",
   },
   {
     content:

--- a/apps/docs/src/demos/cn/accordion/custom-styles.tsx
+++ b/apps/docs/src/demos/cn/accordion/custom-styles.tsx
@@ -36,7 +36,7 @@ export function CustomStyles() {
           )}
         >
           <Accordion.Heading>
-            <Accordion.Trigger className="hover:bgsurface group flex items-center gap-2 transition-none">
+            <Accordion.Trigger className="hover:bg-surface group flex items-center gap-2 transition-none">
               {item.iconUrl ? (
                 <img
                   alt={item.title}

--- a/apps/docs/src/demos/en/accordion/custom-styles.tsx
+++ b/apps/docs/src/demos/en/accordion/custom-styles.tsx
@@ -3,7 +3,7 @@ import {Accordion, cn} from "@heroui/react";
 
 const items = [
   {
-    content: "Stay informed about your account activity with real-time notifications. ",
+    content: "Stay informed about your account activity with real-time notifications.",
     iconUrl: "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/3dicons/bell-small.png",
     subtitle: "Receive account activity updates",
     title: "Set Up Notifications",
@@ -11,7 +11,7 @@ const items = [
   {
     content: "Enhance your browsing experience by installing our official browser extension",
     iconUrl: "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/docs/3dicons/compass-small.png",
-    subtitle: "Connect you browser to your account",
+    subtitle: "Connect your browser to your account",
     title: "Set up Browser Extension",
   },
   {
@@ -37,7 +37,7 @@ export function CustomStyles() {
           )}
         >
           <Accordion.Heading>
-            <Accordion.Trigger className="hover:bgsurface group flex items-center gap-2 transition-none">
+            <Accordion.Trigger className="hover:bg-surface group flex items-center gap-2 transition-none">
               {item.iconUrl ? (
                 <img
                   alt={item.title}


### PR DESCRIPTION
## 📝 Description

Fixes a handful of documentation typos I came across while studying the Accordion component's demos and docs. All changes are docs/content only — no runtime, API, or styling-logic changes.

### `bgsurface` → `bg-surface`
`bgsurface` isn't a valid utility (the real one is `bg-surface`, used throughout `packages/styles` and other demos), so it currently renders as a no-op:
- `apps/docs/src/demos/en/accordion/custom-styles.tsx` and `.../cn/...` — the trigger's `hover:bgsurface`
- `apps/docs/content/docs/en/react/components/(forms)/text-field.mdx` and `.../cn/...` — the "custom styles" `TextField`/`Input` example (two occurrences each)

### Text typos in the Accordion `custom-styles` example
- **"Connect you browser" → "Connect your browser"** — `subtitle` in the en demo and the en/cn docs.
- **Trailing space before the closing quote** in the first item's `content` string — en demo and en/cn docs.

## ⛳️ Current behavior (updates)

- `hover:bgsurface` / `bgsurface` silently do nothing; the intended surface background never applies (the Accordion surface variant's own hover masks it, but the TextField example has no such fallback).
- The subtitle reads "Connect you browser…".
- The notifications `content` string carries a stray trailing space.

## 🚀 New behavior

- `bg-surface` applies as intended.
- Subtitle reads "Connect your browser to your account".
- No trailing whitespace in the content string.

## 💣 Is this a breaking change (Yes/No)?

No — documentation/content only.

## 📝 Additional Information

Both `en` and `cn` locales are kept in sync. The `cn` accordion demo uses translated content, so it only needed the `bg-surface` class fix.