### PR TITLE
fix(styles): allow backdrop click to dismiss modal with scroll outside

### DIFF
--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -138,10 +138,17 @@
 
 /**
  * Modifier: container--scroll-outside
+ *
+ * The container is React Aria's modal ref, so it must stay `pointer-events: none`,
+ * otherwise clicks around the dialog count as inside the modal and never dismiss it.
+ * The backdrop owns the scrolling instead.
  */
 .modal__container--scroll-outside {
-  @apply scrollbar overflow-y-auto;
-  @apply pointer-events-auto;
+  @apply h-auto min-h-(--visual-viewport-height) overflow-y-visible;
+}
+
+.modal__backdrop:has(.modal__container--scroll-outside) {
+  @apply scrollbar items-start overflow-y-auto;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6762

## 📝 Description

<!--- Add a brief description -->

With `scroll="outside"`, `.modal__container--scroll-outside` set `pointer-events: auto` so the container could act as the scroll container. That container is the element React Aria passes to `useModalOverlay` as `modalRef`, and dismiss-on-outside-click is `useInteractOutside` checking `!modalRef.current.contains(event.target)`. Because the container spans the full viewport height, every click in the visual backdrop area hit the container and was classified as *inside* the modal,
so the modal never closed.

The fix moves the scrolling to the backdrop (the underlay) so the container can stay `pointer-events: none`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Clicking the backdrop of a `Modal` with `scroll="outside"` does nothing — `onOpenChange` never fires with `false`. On viewports ≥`sm` the container is `w-fit`, so only clicks far to the left or right of the dialog still dismiss; the full-height column around the dialog is dead.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Backdrop clicks dismiss the modal for both `scroll="inside"` and `scroll="outside"`, and outside
scrolling still works with the backdrop as the scroll container.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

Nope

## 📝 Additional Information
