### PR TITLE
docs(spinner): add animation speed demos

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(feedback)/spinner.mdx
+++ b/apps/docs/content/docs/cn/react/components/(feedback)/spinner.mdx
@@ -32,6 +32,14 @@ import { Spinner } from '@heroui/react';
   name="spinner-sizes"
 />
 
+### 速度
+
+为单个 Spinner 添加动画工具类即可调整其旋转速度。请同时加上 `motion-reduce:animate-none`，以便在用户开启“减少动态效果”时保持静止。
+
+<ComponentPreview
+  name="spinner-speed"
+/>
+
 ## 自定义样式
 
 ### Tailwind CSS

--- a/apps/docs/content/docs/en/react/components/(feedback)/spinner.mdx
+++ b/apps/docs/content/docs/en/react/components/(feedback)/spinner.mdx
@@ -32,6 +32,15 @@ import { Spinner } from '@heroui/react';
   name="spinner-sizes"
 />
 
+### Speed
+
+Apply an animation utility to change how fast a single spinner rotates. Pair it with
+`motion-reduce:animate-none` so it stays still for users who prefer reduced motion.
+
+<ComponentPreview
+  name="spinner-speed"
+/>
+
 ## Customization
 
 ### Tailwind CSS
@@ -43,12 +52,10 @@ import { Spinner } from '@heroui/react';
 To customize the Spinner component classes, you can use the `@layer components` directive.
 [Learn more](https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes).
 
-You can also override the animation duration to control how fast the spinner rotates:
-
 ```css
 @layer components {
   .spinner {
-    @apply animate-[spin_0.4s_linear_infinite];
+    @apply animate-spin;
   }
 
   .spinner--accent {

--- a/apps/docs/content/docs/en/react/components/(feedback)/spinner.mdx
+++ b/apps/docs/content/docs/en/react/components/(feedback)/spinner.mdx
@@ -43,10 +43,12 @@ import { Spinner } from '@heroui/react';
 To customize the Spinner component classes, you can use the `@layer components` directive.
 [Learn more](https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes).
 
+You can also override the animation duration to control how fast the spinner rotates:
+
 ```css
 @layer components {
   .spinner {
-    @apply animate-spin;
+    @apply animate-[spin_0.4s_linear_infinite];
   }
 
   .spinner--accent {

--- a/apps/docs/src/demos/cn/index.ts
+++ b/apps/docs/src/demos/cn/index.ts
@@ -2219,6 +2219,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./spinner/sizes").then((m) => m.SpinnerSizes),
     file: "cn/spinner/sizes.tsx",
   },
+  "spinner-speed": {
+    loader: () => import("./spinner/speed").then((m) => m.SpinnerSpeed),
+    file: "cn/spinner/speed.tsx",
+  },
   "spinner-custom-styles": {
     loader: () => import("./spinner/custom-styles").then((m) => m.CustomStyles),
     file: "cn/spinner/custom-styles.tsx",

--- a/apps/docs/src/demos/cn/spinner/index.ts
+++ b/apps/docs/src/demos/cn/spinner/index.ts
@@ -1,4 +1,5 @@
 export {SpinnerBasic as Basic} from "./basic";
 export {SpinnerColors as Colors} from "./colors";
 export {SpinnerSizes as Sizes} from "./sizes";
+export {SpinnerSpeed as Speed} from "./speed";
 export {CustomStyles} from "./custom-styles";

--- a/apps/docs/src/demos/cn/spinner/speed.tsx
+++ b/apps/docs/src/demos/cn/spinner/speed.tsx
@@ -1,0 +1,20 @@
+import {Spinner} from "@heroui/react";
+
+export function SpinnerSpeed() {
+  return (
+    <div className="flex items-center gap-8">
+      <div className="flex flex-col items-center gap-2">
+        <Spinner className="animate-[spin_1.5s_linear_infinite] motion-reduce:animate-none" />
+        <span className="text-xs text-muted">慢速</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Spinner />
+        <span className="text-xs text-muted">默认</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Spinner className="animate-[spin_0.4s_linear_infinite] motion-reduce:animate-none" />
+        <span className="text-xs text-muted">快速</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/demos/en/index.ts
+++ b/apps/docs/src/demos/en/index.ts
@@ -2274,6 +2274,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./spinner/sizes").then((m) => m.SpinnerSizes),
     file: "en/spinner/sizes.tsx",
   },
+  "spinner-speed": {
+    loader: () => import("./spinner/speed").then((m) => m.SpinnerSpeed),
+    file: "en/spinner/speed.tsx",
+  },
   "spinner-custom-styles": {
     loader: () => import("./spinner/custom-styles").then((m) => m.CustomStyles),
     file: "en/spinner/custom-styles.tsx",

--- a/apps/docs/src/demos/en/spinner/index.ts
+++ b/apps/docs/src/demos/en/spinner/index.ts
@@ -2,3 +2,4 @@ export {SpinnerBasic as Basic} from "./basic";
 export {SpinnerColors as Colors} from "./colors";
 export {CustomStyles} from "./custom-styles";
 export {SpinnerSizes as Sizes} from "./sizes";
+export {SpinnerSpeed as Speed} from "./speed";

--- a/apps/docs/src/demos/en/spinner/speed.tsx
+++ b/apps/docs/src/demos/en/spinner/speed.tsx
@@ -1,0 +1,20 @@
+import {Spinner} from "@heroui/react";
+
+export function SpinnerSpeed() {
+  return (
+    <div className="flex items-center gap-8">
+      <div className="flex flex-col items-center gap-2">
+        <Spinner className="animate-[spin_1.5s_linear_infinite] motion-reduce:animate-none" />
+        <span className="text-xs text-muted">Slow</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Spinner />
+        <span className="text-xs text-muted">Default</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Spinner className="animate-[spin_0.4s_linear_infinite] motion-reduce:animate-none" />
+        <span className="text-xs text-muted">Fast</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6775

## 📝 Description

Adds a speed customization example to Spinner's Global CSS docs section.

## ⛳️ Current behavior (updates)

Global CSS example only shows color override, using default `@apply animate-spin;`. No guidance on controlling speed.

## 🚀 New behavior

Updated the example to `@apply animate-[spin_0.4s_linear_infinite];`, with a one-line explanation. 

## 💣 Is this a breaking change (Yes/No):

No

## ✅ Testing

- [ ] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [ ] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [ ] `pnpm test` passes locally

## 📝 Additional Information
