### PR TITLE
fix(tabs): clamp ListContainer chevron scrolling to the scrollable range

### DIFF
--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -118,15 +118,29 @@ const TabList = ({children, className, ...props}: TabListProps) => {
 
       if (!el) return;
       const size = isVertical ? el.clientHeight : el.clientWidth;
+      const scrollSize = isVertical ? el.scrollHeight : el.scrollWidth;
+      const maxScroll = Math.max(0, scrollSize - size);
 
       // In RTL, the horizontal scroll range runs from 0 (start, on the right) to negative,
       // so the delta sign must be flipped for `scrollLeft` to move toward the intended edge.
       const isRTL = !isVertical && getComputedStyle(el).direction === "rtl";
       const delta = direction * size * 0.8 * (isRTL ? -1 : 1);
+      const current = isVertical ? el.scrollTop : el.scrollLeft;
 
-      el.scrollBy({
+      // Clamp the target to the scrollable range so a press near the edge lands
+      // flush on it instead of requesting a position past the content, which can
+      // cut the smooth scroll short of the edge (e.g. iOS Safari) or leave the
+      // strip visually stranded. RTL ranges run [-maxScroll, 0].
+      const next = Math.min(
+        isRTL ? 0 : maxScroll,
+        Math.max(isRTL ? -maxScroll : 0, current + delta),
+      );
+
+      if (next === current) return;
+
+      el.scrollTo({
         behavior: "smooth",
-        [isVertical ? "top" : "left"]: delta,
+        [isVertical ? "top" : "left"]: next,
       });
     },
     [isVertical],


### PR DESCRIPTION
Closes #6748

## 📝 Description

`Tabs.ListContainer`'s chevron buttons scroll by a fixed `direction * clientSize * 0.8` through `el.scrollBy({ behavior: "smooth", ... })` with no clamping. When the remaining distance is smaller than that delta, the requested target lies past the content edge — on iOS Safari the smooth scroll can then stop short and leave the strip stranded with blank space after the last tab, and pressing a chevron while already at the edge still fires a redundant smooth-scroll request.

## ⛳️ Current behavior (updates)

Chevron press → `scrollBy` a fixed 80% of the viewport, even when that overshoots the scrollable range.

## 🚀 New behavior

The handler computes the target position and clamps it to the scrollable range before calling `scrollTo`:

- LTR / vertical: `[0, scrollSize - clientSize]`
- RTL horizontal: `[-(scrollSize - clientSize), 0]` (keeps the existing RTL delta-flip semantics — modern browsers report RTL `scrollLeft` as 0 at the start edge running negative)
- If the clamped target equals the current position (already flush at the edge), the press is a no-op instead of issuing a redundant smooth scroll.

## 💣 Is this a breaking change (Yes/No):

No. Mid-range presses behave exactly as before (same 0.8 × viewport step); only presses near or at an edge change, landing flush instead of overshooting.

## 📝 Additional Information

Verified in a production app carrying this change as a pnpm patch on `@heroui/react@3.2.2`: overflowing tab strips now land flush on the final tabs on iOS Safari and desktop Chrome, both directions. jsdom has no layout so a meaningful unit test isn't practical for this path; happy to add a Storybook note or interaction test if you'd like.