### PR TITLE
fix(styles): prevent subpixel border overflow on badge

### DIFF
--- a/packages/styles/components/badge.css
+++ b/packages/styles/components/badge.css
@@ -17,6 +17,7 @@
   background-color: var(--badge-bg);
   color: var(--badge-fg);
   border: 1px solid var(--badge-border);
+  background-clip: padding-box;
 }
 
 .badge__label {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes [Discord 🧵](https://discord.com/channels/856545348885676062/1534632541028614354)

## 📝 Description

Badge uses a 1px border with `var(--badge-border)` as an outline. In Firefox, this can show a thin fringe of color outside the badge because of subpixel anti-aliasing on rounded corners.

## ⛳️ Current behavior

A thin line of the background color appears outside the badge edge in Firefox.

## 🚀 New behavior

Add [`background-clip`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/background-clip) that keeps the background inside the padding box and removes the fringe, without changing size or look.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Only Badge uses a background-colored 1px border this way. Other components with 1px + border-radius may have similar issues, but not the same pattern.


#### Before

<img width="1459" height="781" alt="before" src="https://github.com/user-attachments/assets/bdd486e3-3095-456a-8e9b-5f93f17b033a" />

#### After

<img width="1459" height="781" alt="after" src="https://github.com/user-attachments/assets/10c43777-f820-46e7-bee1-165e115eb64e" />
