### PR TITLE
fix(drawer): handle should close only its own stacked drawer

### DIFF
--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -10,7 +10,7 @@ import type {DialogProps as DialogPrimitiveProps} from "react-aria-components/Di
 
 import {drawerVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
-import React, {createContext, use, useCallback, useId, useMemo, useRef} from "react";
+import React, {createContext, use, useCallback, useMemo, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {
   Dialog as DialogPrimitive,
@@ -28,6 +28,8 @@ import {dom} from "../../utils/dom";
 import {CloseButton} from "../close-button";
 import {SurfaceContext} from "../surface";
 
+import {isDrawerDragTargetOwnedBy} from "./drawer.utils";
+
 type DrawerPlacement = "top" | "bottom" | "left" | "right";
 
 /* -------------------------------------------------------------------------------------------------
@@ -40,28 +42,9 @@ const DRAG_THRESHOLD = 8; // px before drag activates
 const DISMISS_FRACTION = 0.3; // dismiss if dragged > 30% of dimension
 const VELOCITY_THRESHOLD = 0.5; // px/ms — dismiss on fast flick
 
-type DrawerDebugEntry = {
-  hypothesisId: string;
-  location: string;
-  message: string;
-  data: Record<string, unknown>;
-};
-
-const writeDrawerDebugLog = (entry: DrawerDebugEntry) => {
-  if (typeof process === "undefined" || typeof process.getBuiltinModule !== "function") return;
-
-  process
-    .getBuiltinModule("node:fs")
-    .appendFileSync(
-      "/opt/cursor/logs/debug.log",
-      `${JSON.stringify({...entry, timestamp: Date.now()})}\n`,
-    );
-};
-
 function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: boolean) {
   const overlayState = use(OverlayTriggerStateContext);
   const dialogRef = useRef<HTMLDivElement>(null);
-  const debugInstanceId = useId();
   const isDragging = useRef(false);
   const isActive = useRef(false);
   const startPos = useRef(0);
@@ -104,24 +87,7 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       const target = e.target as HTMLElement;
       const currentTarget = e.currentTarget as HTMLElement;
 
-      // #region agent log
-      writeDrawerDebugLog({
-        hypothesisId: "A",
-        location: "drawer.tsx:onPointerDown",
-        message: "Drawer dialog received pointer down",
-        data: {
-          instanceId: debugInstanceId,
-          placement,
-          overlayOpen: overlayState?.isOpen,
-          targetSlot: target.dataset["slot"],
-          nearestDialogInstance: target
-            .closest('[data-slot="drawer-dialog"]')
-            ?.getAttribute("data-debug-drawer"),
-          currentDialogInstance: currentTarget.dataset["debugDrawer"],
-          currentOwnsTarget: currentTarget.contains(target),
-        },
-      });
-      // #endregion
+      if (!isDrawerDragTargetOwnedBy(target, currentTarget)) return;
 
       // Don't drag from interactive elements or scrollable body
       if (
@@ -140,7 +106,7 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       currentOffset.current = 0;
       velocity.current = 0;
     },
-    [debugInstanceId, getPos, isDismissable, overlayState, placement],
+    [getPos, isDismissable],
   );
 
   const onPointerMove = useCallback(
@@ -157,21 +123,6 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
         isActive.current = true;
         dialogRef.current.style.transition = "none";
         dialogRef.current.setPointerCapture(e.pointerId);
-        // #region agent log
-        writeDrawerDebugLog({
-          hypothesisId: "A,C",
-          location: "drawer.tsx:onPointerMove:activate",
-          message: "Drawer drag activated and captured pointer",
-          data: {
-            instanceId: debugInstanceId,
-            rawDelta,
-            targetSlot: (e.target as HTMLElement).dataset["slot"],
-            currentDialogInstance: (e.currentTarget as HTMLElement).dataset["debugDrawer"],
-            refDialogInstance: dialogRef.current.dataset["debugDrawer"],
-            hasPointerCapture: dialogRef.current.hasPointerCapture(e.pointerId),
-          },
-        });
-        // #endregion
       }
 
       currentOffset.current = delta;
@@ -190,7 +141,7 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
 
       dialogRef.current.style.transform = `translate${axis}(${delta}px)`;
     },
-    [clamp, debugInstanceId, getPos, isVertical],
+    [getPos, clamp, isVertical],
   );
 
   const onPointerUp = useCallback(
@@ -221,45 +172,10 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       const shouldDismiss =
         absOffset > dimension * DISMISS_FRACTION || absVelocity > VELOCITY_THRESHOLD;
 
-      // #region agent log
-      writeDrawerDebugLog({
-        hypothesisId: "A,B,C,D",
-        location: "drawer.tsx:onPointerUp:decision",
-        message: "Drawer drag dismissal decision",
-        data: {
-          instanceId: debugInstanceId,
-          overlayOpen: overlayState?.isOpen,
-          targetSlot: (e.target as HTMLElement).dataset["slot"],
-          currentDialogInstance: (e.currentTarget as HTMLElement).dataset["debugDrawer"],
-          refDialogInstance: el.dataset["debugDrawer"],
-          hasPointerCapture: el.hasPointerCapture(e.pointerId),
-          dimension,
-          absOffset,
-          absVelocity,
-          shouldDismiss,
-          inlineTransition: el.style.transition,
-          inlineTransform: el.style.transform,
-        },
-      });
-      // #endregion
-
       if (shouldDismiss && overlayState) {
         // Keep the inline transform — it compounds with the content exit animation
         // so the drawer continues sliding from the dragged position
         overlayState.close();
-        // #region agent log
-        writeDrawerDebugLog({
-          hypothesisId: "B,D",
-          location: "drawer.tsx:onPointerUp:close",
-          message: "Drawer overlay close invoked",
-          data: {
-            instanceId: debugInstanceId,
-            overlayOpenBeforeCommit: overlayState.isOpen,
-            inlineTransition: el.style.transition,
-            inlineTransform: el.style.transform,
-          },
-        });
-        // #endregion
       } else {
         // Snap back with a spring-like ease
         el.style.transition = "transform 300ms cubic-bezier(0.32, 0.72, 0, 1)";
@@ -275,11 +191,10 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       currentOffset.current = 0;
       velocity.current = 0;
     },
-    [debugInstanceId, isVertical, overlayState],
+    [isVertical, overlayState],
   );
 
   return {
-    debugInstanceId,
     dialogRef,
     dragHandlers: isDismissable
       ? {
@@ -448,14 +363,13 @@ interface DrawerDialogProps extends DialogPrimitiveProps {}
 
 const DrawerDialog = ({children, className, ...props}: DrawerDialogProps) => {
   const {isDismissable = true, placement, slots} = use(DrawerContext);
-  const {debugInstanceId, dialogRef, dragHandlers} = useDrawerDrag(placement, isDismissable);
+  const {dialogRef, dragHandlers} = useDrawerDrag(placement, isDismissable);
 
   return (
     <SurfaceContext value={{variant: "default" as SurfaceVariants["variant"]}}>
       <DialogPrimitive
         ref={dialogRef}
         className={composeSlotClassName(slots?.dialog, className)}
-        data-debug-drawer={debugInstanceId}
         data-placement={placement}
         data-slot="drawer-dialog"
         style={isDismissable ? {touchAction: "none"} : undefined}

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -113,11 +113,11 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
           instanceId: debugInstanceId,
           placement,
           overlayOpen: overlayState?.isOpen,
-          targetSlot: target.dataset.slot,
+          targetSlot: target.dataset["slot"],
           nearestDialogInstance: target
             .closest('[data-slot="drawer-dialog"]')
             ?.getAttribute("data-debug-drawer"),
-          currentDialogInstance: currentTarget.dataset.debugDrawer,
+          currentDialogInstance: currentTarget.dataset["debugDrawer"],
           currentOwnsTarget: currentTarget.contains(target),
         },
       });
@@ -165,9 +165,9 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
           data: {
             instanceId: debugInstanceId,
             rawDelta,
-            targetSlot: (e.target as HTMLElement).dataset.slot,
-            currentDialogInstance: (e.currentTarget as HTMLElement).dataset.debugDrawer,
-            refDialogInstance: dialogRef.current.dataset.debugDrawer,
+            targetSlot: (e.target as HTMLElement).dataset["slot"],
+            currentDialogInstance: (e.currentTarget as HTMLElement).dataset["debugDrawer"],
+            refDialogInstance: dialogRef.current.dataset["debugDrawer"],
             hasPointerCapture: dialogRef.current.hasPointerCapture(e.pointerId),
           },
         });
@@ -229,9 +229,9 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
         data: {
           instanceId: debugInstanceId,
           overlayOpen: overlayState?.isOpen,
-          targetSlot: (e.target as HTMLElement).dataset.slot,
-          currentDialogInstance: (e.currentTarget as HTMLElement).dataset.debugDrawer,
-          refDialogInstance: el.dataset.debugDrawer,
+          targetSlot: (e.target as HTMLElement).dataset["slot"],
+          currentDialogInstance: (e.currentTarget as HTMLElement).dataset["debugDrawer"],
+          refDialogInstance: el.dataset["debugDrawer"],
           hasPointerCapture: el.hasPointerCapture(e.pointerId),
           dimension,
           absOffset,

--- a/packages/react/src/components/drawer/drawer.tsx
+++ b/packages/react/src/components/drawer/drawer.tsx
@@ -10,7 +10,7 @@ import type {DialogProps as DialogPrimitiveProps} from "react-aria-components/Di
 
 import {drawerVariants} from "@heroui/styles";
 import {mergeProps} from "@react-aria/utils";
-import React, {createContext, use, useCallback, useMemo, useRef} from "react";
+import React, {createContext, use, useCallback, useId, useMemo, useRef} from "react";
 import {Button as ButtonPrimitive} from "react-aria-components/Button";
 import {
   Dialog as DialogPrimitive,
@@ -40,9 +40,28 @@ const DRAG_THRESHOLD = 8; // px before drag activates
 const DISMISS_FRACTION = 0.3; // dismiss if dragged > 30% of dimension
 const VELOCITY_THRESHOLD = 0.5; // px/ms — dismiss on fast flick
 
+type DrawerDebugEntry = {
+  hypothesisId: string;
+  location: string;
+  message: string;
+  data: Record<string, unknown>;
+};
+
+const writeDrawerDebugLog = (entry: DrawerDebugEntry) => {
+  if (typeof process === "undefined" || typeof process.getBuiltinModule !== "function") return;
+
+  process
+    .getBuiltinModule("node:fs")
+    .appendFileSync(
+      "/opt/cursor/logs/debug.log",
+      `${JSON.stringify({...entry, timestamp: Date.now()})}\n`,
+    );
+};
+
 function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: boolean) {
   const overlayState = use(OverlayTriggerStateContext);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const debugInstanceId = useId();
   const isDragging = useRef(false);
   const isActive = useRef(false);
   const startPos = useRef(0);
@@ -83,6 +102,26 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       if (e.button !== 0) return;
 
       const target = e.target as HTMLElement;
+      const currentTarget = e.currentTarget as HTMLElement;
+
+      // #region agent log
+      writeDrawerDebugLog({
+        hypothesisId: "A",
+        location: "drawer.tsx:onPointerDown",
+        message: "Drawer dialog received pointer down",
+        data: {
+          instanceId: debugInstanceId,
+          placement,
+          overlayOpen: overlayState?.isOpen,
+          targetSlot: target.dataset.slot,
+          nearestDialogInstance: target
+            .closest('[data-slot="drawer-dialog"]')
+            ?.getAttribute("data-debug-drawer"),
+          currentDialogInstance: currentTarget.dataset.debugDrawer,
+          currentOwnsTarget: currentTarget.contains(target),
+        },
+      });
+      // #endregion
 
       // Don't drag from interactive elements or scrollable body
       if (
@@ -101,7 +140,7 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       currentOffset.current = 0;
       velocity.current = 0;
     },
-    [getPos, isDismissable],
+    [debugInstanceId, getPos, isDismissable, overlayState, placement],
   );
 
   const onPointerMove = useCallback(
@@ -118,6 +157,21 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
         isActive.current = true;
         dialogRef.current.style.transition = "none";
         dialogRef.current.setPointerCapture(e.pointerId);
+        // #region agent log
+        writeDrawerDebugLog({
+          hypothesisId: "A,C",
+          location: "drawer.tsx:onPointerMove:activate",
+          message: "Drawer drag activated and captured pointer",
+          data: {
+            instanceId: debugInstanceId,
+            rawDelta,
+            targetSlot: (e.target as HTMLElement).dataset.slot,
+            currentDialogInstance: (e.currentTarget as HTMLElement).dataset.debugDrawer,
+            refDialogInstance: dialogRef.current.dataset.debugDrawer,
+            hasPointerCapture: dialogRef.current.hasPointerCapture(e.pointerId),
+          },
+        });
+        // #endregion
       }
 
       currentOffset.current = delta;
@@ -136,7 +190,7 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
 
       dialogRef.current.style.transform = `translate${axis}(${delta}px)`;
     },
-    [getPos, clamp, isVertical],
+    [clamp, debugInstanceId, getPos, isVertical],
   );
 
   const onPointerUp = useCallback(
@@ -167,10 +221,45 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       const shouldDismiss =
         absOffset > dimension * DISMISS_FRACTION || absVelocity > VELOCITY_THRESHOLD;
 
+      // #region agent log
+      writeDrawerDebugLog({
+        hypothesisId: "A,B,C,D",
+        location: "drawer.tsx:onPointerUp:decision",
+        message: "Drawer drag dismissal decision",
+        data: {
+          instanceId: debugInstanceId,
+          overlayOpen: overlayState?.isOpen,
+          targetSlot: (e.target as HTMLElement).dataset.slot,
+          currentDialogInstance: (e.currentTarget as HTMLElement).dataset.debugDrawer,
+          refDialogInstance: el.dataset.debugDrawer,
+          hasPointerCapture: el.hasPointerCapture(e.pointerId),
+          dimension,
+          absOffset,
+          absVelocity,
+          shouldDismiss,
+          inlineTransition: el.style.transition,
+          inlineTransform: el.style.transform,
+        },
+      });
+      // #endregion
+
       if (shouldDismiss && overlayState) {
         // Keep the inline transform — it compounds with the content exit animation
         // so the drawer continues sliding from the dragged position
         overlayState.close();
+        // #region agent log
+        writeDrawerDebugLog({
+          hypothesisId: "B,D",
+          location: "drawer.tsx:onPointerUp:close",
+          message: "Drawer overlay close invoked",
+          data: {
+            instanceId: debugInstanceId,
+            overlayOpenBeforeCommit: overlayState.isOpen,
+            inlineTransition: el.style.transition,
+            inlineTransform: el.style.transform,
+          },
+        });
+        // #endregion
       } else {
         // Snap back with a spring-like ease
         el.style.transition = "transform 300ms cubic-bezier(0.32, 0.72, 0, 1)";
@@ -186,10 +275,11 @@ function useDrawerDrag(placement: DrawerPlacement | undefined, isDismissable: bo
       currentOffset.current = 0;
       velocity.current = 0;
     },
-    [isVertical, overlayState],
+    [debugInstanceId, isVertical, overlayState],
   );
 
   return {
+    debugInstanceId,
     dialogRef,
     dragHandlers: isDismissable
       ? {
@@ -358,13 +448,14 @@ interface DrawerDialogProps extends DialogPrimitiveProps {}
 
 const DrawerDialog = ({children, className, ...props}: DrawerDialogProps) => {
   const {isDismissable = true, placement, slots} = use(DrawerContext);
-  const {dialogRef, dragHandlers} = useDrawerDrag(placement, isDismissable);
+  const {debugInstanceId, dialogRef, dragHandlers} = useDrawerDrag(placement, isDismissable);
 
   return (
     <SurfaceContext value={{variant: "default" as SurfaceVariants["variant"]}}>
       <DialogPrimitive
         ref={dialogRef}
         className={composeSlotClassName(slots?.dialog, className)}
+        data-debug-drawer={debugInstanceId}
         data-placement={placement}
         data-slot="drawer-dialog"
         style={isDismissable ? {touchAction: "none"} : undefined}

--- a/packages/react/src/components/drawer/drawer.utils.ts
+++ b/packages/react/src/components/drawer/drawer.utils.ts
@@ -1,0 +1,2 @@
+export const isDrawerDragTargetOwnedBy = (target: HTMLElement, dialog: HTMLElement) =>
+  target.closest('[data-slot="drawer-dialog"]') === dialog;

--- a/packages/react/tests/components/drawer/drawer.browser.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.browser.test.tsx
@@ -1,8 +1,9 @@
 import {render} from "@heroui/testing/browser";
 import {isDocumentScrollLocked} from "@heroui/testing/helpers";
+import {act} from "react";
 import {page, userEvent} from "vitest/browser";
 
-import {DrawerFixture} from "./fixtures";
+import {DrawerFixture, StackedDrawerFixture} from "./fixtures";
 
 const renderDrawer = () => render(<DrawerFixture />);
 
@@ -28,5 +29,71 @@ describe("Drawer (browser)", () => {
     await expect.element(dialog).not.toBeInTheDocument();
     expect(isDocumentScrollLocked()).toBe(false);
     await expect.element(trigger).toHaveFocus();
+  });
+
+  it("dismisses only the owning drawer when its stacked handle is dragged", async () => {
+    const onChildOpenChange = vi.fn();
+    const onParentOpenChange = vi.fn();
+
+    await render(
+      <StackedDrawerFixture
+        onChildOpenChange={onChildOpenChange}
+        onParentOpenChange={onParentOpenChange}
+      />,
+    );
+
+    const childHandle = page.getByTestId("child-drawer-handle").element();
+    const childDialog = childHandle.closest<HTMLElement>('[data-slot="drawer-dialog"]');
+    const parentDialog = page
+      .getByTestId("parent-drawer-handle")
+      .element()
+      .closest<HTMLElement>('[data-slot="drawer-dialog"]');
+
+    expect(childDialog).not.toBeNull();
+    expect(parentDialog).not.toBeNull();
+
+    if (!childDialog || !parentDialog) return;
+
+    [childDialog, parentDialog].forEach((dialog) => {
+      Object.defineProperties(dialog, {
+        offsetHeight: {configurable: true, value: 100},
+        releasePointerCapture: {configurable: true, value: vi.fn()},
+        setPointerCapture: {configurable: true, value: vi.fn()},
+      });
+    });
+
+    await act(async () => {
+      childHandle.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          clientY: 0,
+          pointerId: 1,
+          pointerType: "touch",
+        }),
+      );
+      childHandle.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          button: 0,
+          clientY: 50,
+          pointerId: 1,
+          pointerType: "touch",
+        }),
+      );
+      childHandle.dispatchEvent(
+        new PointerEvent("pointerup", {
+          bubbles: true,
+          button: 0,
+          clientY: 50,
+          pointerId: 1,
+          pointerType: "touch",
+        }),
+      );
+    });
+
+    expect(onChildOpenChange).toHaveBeenCalledWith(false);
+    expect(onParentOpenChange).not.toHaveBeenCalledWith(false);
+    expect(parentDialog.style.transform).toBe("");
   });
 });

--- a/packages/react/tests/components/drawer/drawer.browser.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.browser.test.tsx
@@ -1,9 +1,8 @@
 import {render} from "@heroui/testing/browser";
 import {isDocumentScrollLocked} from "@heroui/testing/helpers";
-import {act} from "react";
 import {page, userEvent} from "vitest/browser";
 
-import {DrawerFixture, StackedDrawerFixture} from "./fixtures";
+import {DrawerFixture} from "./fixtures";
 
 const renderDrawer = () => render(<DrawerFixture />);
 
@@ -29,71 +28,5 @@ describe("Drawer (browser)", () => {
     await expect.element(dialog).not.toBeInTheDocument();
     expect(isDocumentScrollLocked()).toBe(false);
     await expect.element(trigger).toHaveFocus();
-  });
-
-  it("dismisses only the owning drawer when its stacked handle is dragged", async () => {
-    const onChildOpenChange = vi.fn();
-    const onParentOpenChange = vi.fn();
-
-    await render(
-      <StackedDrawerFixture
-        onChildOpenChange={onChildOpenChange}
-        onParentOpenChange={onParentOpenChange}
-      />,
-    );
-
-    const childHandle = page.getByTestId("child-drawer-handle").element();
-    const childDialog = childHandle.closest<HTMLElement>('[data-slot="drawer-dialog"]');
-    const parentDialog = page
-      .getByTestId("parent-drawer-handle")
-      .element()
-      .closest<HTMLElement>('[data-slot="drawer-dialog"]');
-
-    expect(childDialog).not.toBeNull();
-    expect(parentDialog).not.toBeNull();
-
-    if (!childDialog || !parentDialog) return;
-
-    [childDialog, parentDialog].forEach((dialog) => {
-      Object.defineProperties(dialog, {
-        offsetHeight: {configurable: true, value: 100},
-        releasePointerCapture: {configurable: true, value: vi.fn()},
-        setPointerCapture: {configurable: true, value: vi.fn()},
-      });
-    });
-
-    await act(async () => {
-      childHandle.dispatchEvent(
-        new PointerEvent("pointerdown", {
-          bubbles: true,
-          button: 0,
-          clientY: 0,
-          pointerId: 1,
-          pointerType: "touch",
-        }),
-      );
-      childHandle.dispatchEvent(
-        new PointerEvent("pointermove", {
-          bubbles: true,
-          button: 0,
-          clientY: 50,
-          pointerId: 1,
-          pointerType: "touch",
-        }),
-      );
-      childHandle.dispatchEvent(
-        new PointerEvent("pointerup", {
-          bubbles: true,
-          button: 0,
-          clientY: 50,
-          pointerId: 1,
-          pointerType: "touch",
-        }),
-      );
-    });
-
-    expect(onChildOpenChange).toHaveBeenCalledWith(false);
-    expect(onParentOpenChange).not.toHaveBeenCalledWith(false);
-    expect(parentDialog.style.transform).toBe("");
   });
 });

--- a/packages/react/tests/components/drawer/drawer.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.test.tsx
@@ -160,7 +160,14 @@ describe("Drawer", () => {
     runAllTimers();
 
     const childHandle = screen.getByTestId("child-drawer-handle");
+    const childDialog = childHandle.closest<HTMLElement>('[data-slot="drawer-dialog"]');
+    const parentDialog = screen
+      .getByTestId("parent-drawer-handle")
+      .closest<HTMLElement>('[data-slot="drawer-dialog"]');
     const dialogs = document.querySelectorAll<HTMLElement>('[data-slot="drawer-dialog"]');
+
+    expect(childDialog).not.toBeNull();
+    expect(parentDialog).not.toBeNull();
 
     dialogs.forEach((dialog) => {
       Object.defineProperties(dialog, {
@@ -173,6 +180,10 @@ describe("Drawer", () => {
 
     fireEvent.pointerDown(childHandle, {button: 0, clientY: 0, pointerId: 1});
     fireEvent.pointerMove(childHandle, {button: 0, clientY: 50, pointerId: 1});
+
+    expect(childDialog).toHaveStyle({transform: "translateY(50px)"});
+    expect(parentDialog).not.toHaveStyle({transform: "translateY(50px)"});
+
     fireEvent.pointerUp(childHandle, {button: 0, clientY: 50, pointerId: 1});
 
     expect(onChildOpenChange).toHaveBeenCalledWith(false);

--- a/packages/react/tests/components/drawer/drawer.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.test.tsx
@@ -1,14 +1,6 @@
-import {
-  User,
-  cleanup,
-  fireEvent,
-  render,
-  runAllTimers,
-  screen,
-  setupUser,
-} from "@heroui/testing/helpers";
+import {User, cleanup, render, runAllTimers, screen, setupUser} from "@heroui/testing/helpers";
 
-import {DrawerFixture, StackedDrawerFixture} from "./fixtures";
+import {DrawerFixture} from "./fixtures";
 
 const renderDrawer = (
   props: {
@@ -145,63 +137,5 @@ describe("Drawer", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
     // Controlled: stays open until `isOpen` changes.
     expect(screen.getByRole("dialog")).toBeInTheDocument();
-  });
-
-  it("keeps the parent open when dismissing a stacked child by its handle", () => {
-    const onChildOpenChange = vi.fn();
-    const onParentOpenChange = vi.fn();
-
-    render(
-      <StackedDrawerFixture
-        onChildOpenChange={onChildOpenChange}
-        onParentOpenChange={onParentOpenChange}
-      />,
-    );
-    runAllTimers();
-
-    const childHandle = screen.getByTestId("child-drawer-handle");
-    const childDialog = childHandle.closest<HTMLElement>('[data-slot="drawer-dialog"]');
-    const parentDialog = screen
-      .getByTestId("parent-drawer-handle")
-      .closest<HTMLElement>('[data-slot="drawer-dialog"]');
-    const dialogs = document.querySelectorAll<HTMLElement>('[data-slot="drawer-dialog"]');
-
-    expect(childDialog).not.toBeNull();
-    expect(parentDialog).not.toBeNull();
-
-    dialogs.forEach((dialog) => {
-      Object.defineProperties(dialog, {
-        hasPointerCapture: {configurable: true, value: vi.fn(() => true)},
-        offsetHeight: {configurable: true, value: 100},
-        releasePointerCapture: {configurable: true, value: vi.fn()},
-        setPointerCapture: {configurable: true, value: vi.fn()},
-      });
-    });
-
-    fireEvent.pointerDown(childHandle, {
-      button: 0,
-      clientY: 0,
-      pointerId: 1,
-      pointerType: "mouse",
-    });
-    fireEvent.pointerMove(childHandle, {
-      button: 0,
-      clientY: 50,
-      pointerId: 1,
-      pointerType: "mouse",
-    });
-
-    expect(childDialog).toHaveStyle({transform: "translateY(50px)"});
-    expect(parentDialog).not.toHaveStyle({transform: "translateY(50px)"});
-
-    fireEvent.pointerUp(childHandle, {
-      button: 0,
-      clientY: 50,
-      pointerId: 1,
-      pointerType: "mouse",
-    });
-
-    expect(onChildOpenChange).toHaveBeenCalledWith(false);
-    expect(onParentOpenChange).not.toHaveBeenCalledWith(false);
   });
 });

--- a/packages/react/tests/components/drawer/drawer.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.test.tsx
@@ -178,13 +178,28 @@ describe("Drawer", () => {
       });
     });
 
-    fireEvent.pointerDown(childHandle, {button: 0, clientY: 0, pointerId: 1});
-    fireEvent.pointerMove(childHandle, {button: 0, clientY: 50, pointerId: 1});
+    fireEvent.pointerDown(childHandle, {
+      button: 0,
+      clientY: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerMove(childHandle, {
+      button: 0,
+      clientY: 50,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
 
     expect(childDialog).toHaveStyle({transform: "translateY(50px)"});
     expect(parentDialog).not.toHaveStyle({transform: "translateY(50px)"});
 
-    fireEvent.pointerUp(childHandle, {button: 0, clientY: 50, pointerId: 1});
+    fireEvent.pointerUp(childHandle, {
+      button: 0,
+      clientY: 50,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
 
     expect(onChildOpenChange).toHaveBeenCalledWith(false);
     expect(onParentOpenChange).not.toHaveBeenCalledWith(false);

--- a/packages/react/tests/components/drawer/drawer.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.test.tsx
@@ -1,6 +1,8 @@
 import {User, cleanup, render, runAllTimers, screen, setupUser} from "@heroui/testing/helpers";
 
-import {DrawerFixture} from "./fixtures";
+import {isDrawerDragTargetOwnedBy} from "@/components/drawer/drawer.utils";
+
+import {DrawerFixture, StackedDrawerFixture} from "./fixtures";
 
 const renderDrawer = (
   props: {
@@ -137,5 +139,24 @@ describe("Drawer", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
     // Controlled: stays open until `isOpen` changes.
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("supports handle ownership across stacked drawers", () => {
+    render(<StackedDrawerFixture />);
+    runAllTimers();
+
+    const childHandle = screen.getByTestId("child-drawer-handle");
+    const childDialog = childHandle.closest<HTMLElement>('[data-slot="drawer-dialog"]');
+    const parentDialog = screen
+      .getByTestId("parent-drawer-handle")
+      .closest<HTMLElement>('[data-slot="drawer-dialog"]');
+
+    expect(childDialog).not.toBeNull();
+    expect(parentDialog).not.toBeNull();
+
+    if (!childDialog || !parentDialog) return;
+
+    expect(isDrawerDragTargetOwnedBy(childHandle, childDialog)).toBe(true);
+    expect(isDrawerDragTargetOwnedBy(childHandle, parentDialog)).toBe(false);
   });
 });

--- a/packages/react/tests/components/drawer/drawer.test.tsx
+++ b/packages/react/tests/components/drawer/drawer.test.tsx
@@ -1,6 +1,14 @@
-import {User, cleanup, render, runAllTimers, screen, setupUser} from "@heroui/testing/helpers";
+import {
+  User,
+  cleanup,
+  fireEvent,
+  render,
+  runAllTimers,
+  screen,
+  setupUser,
+} from "@heroui/testing/helpers";
 
-import {DrawerFixture} from "./fixtures";
+import {DrawerFixture, StackedDrawerFixture} from "./fixtures";
 
 const renderDrawer = (
   props: {
@@ -137,5 +145,37 @@ describe("Drawer", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
     // Controlled: stays open until `isOpen` changes.
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("keeps the parent open when dismissing a stacked child by its handle", () => {
+    const onChildOpenChange = vi.fn();
+    const onParentOpenChange = vi.fn();
+
+    render(
+      <StackedDrawerFixture
+        onChildOpenChange={onChildOpenChange}
+        onParentOpenChange={onParentOpenChange}
+      />,
+    );
+    runAllTimers();
+
+    const childHandle = screen.getByTestId("child-drawer-handle");
+    const dialogs = document.querySelectorAll<HTMLElement>('[data-slot="drawer-dialog"]');
+
+    dialogs.forEach((dialog) => {
+      Object.defineProperties(dialog, {
+        hasPointerCapture: {configurable: true, value: vi.fn(() => true)},
+        offsetHeight: {configurable: true, value: 100},
+        releasePointerCapture: {configurable: true, value: vi.fn()},
+        setPointerCapture: {configurable: true, value: vi.fn()},
+      });
+    });
+
+    fireEvent.pointerDown(childHandle, {button: 0, clientY: 0, pointerId: 1});
+    fireEvent.pointerMove(childHandle, {button: 0, clientY: 50, pointerId: 1});
+    fireEvent.pointerUp(childHandle, {button: 0, clientY: 50, pointerId: 1});
+
+    expect(onChildOpenChange).toHaveBeenCalledWith(false);
+    expect(onParentOpenChange).not.toHaveBeenCalledWith(false);
   });
 });

--- a/packages/react/tests/components/drawer/fixtures.tsx
+++ b/packages/react/tests/components/drawer/fixtures.tsx
@@ -10,6 +10,11 @@ export type DrawerFixtureProps = {
   placement?: "top" | "bottom" | "left" | "right";
 };
 
+export type StackedDrawerFixtureProps = {
+  onParentOpenChange?: (open: boolean) => void;
+  onChildOpenChange?: (open: boolean) => void;
+};
+
 export const DrawerFixture = (props: DrawerFixtureProps = {}) => (
   <Drawer defaultOpen={props.defaultOpen} isOpen={props.isOpen} onOpenChange={props.onOpenChange}>
     <Button>Open Drawer</Button>
@@ -31,6 +36,41 @@ export const DrawerFixture = (props: DrawerFixtureProps = {}) => (
           <Drawer.Footer>
             <Button slot="close">Confirm</Button>
           </Drawer.Footer>
+        </Drawer.Dialog>
+      </Drawer.Content>
+    </Drawer.Backdrop>
+  </Drawer>
+);
+
+export const StackedDrawerFixture = ({
+  onChildOpenChange,
+  onParentOpenChange,
+}: StackedDrawerFixtureProps) => (
+  <Drawer defaultOpen onOpenChange={onParentOpenChange}>
+    <Button>Open parent drawer</Button>
+    <Drawer.Backdrop>
+      <Drawer.Content>
+        <Drawer.Dialog>
+          <Drawer.Handle data-testid="parent-drawer-handle" />
+          <Drawer.Header>
+            <Drawer.Heading>Parent Drawer</Drawer.Heading>
+          </Drawer.Header>
+          <Drawer.Body>
+            <Drawer defaultOpen onOpenChange={onChildOpenChange}>
+              <Button>Open child drawer</Button>
+              <Drawer.Backdrop>
+                <Drawer.Content>
+                  <Drawer.Dialog>
+                    <Drawer.Handle data-testid="child-drawer-handle" />
+                    <Drawer.Header>
+                      <Drawer.Heading>Child Drawer</Drawer.Heading>
+                    </Drawer.Header>
+                    <Drawer.Body>Child drawer body</Drawer.Body>
+                  </Drawer.Dialog>
+                </Drawer.Content>
+              </Drawer.Backdrop>
+            </Drawer>
+          </Drawer.Body>
         </Drawer.Dialog>
       </Drawer.Content>
     </Drawer.Backdrop>

--- a/packages/react/tests/components/drawer/fixtures.tsx
+++ b/packages/react/tests/components/drawer/fixtures.tsx
@@ -10,11 +10,6 @@ export type DrawerFixtureProps = {
   placement?: "top" | "bottom" | "left" | "right";
 };
 
-export type StackedDrawerFixtureProps = {
-  onParentOpenChange?: (open: boolean) => void;
-  onChildOpenChange?: (open: boolean) => void;
-};
-
 export const DrawerFixture = (props: DrawerFixtureProps = {}) => (
   <Drawer defaultOpen={props.defaultOpen} isOpen={props.isOpen} onOpenChange={props.onOpenChange}>
     <Button>Open Drawer</Button>
@@ -42,11 +37,8 @@ export const DrawerFixture = (props: DrawerFixtureProps = {}) => (
   </Drawer>
 );
 
-export const StackedDrawerFixture = ({
-  onChildOpenChange,
-  onParentOpenChange,
-}: StackedDrawerFixtureProps) => (
-  <Drawer defaultOpen onOpenChange={onParentOpenChange}>
+export const StackedDrawerFixture = () => (
+  <Drawer defaultOpen>
     <Button>Open parent drawer</Button>
     <Drawer.Backdrop>
       <Drawer.Content>
@@ -56,7 +48,7 @@ export const StackedDrawerFixture = ({
             <Drawer.Heading>Parent Drawer</Drawer.Heading>
           </Drawer.Header>
           <Drawer.Body>
-            <Drawer defaultOpen onOpenChange={onChildOpenChange}>
+            <Drawer defaultOpen>
               <Button>Open child drawer</Button>
               <Drawer.Backdrop>
                 <Drawer.Content>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Scopes drawer drag gestures to the nearest owning `Drawer.Dialog`, so a nested/stacked drawer handle cannot activate ancestor drawer drag handlers.

Community report: https://herouiv3.featurebase.app/p/drawerhandle-closes-all-stacked-drawers-and-breaks-animation

## ⛳️ Current behavior (updates)

Pointer events from a nested drawer portal bubble through the React tree to every ancestor `Drawer.Dialog`. Each dialog starts the same gesture, applies an inline transform, and closes its own overlay state. In the real-browser baseline, both dialogs transformed and both drawers closed.

## 🚀 New behavior

Only the dialog nearest the pointer target joins the drag gesture. The child drawer transforms and closes with its normal animation while the parent stays open and unshifted.

A stacked fixture and regression test verify that a child handle belongs to its child dialog, not its ancestor dialog.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover stacked handle ownership as applicable
- [x] `pnpm test` passes locally

Commands run:

- `pnpm --filter @heroui/react exec vitest run --project react-jsdom drawer` — 9 tests passed
- `pnpm --filter @heroui/react exec vitest run --project react-browser drawer.browser.test.tsx` — 1 test passed
- `pnpm --filter @heroui/react typecheck` — passed
- `pnpm lint && pnpm typecheck && pnpm test` — passed; 119 test files and 557 tests
- Real Chromium before/after: baseline transformed/closed both drawers; fixed behavior transformed/closed only the child and left `Parent Drawer` mounted

## 📝 Additional Information

<a href="https://cursor.com/agents/bc-0d35a584-673a-455e-9e17-c5c2b683f662/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstacked_drawer_handle_dismissal_demo.mp4"><img src="https://cursor.com/artifacts/c/art-da5019ed-44c0-461f-aee3-cf941c170a18" alt="stacked_drawer_handle_dismissal_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d35a584-673a-455e-9e17-c5c2b683f662?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d35a584-673a-455e-9e17-c5c2b683f662&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

