### PR TITLE
fix(tooltip): preserve ButtonGroup context for tooltip-wrapped buttons

### DIFF
--- a/packages/react/src/components/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/alert-dialog/alert-dialog.tsx
@@ -19,6 +19,7 @@ import {
   Pressable as PressablePrimitive,
 } from "react-aria-components/Modal";
 
+import {enableChildProps, forwardChildProps} from "../../utils/children";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {dom} from "../../utils/dom";
 import {CloseButton} from "../close-button";
@@ -43,7 +44,8 @@ const AlertDialogContext = createContext<AlertDialogContext>({});
  * -----------------------------------------------------------------------------------------------*/
 interface AlertDialogRootProps extends ComponentPropsWithRef<typeof AlertDialogTriggerPrimitive> {}
 
-const AlertDialogRoot = ({children, ...props}: AlertDialogRootProps) => {
+const AlertDialogRoot = enableChildProps((inputProps: AlertDialogRootProps) => {
+  const {children, ...props} = forwardChildProps(inputProps);
   const alertDialogContext = useMemo<AlertDialogContext>(
     () => ({slots: alertDialogVariants(), placement: undefined}),
     [],
@@ -56,7 +58,7 @@ const AlertDialogRoot = ({children, ...props}: AlertDialogRootProps) => {
       </AlertDialogTriggerPrimitive>
     </AlertDialogContext>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog Trigger

--- a/packages/react/src/components/button-group/button-group.stories.tsx
+++ b/packages/react/src/components/button-group/button-group.stories.tsx
@@ -8,6 +8,7 @@ import {Chip} from "../chip";
 import {Description} from "../description";
 import {Dropdown} from "../dropdown";
 import {Label} from "../label";
+import {Tooltip} from "../tooltip";
 
 import {ButtonGroup} from "./";
 
@@ -294,6 +295,21 @@ export const WithoutSeparator: Story = {
       <Button>First</Button>
       <Button>Second</Button>
       <Button>Third</Button>
+    </ButtonGroup>
+  ),
+};
+
+export const WithTooltips: Story = {
+  render: () => (
+    <ButtonGroup size="sm" variant="secondary">
+      <Tooltip>
+        <Button>First</Button>
+        <Tooltip.Content>First action</Tooltip.Content>
+      </Tooltip>
+      <Tooltip>
+        <Button>Second</Button>
+        <Tooltip.Content>Second action</Tooltip.Content>
+      </Tooltip>
     </ButtonGroup>
   ),
 };

--- a/packages/react/src/components/button-group/button-group.tsx
+++ b/packages/react/src/components/button-group/button-group.tsx
@@ -12,6 +12,7 @@ import {useSlottedContext} from "react-aria-components/slots";
 import {ToggleButtonGroupContext as RACToggleButtonGroupContext} from "react-aria-components/ToggleButtonGroup";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils";
+import {supportsChildProps, withChildProps} from "../../utils/children";
 import {dom} from "../../utils/dom";
 
 /* -------------------------------------------------------------------------------------------------
@@ -60,16 +61,15 @@ const ButtonGroupRoot = ({
     [fullWidth, orientation],
   );
 
-  // Wrap only direct children with context provider
+  // Mark only direct children that can consume or forward the group marker.
   const wrappedChildren = Children.map(children as React.ReactNode, (child) => {
-    if (!isValidElement(child)) {
+    if (!isValidElement(child) || !supportsChildProps(child)) {
       return child;
     }
 
-    // Clone the child and add the special prop
-    return React.cloneElement(child, {
+    return withChildProps(child, {
       [BUTTON_GROUP_CHILD]: true,
-    } as any);
+    });
   });
 
   return (

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -8,6 +8,7 @@ import {use} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 
 import {composeTwRenderProps} from "../../utils";
+import {enableChildProps, mergeChildProps} from "../../utils/children";
 import {BUTTON_GROUP_CHILD, ButtonGroupContext} from "../button-group";
 
 /* -------------------------------------------------------------------------------------------------
@@ -17,19 +18,20 @@ interface ButtonRootProps extends ComponentPropsWithRef<typeof ButtonPrimitive>,
   [BUTTON_GROUP_CHILD]?: boolean;
 }
 
-const ButtonRoot = ({
-  children,
-  className,
-  fullWidth,
-  isDisabled,
-  isIconOnly,
-  size,
-  slot,
-  style,
-  variant,
-  [BUTTON_GROUP_CHILD]: isButtonGroupChild,
-  ...rest
-}: ButtonRootProps) => {
+const ButtonRoot = enableChildProps((inputProps: ButtonRootProps) => {
+  const {
+    children,
+    className,
+    fullWidth,
+    isDisabled,
+    isIconOnly,
+    size,
+    slot,
+    style,
+    variant,
+    [BUTTON_GROUP_CHILD]: isButtonGroupChild,
+    ...rest
+  } = mergeChildProps(inputProps);
   const buttonGroupContext = use(ButtonGroupContext);
 
   // Only use context if this button is a direct child of ButtonGroup
@@ -62,7 +64,7 @@ const ButtonRoot = ({
       {(renderProps) => (typeof children === "function" ? children(renderProps) : children)}
     </ButtonPrimitive>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Exports

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -23,6 +23,7 @@ import {
   Modal as ModalPrimitive,
 } from "react-aria-components/Modal";
 
+import {enableChildProps, forwardChildProps} from "../../utils/children";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {dom} from "../../utils/dom";
 import {CloseButton} from "../close-button";
@@ -219,7 +220,8 @@ interface DrawerRootProps extends ComponentPropsWithRef<typeof DrawerTriggerPrim
   state?: UseOverlayStateReturn;
 }
 
-const DrawerRoot = ({children, state, ...props}: DrawerRootProps) => {
+const DrawerRoot = enableChildProps(({children, state, ...props}: DrawerRootProps) => {
+  const {children: forwardedChildren, ...rootProps} = forwardChildProps({children, ...props});
   const drawerContext = useMemo<DrawerContext>(
     () => ({slots: drawerVariants(), placement: undefined, isDismissable: true}),
     [],
@@ -232,12 +234,12 @@ const DrawerRoot = ({children, state, ...props}: DrawerRootProps) => {
 
   return (
     <DrawerContext value={drawerContext}>
-      <DrawerTriggerPrimitive data-slot="drawer-root" {...mergeProps(props, controlledProps)}>
-        {children}
+      <DrawerTriggerPrimitive data-slot="drawer-root" {...mergeProps(rootProps, controlledProps)}>
+        {forwardedChildren}
       </DrawerTriggerPrimitive>
     </DrawerContext>
   );
-};
+});
 
 DrawerRoot.displayName = "HeroUI.Drawer";
 

--- a/packages/react/src/components/dropdown/dropdown.tsx
+++ b/packages/react/src/components/dropdown/dropdown.tsx
@@ -14,6 +14,7 @@ import {
   SubmenuTrigger as SubmenuTriggerPrimitive,
 } from "react-aria-components/Menu";
 
+import {enableChildProps, forwardChildProps} from "../../utils/children";
 import {composeTwRenderProps} from "../../utils/compose";
 import {MenuItemIndicator, MenuItemRoot, MenuItemSubmenuIndicator} from "../menu-item";
 import {MenuSectionRoot} from "../menu-section";
@@ -36,7 +37,8 @@ interface DropdownRootProps
   className?: string;
 }
 
-const DropdownRoot = ({children, ...props}: DropdownRootProps) => {
+const DropdownRoot = enableChildProps((inputProps: DropdownRootProps) => {
+  const {children, ...props} = forwardChildProps(inputProps);
   const slots = React.useMemo(() => dropdownVariants(), []);
 
   return (
@@ -44,7 +46,7 @@ const DropdownRoot = ({children, ...props}: DropdownRootProps) => {
       <MenuTriggerPrimitive {...props}>{children}</MenuTriggerPrimitive>
     </DropdownContext>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Dropdown Trigger (Button wrapper)

--- a/packages/react/src/components/modal/modal.tsx
+++ b/packages/react/src/components/modal/modal.tsx
@@ -22,6 +22,7 @@ import {
   Pressable as PressablePrimitive,
 } from "react-aria-components/Modal";
 
+import {enableChildProps, forwardChildProps} from "../../utils/children";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {dom} from "../../utils/dom";
 import {CloseButton} from "../close-button";
@@ -46,7 +47,8 @@ interface ModalRootProps extends ComponentPropsWithRef<typeof ModalTriggerPrimit
   state?: UseOverlayStateReturn;
 }
 
-const ModalRoot = ({children, state, ...props}: ModalRootProps) => {
+const ModalRoot = enableChildProps(({children, state, ...props}: ModalRootProps) => {
+  const {children: forwardedChildren, ...rootProps} = forwardChildProps({children, ...props});
   const modalContext = useMemo<ModalContext>(
     () => ({slots: modalVariants(), placement: undefined}),
     [],
@@ -59,12 +61,12 @@ const ModalRoot = ({children, state, ...props}: ModalRootProps) => {
 
   return (
     <ModalContext value={modalContext}>
-      <ModalTriggerPrimitive data-slot="modal-root" {...mergeProps(props, controlledProps)}>
-        {children}
+      <ModalTriggerPrimitive data-slot="modal-root" {...mergeProps(rootProps, controlledProps)}>
+        {forwardedChildren}
       </ModalTriggerPrimitive>
     </ModalContext>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Modal Trigger

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -18,6 +18,7 @@ import {
   Pressable as PressablePrimitive,
 } from "react-aria-components/Popover";
 
+import {enableChildProps, forwardChildProps} from "../../utils/children";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {dom} from "../../utils/dom";
 import {SurfaceContext} from "../surface";
@@ -36,10 +37,8 @@ const PopoverContext = createContext<PopoverContext>({});
  * -----------------------------------------------------------------------------------------------*/
 type PopoverRootProps = ComponentPropsWithRef<typeof PopoverTriggerPrimitive>;
 
-const PopoverRoot = ({
-  children,
-  ...props
-}: ComponentPropsWithRef<typeof PopoverTriggerPrimitive>) => {
+const PopoverRoot = enableChildProps((inputProps: PopoverRootProps) => {
+  const {children, ...props} = forwardChildProps(inputProps);
   const slots = React.useMemo(() => popoverVariants(), []);
 
   return (
@@ -49,7 +48,7 @@ const PopoverRoot = ({
       </PopoverTriggerPrimitive>
     </PopoverContext>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Popover Content

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -2,7 +2,7 @@
 
 import type {DOMRenderProps} from "../../utils/dom";
 import type {TooltipVariants} from "@heroui/styles";
-import type {ComponentPropsWithRef, ReactNode} from "react";
+import type {ComponentPropsWithRef, ReactElement, ReactNode} from "react";
 
 import {tooltipVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
@@ -18,6 +18,12 @@ import {useCSSVariable} from "../../hooks/use-css-variable";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {parseCSSTime} from "../../utils/css";
 import {dom} from "../../utils/dom";
+import {Button} from "../button";
+import {BUTTON_GROUP_CHILD} from "../button-group";
+
+type ButtonGroupChildProps = {
+  [BUTTON_GROUP_CHILD]?: boolean;
+};
 
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Context
@@ -31,14 +37,41 @@ const TooltipContext = createContext<TooltipContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Root
  * -----------------------------------------------------------------------------------------------*/
-type TooltipRootProps = ComponentPropsWithRef<typeof TooltipTriggerPrimitive>;
+interface TooltipRootProps
+  extends ComponentPropsWithRef<typeof TooltipTriggerPrimitive>,
+    ButtonGroupChildProps {}
+
+const markButtonGroupTrigger = (children: ReactNode): ReactNode => {
+  let isMarked = false;
+
+  return React.Children.map(children, (child) => {
+    if (isMarked || !React.isValidElement(child)) {
+      return child;
+    }
+
+    isMarked = true;
+
+    const props: ButtonGroupChildProps & {children?: ReactNode} = {
+      [BUTTON_GROUP_CHILD]: true,
+    };
+
+    const element = child as ReactElement<{children?: ReactNode}>;
+
+    if (element.type !== Button && element.type !== Button.Root) {
+      props.children = markButtonGroupTrigger(element.props.children);
+    }
+
+    return React.cloneElement(element, props);
+  });
+};
 
 const TooltipRoot = ({
   children,
   closeDelay,
   delay,
+  [BUTTON_GROUP_CHILD]: isButtonGroupChild,
   ...props
-}: ComponentPropsWithRef<typeof TooltipTriggerPrimitive>) => {
+}: TooltipRootProps) => {
   const slots = React.useMemo(() => tooltipVariants(), []);
 
   const cssDelay = useCSSVariable("--tooltip-delay");
@@ -46,6 +79,7 @@ const TooltipRoot = ({
 
   const resolvedDelay = delay ?? parseCSSTime(cssDelay);
   const resolvedCloseDelay = closeDelay ?? parseCSSTime(cssCloseDelay);
+  const resolvedChildren = isButtonGroupChild ? markButtonGroupTrigger(children) : children;
 
   return (
     <TooltipContext value={{slots}}>
@@ -55,7 +89,7 @@ const TooltipRoot = ({
         delay={resolvedDelay}
         {...props}
       >
-        {children}
+        {resolvedChildren}
       </TooltipTriggerPrimitive>
     </TooltipContext>
   );

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -2,7 +2,7 @@
 
 import type {DOMRenderProps} from "../../utils/dom";
 import type {TooltipVariants} from "@heroui/styles";
-import type {ComponentPropsWithRef, ReactElement, ReactNode} from "react";
+import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {tooltipVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
@@ -15,15 +15,10 @@ import {
 } from "react-aria-components/Tooltip";
 
 import {useCSSVariable} from "../../hooks/use-css-variable";
+import {enableChildProps, forwardChildProps} from "../../utils/children";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {parseCSSTime} from "../../utils/css";
 import {dom} from "../../utils/dom";
-import {Button} from "../button";
-import {BUTTON_GROUP_CHILD} from "../button-group";
-
-type ButtonGroupChildProps = {
-  [BUTTON_GROUP_CHILD]?: boolean;
-};
 
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Context
@@ -39,37 +34,8 @@ const TooltipContext = createContext<TooltipContext>({});
  * -----------------------------------------------------------------------------------------------*/
 type TooltipRootProps = ComponentPropsWithRef<typeof TooltipTriggerPrimitive>;
 
-const markButtonGroupTrigger = (children: ReactNode): ReactNode => {
-  let isMarked = false;
-
-  return React.Children.map(children, (child) => {
-    if (isMarked || !React.isValidElement(child)) {
-      return child;
-    }
-
-    isMarked = true;
-
-    const props: ButtonGroupChildProps & {children?: ReactNode} = {
-      [BUTTON_GROUP_CHILD]: true,
-    };
-
-    const element = child as ReactElement<{children?: ReactNode}>;
-
-    if (element.type !== Button && element.type !== Button.Root) {
-      props.children = markButtonGroupTrigger(element.props.children);
-    }
-
-    return React.cloneElement(element, props);
-  });
-};
-
-const TooltipRoot: React.FC<TooltipRootProps> = ({
-  children,
-  closeDelay,
-  delay,
-  [BUTTON_GROUP_CHILD]: isButtonGroupChild,
-  ...props
-}: TooltipRootProps & ButtonGroupChildProps) => {
+const TooltipRoot = enableChildProps((inputProps: TooltipRootProps) => {
+  const {children, closeDelay, delay, ...props} = forwardChildProps(inputProps);
   const slots = React.useMemo(() => tooltipVariants(), []);
 
   const cssDelay = useCSSVariable("--tooltip-delay");
@@ -77,7 +43,6 @@ const TooltipRoot: React.FC<TooltipRootProps> = ({
 
   const resolvedDelay = delay ?? parseCSSTime(cssDelay);
   const resolvedCloseDelay = closeDelay ?? parseCSSTime(cssCloseDelay);
-  const resolvedChildren = isButtonGroupChild ? markButtonGroupTrigger(children) : children;
 
   return (
     <TooltipContext value={{slots}}>
@@ -87,11 +52,11 @@ const TooltipRoot: React.FC<TooltipRootProps> = ({
         delay={resolvedDelay}
         {...props}
       >
-        {resolvedChildren}
+        {children}
       </TooltipTriggerPrimitive>
     </TooltipContext>
   );
-};
+});
 
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Content

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -63,7 +63,7 @@ const markButtonGroupTrigger = (children: ReactNode): ReactNode => {
   });
 };
 
-const TooltipRoot = ({
+const TooltipRoot: React.FC<TooltipRootProps> = ({
   children,
   closeDelay,
   delay,

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -37,9 +37,7 @@ const TooltipContext = createContext<TooltipContext>({});
 /* -------------------------------------------------------------------------------------------------
  * Tooltip Root
  * -----------------------------------------------------------------------------------------------*/
-interface TooltipRootProps
-  extends ComponentPropsWithRef<typeof TooltipTriggerPrimitive>,
-    ButtonGroupChildProps {}
+type TooltipRootProps = ComponentPropsWithRef<typeof TooltipTriggerPrimitive>;
 
 const markButtonGroupTrigger = (children: ReactNode): ReactNode => {
   let isMarked = false;
@@ -71,7 +69,7 @@ const TooltipRoot = ({
   delay,
   [BUTTON_GROUP_CHILD]: isButtonGroupChild,
   ...props
-}: TooltipRootProps) => {
+}: TooltipRootProps & ButtonGroupChildProps) => {
   const slots = React.useMemo(() => tooltipVariants(), []);
 
   const cssDelay = useCSSVariable("--tooltip-delay");

--- a/packages/react/src/utils/children.ts
+++ b/packages/react/src/utils/children.ts
@@ -1,6 +1,129 @@
-import type {ReactNode} from "react";
+import type {ReactElement, ReactNode} from "react";
 
-import {Children, isValidElement} from "react";
+import {Children, Fragment, cloneElement, isValidElement} from "react";
+
+const CHILD_PROPS = "__heroui_child_props";
+const SUPPORTS_CHILD_PROPS = Symbol("supportsChildProps");
+
+type ChildProps = Record<string, unknown>;
+type ChildPropsCarrier = {
+  [CHILD_PROPS]?: ChildProps;
+};
+type ChildPropsComponent = React.ElementType & {
+  [SUPPORTS_CHILD_PROPS]?: true;
+};
+
+/** Marks a component as able to consume or forward internal child props. */
+export const enableChildProps = <T extends React.ElementType>(
+  component: T,
+): T & {displayName?: string} => {
+  Object.defineProperty(component, SUPPORTS_CHILD_PROPS, {value: true});
+
+  return component;
+};
+
+/** Returns whether an element can safely receive internal child props. */
+export const supportsChildProps = (child: ReactElement): boolean => {
+  if (child.type === Fragment) {
+    let firstElement: ReactElement | undefined;
+
+    Children.forEach((child.props as {children?: ReactNode}).children, (fragmentChild) => {
+      if (!firstElement && isValidElement(fragmentChild)) {
+        firstElement = fragmentChild;
+      }
+    });
+
+    return firstElement ? supportsChildProps(firstElement) : false;
+  }
+
+  if (typeof child.type === "string") {
+    return false;
+  }
+
+  return (child.type as ChildPropsComponent)[SUPPORTS_CHILD_PROPS] === true;
+};
+
+const setChildProps = (child: ReactElement, childProps: ChildProps): ReactElement => {
+  const element = child as ReactElement<ChildPropsCarrier>;
+
+  return cloneElement(element, {
+    [CHILD_PROPS]: {
+      ...element.props[CHILD_PROPS],
+      ...childProps,
+    },
+  });
+};
+
+const forwardToFirstChild = (children: ReactNode, childProps: ChildProps): [ReactNode, boolean] => {
+  let didForward = false;
+
+  const forwardedChildren = Children.map(children, (child) => {
+    if (didForward || !isValidElement(child)) {
+      return child;
+    }
+
+    if (child.type === Fragment) {
+      const [fragmentChildren, fragmentDidForward] = forwardToFirstChild(
+        (child.props as {children?: ReactNode}).children,
+        childProps,
+      );
+
+      if (!fragmentDidForward) {
+        return child;
+      }
+
+      didForward = true;
+
+      return cloneElement(child, undefined, fragmentChildren);
+    }
+
+    didForward = true;
+
+    return setChildProps(child, childProps);
+  });
+
+  return [forwardedChildren, didForward];
+};
+
+/**
+ * Passes internal parent props through a transparent wrapper to its first element child.
+ */
+export const forwardChildProps = <T extends {children?: ReactNode}>(inputProps: T): T => {
+  const {[CHILD_PROPS]: childProps, ...props} = inputProps as T & ChildPropsCarrier;
+
+  if (!childProps) {
+    return inputProps;
+  }
+
+  const [children] = forwardToFirstChild(props.children, childProps);
+
+  return {...props, children} as T;
+};
+
+/** Applies props forwarded by a transparent parent to the current component. */
+export const mergeChildProps = <T extends object>(inputProps: T): T => {
+  const {[CHILD_PROPS]: childProps, ...props} = inputProps as T & ChildPropsCarrier;
+
+  if (!childProps) {
+    return inputProps;
+  }
+
+  return {...childProps, ...props} as T;
+};
+
+/** Marks an element with props that transparent wrappers pass to their first child. */
+export const withChildProps = (child: ReactElement, childProps: ChildProps): ReactElement => {
+  if (child.type === Fragment) {
+    const [children] = forwardToFirstChild(
+      (child.props as {children?: ReactNode}).children,
+      childProps,
+    );
+
+    return cloneElement(child, undefined, children);
+  }
+
+  return setChildProps(child, childProps);
+};
 
 /**
  * Gets only the valid children of a component,


### PR DESCRIPTION
## Summary
- Add generic internal child-prop forwarding for transparent trigger wrappers.
- Preserve ButtonGroup direct-child semantics while allowing group props through Tooltip, Dropdown, Popover, Modal, Drawer, and AlertDialog.
- Keep wrappers independent of Button/ButtonGroup internals and prevent internal props from reaching DOM elements or separators.
- Add ButtonGroup stories covering Tooltip and Dropdown wrappers.
- Fixes #6516

## Verification
- `pnpm typecheck:react`
- `pnpm lint:react`
- `pnpm build`
- SSR regression checks for every supported wrapper, nested and fragment forwarding, and internal-prop leakage.