### PR TITLE
fix(button): scope will-change to enter/exit to stop modal label blur

### DIFF
--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -12,7 +12,7 @@
     transform 250ms var(--ease-smooth),
     background-color 100ms var(--ease-out),
     box-shadow 100ms var(--ease-out);
-  @apply transform-gpu will-change-transform motion-reduce:transition-none;
+  @apply transform-gpu motion-reduce:transition-none;
 
   /* Cursor */
   cursor: var(--cursor-interactive);
@@ -46,6 +46,7 @@
   /* Active / pressed */
   &:active,
   &[data-pressed="true"] {
+    @apply will-change-transform;
     background-color: var(--button-bg-pressed);
     transform: scale(0.97);
   }

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -49,7 +49,7 @@
 
 /* Similar to select popover styles */
 .dropdown__popover {
-  @apply max-w-[48svw] origin-(--trigger-anchor-point) scroll-py-1 scrollbar overflow-y-auto overscroll-contain bg-overlay p-0 text-sm will-change-transform md:min-w-55;
+  @apply max-w-[48svw] origin-(--trigger-anchor-point) scroll-py-1 scrollbar overflow-y-auto overscroll-contain bg-overlay p-0 text-sm md:min-w-55;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 

--- a/packages/styles/components/menu-item.css
+++ b/packages/styles/components/menu-item.css
@@ -13,7 +13,7 @@
     transform 250ms var(--ease-out-quart),
     box-shadow 150ms var(--ease-out);
 
-  @apply will-change-transform motion-reduce:transition-none;
+  @apply motion-reduce:transition-none;
 
   /* Cursor */
   cursor: var(--cursor-interactive);
@@ -54,6 +54,7 @@
   /* Pressed state */
   &:active,
   &[data-pressed="true"] {
+    @apply will-change-transform;
     transform: scale(0.98);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6764

## 📝 Description

Removes long-lived `will-change: transform` hints introduced by #6661 from buttons, menu items, and dropdown popovers.

## ⛳️ Current behavior (updates)

Buttons and menu items retain a compositor hint after their press animations finish, which can leave labels blurry inside transformed overlays such as modals. Dropdown popovers also retain a redundant permanent transform hint.

## 🚀 New behavior

- Buttons and menu items apply `will-change: transform` only while pressed, preserving the press-scale optimization.
- Dropdown popovers use their existing `will-change: opacity, transform` hint only during enter/exit animations.
- Static component text no longer retains the permanent `will-change` hint.

## 💣 Is this a breaking change (Yes/No):

No

## ✅ Testing

- [x] `pnpm --filter @heroui/styles build`
- [x] `pnpm lint` (passes with one existing docs import-order warning)
- [x] `pnpm typecheck`
- [x] `pnpm --filter @heroui/react exec vitest run button menu dropdown modal` (73 tests)
- [x] `pnpm test` (119 files, 556 tests, including Chromium browser suites)
- [x] Manual Storybook modal close/reopen verification after the entrance animation

<a href="https://cursor.com/agents/bc-951bea54-3643-4567-a4a0-d3aa65db82dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodal_button_label_sharp_after_reopen.mp4"><img src="https://cursor.com/artifacts/c/art-14f1e90f-1a5e-4506-96f1-278302d89869" alt="modal_button_label_sharp_after_reopen.mp4" /></a>

## 📝 Additional Information

This restores the scoped approach from #6136 while preserving the animation intent of #6661.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-951bea54-3643-4567-a4a0-d3aa65db82dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-951bea54-3643-4567-a4a0-d3aa65db82dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

