### PR TITLE
fix(autocomplete): prevent popover from clipping the last options

### DIFF
--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -130,7 +130,7 @@
 
 /* Similar to popover content styles */
 .autocomplete__popover {
-  @apply w-(--trigger-width) max-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 overflow-hidden overscroll-contain bg-overlay p-0 pt-2 text-sm outline-none;
+  @apply flex w-(--trigger-width) max-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 flex-col overflow-hidden overscroll-contain bg-overlay p-0 pt-2 text-sm outline-none;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 
@@ -191,9 +191,13 @@
     rotate: 90deg;
   }
 
-  /* Listbox styles */
+  /* Listbox styles.
+   * `min-h-0` + the popover's flex column let the list shrink below 320px when the
+   * popover itself is constrained (e.g. inside a Modal, or a short viewport). Without
+   * it the list keeps its full 320px and its overflow is clipped by the popover, making
+   * the last options unreachable. */
   [data-slot="list-box"] {
-    @apply max-h-[320px] scrollbar overflow-y-auto p-1.5 outline-none;
+    @apply max-h-[320px] min-h-0 scrollbar overflow-y-auto p-1.5 outline-none;
   }
 
   [data-slot="list-box-item"] {
@@ -219,7 +223,7 @@
 
   /* Search Field styles */
   [data-slot="search-field"] {
-    @apply px-3 py-1 outline-none;
+    @apply shrink-0 px-3 py-1 outline-none;
   }
 
   /* Empty State */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6759

## 📝 Description

<!--- Add a brief description -->

The popover is `overflow: hidden` with a max-height computed by React Aria from the space available below the trigger, while the inner list-box is pinned to `max-h-[320px]`. When that computed max-height is under the 372px the content
needs (8px padding + 44px search field + 320px list), the overflow is clipped and the last options stay unreachable no matter how far you scroll. A centered Modal hits this almost always, since it puts the trigger mid-viewport.

Make the popover a flex column and add `min-h-0` to the list so it shrinks to fit instead of overflowing. The 320px cap is unchanged, so virtualized lists keep the behaviour from #6642 and #6636.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

<img width="526" height="317" alt="image" src="https://github.com/user-attachments/assets/1fe008af-05b3-4cb8-b05e-8e246f121d5f" />

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

<img width="507" height="324" alt="image" src="https://github.com/user-attachments/assets/fbac7ac2-1b4a-4423-8421-fe2e864aff26" />

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
