### PR TITLE
docs(avatar): document custom image composition with asChild

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(media)/avatar.mdx
+++ b/apps/docs/content/docs/cn/react/components/(media)/avatar.mdx
@@ -58,6 +58,12 @@ export default () => (
 
 <ComponentPreview name="avatar-custom-styles" />
 
+### 自定义图片组件
+
+在 `Avatar.Image` 上使用 `asChild`，即可与自定义图片组件组合。以下示例使用 Next.js `Image` 以实现优化加载。请将 `src` 传给 `Avatar.Image`，以便跟踪加载状态，并在图片就绪前显示回退内容。
+
+<ComponentPreview name="avatar-custom-image-component" />
+
 <RelatedComponents component="avatar" />
 
 ## 样式
@@ -139,6 +145,7 @@ Avatar 组件使用以下 CSS 类（[查看源码样式](https://github.com/hero
 | `srcSet` | `string` | - | 响应式图片的 `srcset` |
 | `sizes` | `string` | - | 响应式图片的 `sizes` |
 | `alt` | `string` | - | 图片替代文本 |
+| `asChild` | `boolean` | `false` | 将属性合并到子元素上（例如 `next/image`），而不是渲染原生 `img` |
 | `onLoad` | `(event: SyntheticEvent<HTMLImageElement>) => void` | - | 图片加载成功时的事件处理函数 |
 | `onError` | `(event: SyntheticEvent<HTMLImageElement>) => void` | - | 图片加载失败时的事件处理函数 |
 | `crossOrigin` | `'anonymous' \| 'use-credentials'` | - | 图片请求的 CORS 设置 |

--- a/apps/docs/content/docs/en/react/components/(media)/avatar.mdx
+++ b/apps/docs/content/docs/en/react/components/(media)/avatar.mdx
@@ -58,6 +58,12 @@ export default () => (
 
 <ComponentPreview name="avatar-custom-styles" />
 
+### Custom Image Component
+
+Use `asChild` on `Avatar.Image` to compose with a custom image component. This example uses Next.js `Image` for optimized loading. Pass `src` on `Avatar.Image` so it can track the loading state and show the fallback until the image is ready.
+
+<ComponentPreview name="avatar-custom-image-component" />
+
 <RelatedComponents component="avatar" />
 
 ## Styling
@@ -139,6 +145,7 @@ The Avatar component uses these CSS classes ([View source styles](https://github
 | `srcSet` | `string` | - | The image `srcset` attribute for responsive images |
 | `sizes` | `string` | - | The image `sizes` attribute for responsive images |
 | `alt` | `string` | - | Alternative text for the image |
+| `asChild` | `boolean` | `false` | Merge props onto the child element (e.g. `next/image`) instead of rendering a native `img` |
 | `onLoad` | `(event: SyntheticEvent<HTMLImageElement>) => void` | - | Callback when the image loads successfully |
 | `onError` | `(event: SyntheticEvent<HTMLImageElement>) => void` | - | Callback when there's an error loading the image |
 | `crossOrigin` | `'anonymous' \| 'use-credentials'` | - | CORS setting for the image request |

--- a/apps/docs/src/demos/cn/avatar/custom-image-component.tsx
+++ b/apps/docs/src/demos/cn/avatar/custom-image-component.tsx
@@ -1,0 +1,15 @@
+import {Avatar} from "@heroui/react";
+import Image from "next/image";
+
+const SRC = "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/blue.jpg";
+
+export function CustomImageComponent() {
+  return (
+    <Avatar>
+      <Avatar.Image asChild height={40} src={SRC} width={40}>
+        <Image alt="约翰·多伊" src={SRC} />
+      </Avatar.Image>
+      <Avatar.Fallback>JD</Avatar.Fallback>
+    </Avatar>
+  );
+}

--- a/apps/docs/src/demos/cn/avatar/index.ts
+++ b/apps/docs/src/demos/cn/avatar/index.ts
@@ -5,3 +5,4 @@ export {Fallback} from "./fallback";
 export {Group} from "./group";
 export {Sizes} from "./sizes";
 export {Variants} from "./variants";
+export {CustomImageComponent} from "./custom-image-component";

--- a/apps/docs/src/demos/cn/index.ts
+++ b/apps/docs/src/demos/cn/index.ts
@@ -135,6 +135,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./avatar/custom-styles").then((m) => m.CustomStyles),
     file: "cn/avatar/custom-styles.tsx",
   },
+  "avatar-custom-image-component": {
+    loader: () => import("./avatar/custom-image-component").then((m) => m.CustomImageComponent),
+    file: "cn/avatar/custom-image-component.tsx",
+  },
   // Badge demos
   "badge-basic": {
     loader: () => import("./badge/basic").then((m) => m.BadgeBasic),

--- a/apps/docs/src/demos/en/avatar/custom-image-component.tsx
+++ b/apps/docs/src/demos/en/avatar/custom-image-component.tsx
@@ -1,0 +1,15 @@
+import {Avatar} from "@heroui/react";
+import Image from "next/image";
+
+const SRC = "https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/blue.jpg";
+
+export function CustomImageComponent() {
+  return (
+    <Avatar>
+      <Avatar.Image asChild height={40} src={SRC} width={40}>
+        <Image alt="John Doe" src={SRC} />
+      </Avatar.Image>
+      <Avatar.Fallback>JD</Avatar.Fallback>
+    </Avatar>
+  );
+}

--- a/apps/docs/src/demos/en/avatar/index.ts
+++ b/apps/docs/src/demos/en/avatar/index.ts
@@ -5,3 +5,4 @@ export {Fallback} from "./fallback";
 export {Group} from "./group";
 export {Sizes} from "./sizes";
 export {Variants} from "./variants";
+export {CustomImageComponent} from "./custom-image-component";

--- a/apps/docs/src/demos/en/index.ts
+++ b/apps/docs/src/demos/en/index.ts
@@ -134,6 +134,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./avatar/custom-styles").then((m) => m.CustomStyles),
     file: "en/avatar/custom-styles.tsx",
   },
+  "avatar-custom-image-component": {
+    loader: () => import("./avatar/custom-image-component").then((m) => m.CustomImageComponent),
+    file: "en/avatar/custom-image-component.tsx",
+  },
   // Badge demos
   "badge-basic": {
     loader: () => import("./badge/basic").then((m) => m.BadgeBasic),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

- ref: [How can we use Next Image with the avatar?](https://discord.com/channels/856545348885676062/1528359953130061934)
- Document composing a custom image component with `Avatar.Image` via `asChild` (EN + CN)
- Add live `avatar-custom-image-component` demos using Next.js `Image` as the example
- Document the `asChild` prop on `Avatar.Image` in the API reference

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
