### PR TITLE
fix(table): don't let typeahead steal keys from nested inputs

### DIFF
--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -100,14 +100,18 @@ interface TableContentProps extends Omit<
   className?: string;
 }
 
-function TableContent({className, ...props}: TableContentProps) {
+function TableContent({
+  className,
+  keyboardNavigationBehavior = "tab",
+  ...props
+}: TableContentProps) {
   const {slots} = use(TableContext);
 
   return (
     <TablePrimitive
       className={composeTwRenderProps(className, slots?.content())}
       data-slot="table-content"
-      keyboardNavigationBehavior="tab"
+      keyboardNavigationBehavior={keyboardNavigationBehavior}
       {...props}
     />
   );

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -107,6 +107,7 @@ function TableContent({className, ...props}: TableContentProps) {
     <TablePrimitive
       className={composeTwRenderProps(className, slots?.content())}
       data-slot="table-content"
+      keyboardNavigationBehavior="tab"
       {...props}
     />
   );

--- a/packages/react/tests/components/table/table.test.tsx
+++ b/packages/react/tests/components/table/table.test.tsx
@@ -121,11 +121,17 @@ const renderEditable = (kind: EditableKind) => {
   }
 };
 
-const renderTypeaheadTable = (kind: EditableKind = "input") => {
+const renderTypeaheadTable = (
+  kind: EditableKind = "input",
+  keyboardNavigationBehavior?: "arrow" | "tab",
+) => {
   return render(
     <Table>
       <Table.ScrollContainer>
-        <Table.Content aria-label="Editable values">
+        <Table.Content
+          aria-label="Editable values"
+          keyboardNavigationBehavior={keyboardNavigationBehavior}
+        >
           <Table.Header>
             <Table.Column isRowHeader>Name</Table.Column>
             <Table.Column>Value</Table.Column>
@@ -247,6 +253,18 @@ describe("Table", () => {
     fireEvent.keyDown(screen.getByTestId("contenteditable-target"), {key: "y"});
 
     expect(editable).toHaveFocus();
+  });
+
+  it("supports overriding keyboard navigation behavior", async () => {
+    renderTypeaheadTable("input", "arrow");
+    const editable = screen.getByRole("textbox", {name: "Alpha value"});
+    const yearRangeCell = screen.getByRole("rowheader", {name: "Year Range"});
+
+    await user.click(editable);
+    expect(editable).toHaveFocus();
+    await user.keyboard("y");
+
+    expect(yearRangeCell).toHaveFocus();
   });
 
   it("supports typeahead from non-editable cells", async () => {

--- a/packages/react/tests/components/table/table.test.tsx
+++ b/packages/react/tests/components/table/table.test.tsx
@@ -1,9 +1,19 @@
 import type {Selection, SortDescriptor} from "react-aria-components/Table";
 
-import {User, cleanup, render, runAllTimers, screen} from "@heroui/testing/helpers";
+import {
+  User,
+  cleanup,
+  fireEvent,
+  render,
+  runAllTimers,
+  screen,
+  setupUser,
+} from "@heroui/testing/helpers";
 
 import {Checkbox} from "@/components/checkbox";
+import {Input} from "@/components/input";
 import {Table} from "@/components/table";
+import {TextField} from "@/components/textfield";
 
 const rows = [
   {id: "1", name: "Kate", role: "CEO"},
@@ -72,11 +82,77 @@ const renderTable = (
   );
 };
 
+type EditableKind = "contenteditable" | "input" | "select" | "textarea";
+
+const renderEditable = (kind: EditableKind) => {
+  switch (kind) {
+    case "contenteditable":
+      return (
+        <div
+          contentEditable
+          suppressContentEditableWarning
+          aria-label="Alpha value"
+          role="textbox"
+          tabIndex={0}
+        >
+          <span data-testid="contenteditable-target">Edit</span>
+        </div>
+      );
+    case "input":
+      return (
+        <TextField aria-label="Alpha value">
+          <Input />
+        </TextField>
+      );
+    case "select":
+      return (
+        <select aria-label="Alpha value" defaultValue="alpha">
+          <option value="alpha">Alpha</option>
+          <option value="yes">Yes</option>
+        </select>
+      );
+    case "textarea":
+      return <textarea aria-label="Alpha value" />;
+    default: {
+      const exhaustiveKind: never = kind;
+
+      return exhaustiveKind;
+    }
+  }
+};
+
+const renderTypeaheadTable = (kind: EditableKind = "input") => {
+  return render(
+    <Table>
+      <Table.ScrollContainer>
+        <Table.Content aria-label="Editable values">
+          <Table.Header>
+            <Table.Column isRowHeader>Name</Table.Column>
+            <Table.Column>Value</Table.Column>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row id="alpha">
+              <Table.Cell>Alpha</Table.Cell>
+              <Table.Cell>{renderEditable(kind)}</Table.Cell>
+            </Table.Row>
+            <Table.Row id="year-range">
+              <Table.Cell>Year Range</Table.Cell>
+              <Table.Cell>2020–2026</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Content>
+      </Table.ScrollContainer>
+    </Table>,
+  );
+};
+
 describe("Table", () => {
   let testUtilUser: User;
+  let user: ReturnType<typeof setupUser>;
 
   beforeEach(() => {
     vi.useFakeTimers({shouldAdvanceTime: true});
+    user = setupUser({advanceTimers: vi.advanceTimersByTime});
     testUtilUser = new User({
       interactionType: "mouse",
       advanceTimer: vi.advanceTimersByTime,
@@ -142,5 +218,45 @@ describe("Table", () => {
 
     expect(onSortChange).toHaveBeenCalled();
     expect(onSortChange.mock.calls[0]?.[0]).toEqual(expect.objectContaining({column: "name"}));
+  });
+
+  it.each([
+    ["input", "textbox"],
+    ["textarea", "textbox"],
+    ["select", "combobox"],
+  ] as const)("supports matching letter keystrokes in a nested %s", async (kind, role) => {
+    renderTypeaheadTable(kind);
+    const editable = screen.getByRole(role, {name: "Alpha value"});
+
+    await user.click(editable);
+    expect(editable).toHaveFocus();
+    await user.keyboard("y");
+
+    expect(editable).toHaveFocus();
+    if (kind !== "select") {
+      expect(editable).toHaveValue("y");
+    }
+  });
+
+  it("supports matching letter keystrokes in a nested contenteditable target", async () => {
+    renderTypeaheadTable("contenteditable");
+    const editable = screen.getByRole("textbox", {name: "Alpha value"});
+
+    await user.click(editable);
+    expect(editable).toHaveFocus();
+    fireEvent.keyDown(screen.getByTestId("contenteditable-target"), {key: "y"});
+
+    expect(editable).toHaveFocus();
+  });
+
+  it("supports typeahead from non-editable cells", async () => {
+    renderTypeaheadTable();
+    const alphaCell = screen.getByRole("rowheader", {name: "Alpha"});
+    const yearRangeCell = screen.getByRole("rowheader", {name: "Year Range"});
+
+    alphaCell.focus();
+    await user.keyboard("y");
+
+    expect(yearRangeCell).toHaveFocus();
   });
 });

--- a/packages/react/tests/components/table/table.test.tsx
+++ b/packages/react/tests/components/table/table.test.tsx
@@ -254,7 +254,8 @@ describe("Table", () => {
     const alphaCell = screen.getByRole("rowheader", {name: "Alpha"});
     const yearRangeCell = screen.getByRole("rowheader", {name: "Year Range"});
 
-    alphaCell.focus();
+    await user.click(alphaCell);
+    expect(alphaCell).toHaveFocus();
     await user.keyboard("y");
 
     expect(yearRangeCell).toHaveFocus();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6746

## 📝 Description

Defaults HeroUI Table content to React Aria's tab keyboard-navigation behavior so keyboard events from interactive descendants remain with those controls. Consumers can explicitly override `keyboardNavigationBehavior` on `Table.Content`.

## ⛳️ Current behavior (updates)

Table typeahead can consume matching letters typed into nested inputs and move focus to another row.

## 🚀 New behavior

Nested inputs, textareas, selects, and contenteditable elements keep their keystrokes and focus by default. Typeahead remains available from non-editable cells, and callers can select a different keyboard navigation behavior.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover nested editable controls, non-editable cell typeahead, and an explicit `"arrow"` override
- [x] Focused Table suite — 9 tests passed
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — all 119 files and 562 tests pass, but Vitest exits nonzero after an unrelated asynchronous error from `input-otp.ssr.test.tsx`

## 📝 Additional Information

The regression coverage includes `input`, `textarea`, `select`, a nested target within a contenteditable ancestor, and ordinary-cell typeahead.

<a href="https://cursor.com/agents/bc-a15fbb3c-b1a9-45b6-8c68-aca8268727a8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_nested_input_typeahead_fix.mp4"><img src="https://cursor.com/artifacts/c/art-fe9ac01e-bd37-4b0d-91ba-081b45f9879e" alt="table_nested_input_typeahead_fix.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a15fbb3c-b1a9-45b6-8c68-aca8268727a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a15fbb3c-b1a9-45b6-8c68-aca8268727a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

