### PR TITLE
fix(styles): restore focus outline gap for accent buttons

### DIFF
--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -60,11 +60,10 @@
   transform: none;
 }
 
-/* Override focus ring to use inset style so it stays within button bounds */
+/* Raise focused button so its outward focus ring + gap shows above adjacent buttons */
 .button-group .button:focus-visible:not(:focus),
 .button-group .button[data-focus-visible="true"] {
-  --tw-ring-offset-width: 0px;
-  @apply ring-inset;
+  @apply z-10;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Reported from [here](https://discord.com/channels/856545348885676062/1528179297360285878)

> ButtonGroup with accent variant can't show focus outline, since focus outline is the same color as it

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="244" height="89" alt="image" src="https://github.com/user-attachments/assets/ce8317b4-3a4e-4a29-b60e-2a784efe6c02" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="256" height="92" alt="image" src="https://github.com/user-attachments/assets/ce125ddd-4158-4dfe-aec6-3901ded21c86" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
