### PR TITLE
fix(button-group): stop internal child marker from reaching the DOM

### DIFF
--- a/packages/react/src/components/button-group/button-group.tsx
+++ b/packages/react/src/components/button-group/button-group.tsx
@@ -66,6 +66,12 @@ const ButtonGroupRoot = ({
       return child;
     }
 
+    // Host elements and the separator forward unknown props straight to the DOM, where React
+    // warns about the non-boolean attribute. Only stamp children that can consume the marker.
+    if (typeof child.type === "string" || child.type === ButtonGroupSeparator) {
+      return child;
+    }
+
     // Clone the child and add the special prop
     return React.cloneElement(child, {
       [BUTTON_GROUP_CHILD]: true,


### PR DESCRIPTION
No existing issue — found while investigating #6516.

## 📝 Description

`ButtonGroup` stamps the internal `__button_group_child` marker onto every valid element child via `Children.map` + `cloneElement`. Children that forward unknown props to a host element cannot consume it, so the marker reaches the DOM and React logs a warning.

This affects HeroUI's own `ButtonGroup.Separator` when used as a direct sibling, and any plain host child (e.g. a `<span>`).

## ⛳️ Current behavior (updates)

```tsx
<ButtonGroup size="sm" variant="secondary">
  <Button>one</Button>
  <ButtonGroup.Separator />
  <Button>two</Button>
</ButtonGroup>
```

logs:

```
Received `true` for a non-boolean attribute `__button_group_child`.

If you want to write it to the DOM, pass a string instead:
__button_group_child="true" or __button_group_child={value.toString()}
```

`ButtonGroupSeparator` only destructures `className` and spreads the rest onto `dom.span`, so the marker lands on the DOM node. A plain `<span>` child hits the same path.

## 🚀 New behavior

No warning. The marker is only stamped on children that can actually consume it — host elements and `ButtonGroup.Separator` are skipped.

Only `Button` reads the marker, so `size` / `variant` / `isDisabled` / `fullWidth` inheritance is unchanged. Verified by rendering before/after and diffing the emitted markup:

| case | before | after |
|---|---|---|
| direct `<Button>` child | `button--sm button--secondary` | unchanged |
| `<Button>` behind a wrapper component | not inherited (see #6021) | unchanged |
| `<ButtonGroup.Separator />` sibling | warning | no warning, same markup |
| `<span>` child | warning | no warning, same markup |

## 💣 Is this a breaking change (Yes/No):

No. Behaviour is identical apart from the removed warning; no public API changes.

## 📝 Additional Information

- `pnpm build`, `pnpm lint`, `pnpm typecheck` and `prettier --check` all pass.
- Found while investigating #6516. That issue needs a design decision (it conflicts with #6021), so I've left the analysis in a [comment there](https://github.com/heroui-inc/heroui/issues/6516#issuecomment-5124482584) and kept this PR to the part that is a bug under either outcome.
- Related, not touched here: `TOGGLE_BUTTON_GROUP_CHILD` is declared and exported in `toggle-button-group.tsx` but never referenced. It's a public export, so removing it would be breaking — happy to follow up if you'd like it deprecated.
