### PR TITLE
fix(tooltip): restore exit animation when swapping between tooltips

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(overlays)/tooltip.mdx
+++ b/apps/docs/content/docs/cn/react/components/(overlays)/tooltip.mdx
@@ -141,6 +141,7 @@ Tooltip 使用以下 CSS 类（[查看源码样式](https://github.com/heroui-in
 | `closeDelay` | `number` | `500` 或 CSS 变量 | 隐藏 Tooltip 前的延迟（毫秒）；可通过 `--tooltip-close-delay` CSS 变量全局配置 |
 | `trigger` | `"hover" \| "focus"` | `"hover"` | Tooltip 的触发方式 |
 | `isDisabled` | `boolean` | `false` | 是否禁用 Tooltip |
+| `shouldSkipAnimation` | `boolean` | `false` | 在多个 Tooltip 之间快速切换时，是否跳过进入与退出动画 |
 
 ### Tooltip.Content
 | Prop | 类型 | 默认值 | 描述 |

--- a/apps/docs/content/docs/en/react/components/(overlays)/tooltip.mdx
+++ b/apps/docs/content/docs/en/react/components/(overlays)/tooltip.mdx
@@ -118,6 +118,7 @@ The component supports animation states:
 | `closeDelay` | `number` | `0` | Delay in milliseconds before hiding tooltip |
 | `trigger` | `"hover" \| "focus"` | `"hover"` | How the tooltip is triggered |
 | `isDisabled` | `boolean` | `false` | Whether the tooltip is disabled |
+| `shouldSkipAnimation` | `boolean` | `false` | Whether to skip the enter and exit animations when moving quickly from one tooltip to another |
 
 ### Tooltip.Content
 

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -12,6 +12,7 @@ import {
   OverlayArrow,
   Tooltip as TooltipPrimitive,
   TooltipTrigger as TooltipTriggerPrimitive,
+  TooltipTriggerStateContext,
 } from "react-aria-components/Tooltip";
 
 import {useCSSVariable} from "../../hooks/use-css-variable";
@@ -29,16 +30,48 @@ type TooltipContext = {
 const TooltipContext = createContext<TooltipContext>({});
 
 /* -------------------------------------------------------------------------------------------------
+ * Tooltip Animation Scope
+ * -----------------------------------------------------------------------------------------------*/
+type TooltipAnimationScopeProps = {
+  children: ReactNode;
+  shouldSkipAnimation?: boolean;
+};
+
+// React Aria sets `shouldSkipAnimation` while its global warmup timer is active, which makes
+// `Tooltip` drop `data-entering` / `data-exiting` when one tooltip replaces another. HeroUI drives
+// both phases from CSS keyframes, so the flag is cleared for descendants to keep the fade on swap.
+const TooltipAnimationScope = ({children, shouldSkipAnimation}: TooltipAnimationScopeProps) => {
+  const state = use(TooltipTriggerStateContext);
+
+  if (!state || shouldSkipAnimation) return children;
+
+  return (
+    <TooltipTriggerStateContext value={{...state, shouldSkipAnimation: false}}>
+      {children}
+    </TooltipTriggerStateContext>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
  * Tooltip Root
  * -----------------------------------------------------------------------------------------------*/
-type TooltipRootProps = ComponentPropsWithRef<typeof TooltipTriggerPrimitive>;
+type TooltipRootProps = ComponentPropsWithRef<typeof TooltipTriggerPrimitive> & {
+  /**
+   * Whether to let React Aria skip the enter and exit animations while its global warmup timer is
+   * active, i.e. when moving quickly from one tooltip to another.
+   *
+   * @default false
+   */
+  shouldSkipAnimation?: boolean;
+};
 
 const TooltipRoot = ({
   children,
   closeDelay,
   delay,
+  shouldSkipAnimation = false,
   ...props
-}: ComponentPropsWithRef<typeof TooltipTriggerPrimitive>) => {
+}: TooltipRootProps) => {
   const slots = React.useMemo(() => tooltipVariants(), []);
 
   const cssDelay = useCSSVariable("--tooltip-delay");
@@ -55,7 +88,9 @@ const TooltipRoot = ({
         delay={resolvedDelay}
         {...props}
       >
-        {children}
+        <TooltipAnimationScope shouldSkipAnimation={shouldSkipAnimation}>
+          {children}
+        </TooltipAnimationScope>
       </TooltipTriggerPrimitive>
     </TooltipContext>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # [Discord Thread](https://discord.com/channels/856545348885676062/1533928229100978196)

## 📝 Description

<!--- Add a brief description -->

Tooltips stopped fading out when moving from one trigger to an adjacent one, a regression introduced by the `react-aria-components` 1.19 → 1.20 and `react-stately` 3.48 → 3.49 bumps. 

`useTooltipTriggerState` gained a `shouldSkipAnimation` flag that `closeOpenTooltips()` sets on every other open tooltip during the global warmup period. React Aria then computes `isExiting = props.isExiting || !state.shouldSkipAnimation && exitAnimation`, so the flag suppresses `data-exiting` and `Tooltip` hits `if (!state.isOpen && !isExiting) return null` — the node unmounts before HeroUI's keyframes can run. This is intentional upstream, but it conflicts with HeroUI driving both animation phases from CSS.

`TooltipAnimationScope` sits inside `TooltipTrigger` and re-provides `TooltipTriggerStateContext` with the flag cleared. This is the only override point: the warmup state lives in module-level globals in `react-stately` with no props to configure it, and a CSS-only fix is impossible because the element is already unmounted.


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Swapping between adjacent tooltips removes the old one instantly, with no fade out (and no fade in on the new one).


## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Swaps fade in and out again, matching pre-3.2.3 behavior. A new `shouldSkipAnimation` prop on `Tooltip` opts back into React Aria's instant swap:

​```tsx
<Tooltip shouldSkipAnimation>...</Tooltip>
​```

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## 📝 Additional Information
