### PR TITLE
fix(icons): remove aria-label from aria-hidden decorative icons

### DIFF
--- a/packages/react/src/components/icons.tsx
+++ b/packages/react/src/components/icons.tsx
@@ -5,7 +5,6 @@ interface IconProps extends React.SVGProps<SVGSVGElement> {}
 export const IconChevronDown = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Chevron down icon"
     fill="none"
     height={16}
     role="presentation"
@@ -26,7 +25,6 @@ export const IconChevronDown = (props: IconProps) => (
 export const IconChevronUp = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Chevron up icon"
     fill="none"
     height={16}
     role="presentation"
@@ -47,7 +45,6 @@ export const IconChevronUp = (props: IconProps) => (
 export const IconChevronLeft = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Chevron left icon"
     fill="none"
     height={16}
     role="presentation"
@@ -68,7 +65,6 @@ export const IconChevronLeft = (props: IconProps) => (
 export const IconChevronRight = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Chevron right icon"
     fill="none"
     height={16}
     role="presentation"
@@ -89,7 +85,6 @@ export const IconChevronRight = (props: IconProps) => (
 export const ExternalLinkIcon = ({height = 9, width = 9, ...props}: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="External link icon"
     fill="none"
     height={height}
     role="presentation"
@@ -108,7 +103,6 @@ export const ExternalLinkIcon = ({height = 9, width = 9, ...props}: IconProps) =
 export const CircleDashedIcon = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Circle dashed icon"
     fill="none"
     height={16}
     role="presentation"
@@ -127,7 +121,6 @@ export const CircleDashedIcon = (props: IconProps) => (
 export const CloseIcon = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Close icon"
     fill="none"
     height={16}
     role="presentation"
@@ -148,7 +141,6 @@ export const CloseIcon = (props: IconProps) => (
 export const InfoIcon = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Info icon"
     fill="none"
     height={16}
     role="presentation"
@@ -169,7 +161,6 @@ export const InfoIcon = (props: IconProps) => (
 export const WarningIcon = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Warning icon"
     fill="none"
     height={16}
     role="presentation"
@@ -190,7 +181,6 @@ export const WarningIcon = (props: IconProps) => (
 export const DangerIcon = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Danger icon"
     fill="none"
     height={16}
     role="presentation"
@@ -211,7 +201,6 @@ export const DangerIcon = (props: IconProps) => (
 export const SuccessIcon = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Success icon"
     fill="none"
     height={16}
     role="presentation"
@@ -232,7 +221,6 @@ export const SuccessIcon = (props: IconProps) => (
 export const IconMinus = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Minus icon"
     fill="none"
     height={16}
     role="presentation"
@@ -253,7 +241,6 @@ export const IconMinus = (props: IconProps) => (
 export const IconPlus = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Plus icon"
     fill="none"
     height={16}
     role="presentation"
@@ -274,7 +261,6 @@ export const IconPlus = (props: IconProps) => (
 export const IconSearch = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Search icon"
     fill="none"
     height={16}
     role="presentation"
@@ -295,7 +281,6 @@ export const IconSearch = (props: IconProps) => (
 export const IconCalendar = (props: IconProps) => (
   <svg
     aria-hidden="true"
-    aria-label="Calendar icon"
     fill="none"
     height="1em"
     role="presentation"


### PR DESCRIPTION
Refs #6718

## 📝 Description

Follow-up to #6718 covering the shared icon set. #6721 fixed `Spinner`, but the set-wide part discussed on the issue was never applied — every icon in `packages/react/src/components/icons.tsx` still carries an `aria-label` on an element that is also `aria-hidden="true"`.

Since `aria-hidden="true"` removes an element from the accessibility tree, the `aria-label` can never be announced. It is dead weight that trips accessibility linters and audits.

## ⛳️ Current behavior (updates)

All 15 icons render with both attributes on the same `<svg>`:

```html
<svg aria-hidden="true" aria-label="Chevron down icon" role="presentation" ...>
<svg aria-hidden="true" aria-label="Close icon" role="presentation" ...>
<svg aria-hidden="true" aria-label="External link icon" role="presentation" ...>
```

Affected: `IconChevronDown`, `IconChevronUp`, `IconChevronLeft`, `IconChevronRight`, `ExternalLinkIcon`, `CircleDashedIcon`, `CloseIcon`, `InfoIcon`, `WarningIcon`, `DangerIcon`, `SuccessIcon`, `IconMinus`, `IconPlus`, `IconSearch`, `IconCalendar`.

## 🚀 New behavior

The `aria-label` is removed from all 15 icons; they stay `aria-hidden="true"` + `role="presentation"`, which is the correct decorative-SVG pattern.

```html
<svg aria-hidden="true" role="presentation" ...>
```

## 💣 Is this a breaking change (Yes/No):

No — and specifically it cannot change any announced name:

- The icons were already `aria-hidden="true"`, so nothing in the accessibility tree ever exposed these labels. I checked the repo and nothing renders these icons with `aria-hidden={false}`, so there is no usage where the label was reachable.
- Accessible names continue to come from the wrapping control, e.g. `<Button isIconOnly aria-label="Align left">` as used in the docs demos.
- `{...props}` is still spread last on every icon, so a consumer can supply `aria-label` (or override `aria-hidden`) per usage if they ever need to.

## 📝 Additional Information

- Verified with `renderToStaticMarkup` before/after: the only difference in emitted markup is the removed attribute.
- `pnpm build`, `pnpm lint`, `pnpm typecheck` and `prettier --check` all pass.
- Targeting `v3` (the default branch). Note that `icons.tsx` has the same 15 occurrences on `v3.2.3`, and the `Spinner` fix from #6721 landed on `v3.2.3` but is not yet an ancestor of `v3` — so `spinner.tsx` on `v3` still has the same conflicting pair on its inner `<SpinnerPrimitive aria-hidden aria-label="Loading" />`. I've deliberately left that alone since it looks like a forward-port question for the release branch rather than something to re-fix here, but happy to include it if you'd prefer.
