### PR TITLE
fix(react): move react-aria packages to peerDependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,15 +57,10 @@
   "dependencies": {
     "@heroui/styles": "workspace:*",
     "@radix-ui/react-avatar": "1.1.11",
-    "@react-aria/ssr": "3.10.1",
-    "@react-aria/i18n": "3.13.1",
-    "@react-aria/utils": "3.34.1",
     "@react-types/shared": "3.36.0",
     "@react-types/color": "3.2.0",
     "@react-stately/utils": "3.12.1",
     "input-otp": "1.4.2",
-    "react-aria": "^3.50.0",
-    "react-aria-components": "^1.19.0",
     "tailwind-merge": "3.4.0",
     "tailwind-variants": "3.3.0"
   },
@@ -73,6 +68,9 @@
     "@heroui/standard": "workspace:*",
     "@iconify/react": "6.0.2",
     "@internationalized/date": "3.12.2",
+    "@react-aria/i18n": "3.13.1",
+    "@react-aria/ssr": "3.10.1",
+    "@react-aria/utils": "3.34.1",
     "@react-stately/data": "3.16.1",
     "@storybook/react": "10.1.10",
     "@types/fs-extra": "11.0.4",
@@ -80,11 +78,18 @@
     "@types/react-dom": "19.2.3",
     "fs-extra": "11.3.3",
     "react": "19.2.6",
+    "react-aria": "3.50.0",
+    "react-aria-components": "1.19.0",
     "react-dom": "19.2.6",
     "tailwindcss": "4.1.18"
   },
   "peerDependencies": {
+    "@react-aria/i18n": "^3.13.1",
+    "@react-aria/ssr": "^3.10.1",
+    "@react-aria/utils": "^3.34.1",
     "react": ">=19.0.0",
+    "react-aria": "^3.50.0",
+    "react-aria-components": "^1.19.0",
     "react-dom": ">=19.0.0",
     "tailwindcss": ">=4.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,15 +358,6 @@ importers:
       '@radix-ui/react-avatar':
         specifier: 1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-aria/i18n':
-        specifier: 3.13.1
-        version: 3.13.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-aria/ssr':
-        specifier: 3.10.1
-        version: 3.10.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-aria/utils':
-        specifier: 3.34.1
-        version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/utils':
         specifier: 3.12.1
         version: 3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -379,12 +370,6 @@ importers:
       input-otp:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-aria:
-        specifier: ^3.50.0
-        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-aria-components:
-        specifier: ^1.19.0
-        version: 1.19.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tailwind-merge:
         specifier: 3.4.0
         version: 3.4.0
@@ -401,6 +386,15 @@ importers:
       '@internationalized/date':
         specifier: 3.12.2
         version: 3.12.2
+      '@react-aria/i18n':
+        specifier: 3.13.1
+        version: 3.13.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-aria/ssr':
+        specifier: 3.10.1
+        version: 3.10.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-aria/utils':
+        specifier: 3.34.1
+        version: 3.34.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/data':
         specifier: 3.16.1
         version: 3.16.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -422,6 +416,12 @@ importers:
       react:
         specifier: 19.2.6
         version: 19.2.6
+      react-aria:
+        specifier: 3.50.0
+        version: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-aria-components:
+        specifier: 1.19.0
+        version: 1.19.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6738

## 📝 Description

<!--- Add a brief description -->

### Root cause

`Form`, `TextField`, and `FieldError` communicate through React Aria's `FormValidationContext` (from `react-stately`, pulled in via `react-aria` / `react-aria-components`). Those packages were declared as regular **`dependencies`** with caret ranges, so a consumer whose own dependency graph resolves a slightly different version ends up with **two physical copies** of `react-aria-components` / `react-stately`. Two copies means `React.createContext()` runs twice → the `Form` provider and the field consumer read **different context objects** → validation errors silently never propagate.

This is package-manager-dependent (bun's hoisting reproduces it; npm often dedupes), which is why it hit some users and not others.

### Fix

Move the shared, context-bearing React Aria runtime packages from `dependencies` to `peerDependencies` so the host app always provides a **single shared instance**:

- `react-aria`, `react-aria-components`
- `@react-aria/i18n`, `@react-aria/ssr`, `@react-aria/utils`

Pinned copies are kept in `devDependencies` for the workspace build/Storybook. As a bonus, version drift now surfaces as a **visible peer-dependency warning** at install time instead of a silent runtime break.

### Verification

- **Isolated lab (both cases):** plain `dependencies` + version drift under bun → 2 copies → `FormValidationContext` split → repro fails; `peerDependencies` → 1 copy + install warning → repro passes. Same result for the OSS↔Pro sibling-dedupe case.
- **Real packaged artifact:** `pnpm pack` → installed the tarball into a consumer app (bun) with the peers → `react-aria-components`, `react-stately`, and `react-aria` each resolve to **1 copy**, and the `Form.validationErrors` → `FieldError` + `data-invalid` repro renders correctly (`PASS=true`).
- `pnpm --filter=@heroui/react typecheck` ✅ · `pnpm build --filter=@heroui/react` ✅ · dist externalizes the peers (no `FormValidationContext` bundled inline).

### Notes / follow-up

- No source or API changes — packaging only.
- For the dedupe guarantee to hold end-to-end, **`@heroui-pro/react` should declare the same react-aria peers symmetrically**; otherwise Pro can still resolve its own copy and reintroduce a split.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
