### PR TITLE
fix(number-field): don't reserve stepper columns when buttons are absent

### DIFF
--- a/packages/react/tests/components/number-field/number-field.test.tsx
+++ b/packages/react/tests/components/number-field/number-field.test.tsx
@@ -61,9 +61,9 @@ describe("NumberField", () => {
         <NumberField defaultValue={11} name="customer-number">
           <Label>Customer number</Label>
           <NumberField.Group data-testid="number-field-group">
-            {hasDecrement && <NumberField.DecrementButton />}
+            {hasDecrement ? <NumberField.DecrementButton /> : null}
             <NumberField.Input />
-            {hasIncrement && <NumberField.IncrementButton />}
+            {hasIncrement ? <NumberField.IncrementButton /> : null}
           </NumberField.Group>
         </NumberField>,
       );

--- a/packages/react/tests/components/number-field/number-field.test.tsx
+++ b/packages/react/tests/components/number-field/number-field.test.tsx
@@ -6,6 +6,13 @@ import {FieldError} from "@/components/field-error";
 import {Label} from "@/components/label";
 import {NumberField} from "@/components/number-field";
 
+const stepperCompositions = [
+  ["no stepper buttons", false, false],
+  ["only a decrement button", true, false],
+  ["only an increment button", false, true],
+  ["both stepper buttons", true, true],
+] as const;
+
 describe("NumberField", () => {
   let user: ReturnType<typeof setupUser>;
 
@@ -46,6 +53,27 @@ describe("NumberField", () => {
     expect(document.querySelector('[data-slot="number-field-increment-button"]')).not.toBeNull();
     expect(document.querySelector('[data-slot="number-field-decrement-button"]')).not.toBeNull();
   });
+
+  it.each(stepperCompositions)(
+    "supports composition with %s",
+    (_description, hasDecrement, hasIncrement) => {
+      render(
+        <NumberField defaultValue={11} name="customer-number">
+          <Label>Customer number</Label>
+          <NumberField.Group data-testid="number-field-group">
+            {hasDecrement && <NumberField.DecrementButton />}
+            <NumberField.Input />
+            {hasIncrement && <NumberField.IncrementButton />}
+          </NumberField.Group>
+        </NumberField>,
+      );
+
+      const group = screen.getByTestId("number-field-group");
+
+      expect(group.querySelector('[slot="decrement"]') !== null).toBe(hasDecrement);
+      expect(group.querySelector('[slot="increment"]') !== null).toBe(hasIncrement);
+    },
+  );
 
   it("exposes variant BEM modifier", () => {
     renderNumber({variant: "secondary"});

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -18,7 +18,19 @@
   @apply grid h-9 items-center overflow-hidden rounded-field border bg-field text-sm text-field-foreground shadow-field outline-none;
   border-width: var(--border-width-field);
   border-color: var(--field-border);
-  grid-template-columns: 40px 1fr 40px;
+  grid-template-columns: 1fr;
+
+  &:has([slot="decrement"]) {
+    grid-template-columns: 40px 1fr;
+  }
+
+  &:has([slot="increment"]) {
+    grid-template-columns: 1fr 40px;
+  }
+
+  &:has([slot="decrement"]):has([slot="increment"]) {
+    grid-template-columns: 40px 1fr 40px;
+  }
 
   /**
    * Transitions


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6777

## 📝 Description

Make the NumberField group's CSS grid tracks follow the rendered decrement and increment buttons, and cover all four optional-stepper compositions.

## ⛳️ Current behavior (updates)

The group always reserves two 40px stepper columns, so an input-only NumberField loses 80px of usable width.

## 🚀 New behavior

The group uses one input track by default and adds a 40px track only for each rendered stepper button.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover all four decrement/increment button combinations
- [x] Focused NumberField tests pass (14 tests across component and SSR suites)
- [x] Styles build succeeds
- [x] `pnpm lint` passes (one pre-existing docs import-order warning)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (119 files, 560 tests)
- [x] Browser-computed tracks are `160px`, `40px 120px`, `120px 40px`, and `40px 80px 40px` for a 160px group

## 📝 Additional Information

<a href="https://cursor.com/agents/bc-af97f816-4e75-480b-ba68-1e1b66f270ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnumber_field_optional_stepper_layouts.mp4"><img src="https://cursor.com/artifacts/c/art-dd2cf7b8-2a3b-483f-af2c-42900c1afd98" alt="number_field_optional_stepper_layouts.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af97f816-4e75-480b-ba68-1e1b66f270ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af97f816-4e75-480b-ba68-1e1b66f270ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

