### PR TITLE
fix(testing): clear stray timers in ssr smoke teardown

### DIFF
--- a/packages/testing/helpers/ssr.ts
+++ b/packages/testing/helpers/ssr.ts
@@ -1,4 +1,5 @@
 import type {ReactElement, ReactNode} from "react";
+import type {Root} from "react-dom/client";
 
 import {act} from "@testing-library/react";
 import {createElement, isValidElement} from "react";
@@ -44,9 +45,32 @@ export const ssrSmoke = async (ui: ReactElement, options: SsrSmokeOptions = {}) 
     originalError(...args);
   };
 
+  // Clear timers scheduled during hydrate before jsdom teardown.
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalSetInterval = globalThis.setInterval;
+  const strayTimers: ReturnType<typeof setTimeout>[] = [];
+
+  globalThis.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+    const timer = originalSetTimeout(...args);
+
+    strayTimers.push(timer);
+
+    return timer;
+  }) as typeof setTimeout;
+
+  globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
+    const timer = originalSetInterval(...args);
+
+    strayTimers.push(timer);
+
+    return timer;
+  }) as typeof setInterval;
+
+  let root: Root | undefined;
+
   try {
     await act(async () => {
-      hydrateRoot(container, wrap(ui, options.wrapper));
+      root = hydrateRoot(container, wrap(ui, options.wrapper));
     });
 
     const hydrationErrors = errors.filter((entry) => {
@@ -57,8 +81,21 @@ export const ssrSmoke = async (ui: ReactElement, options: SsrSmokeOptions = {}) 
 
     expect(hydrationErrors).toEqual([]);
   } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.setInterval = originalSetInterval;
+
+    for (const timer of strayTimers) {
+      clearTimeout(timer);
+      clearInterval(timer);
+    }
+
     // eslint-disable-next-line no-console
     console.error = originalError;
+
+    await act(async () => {
+      root?.unmount();
+    });
+
     container.remove();
   }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Harden `ssrSmoke` teardown so leftover timers and effects cannot run after jsdom is gone.

## ⛳️ Current behavior (updates)

The `ssrSmoke` hydrates, then removes the container. It does not unmount the root or clear timers scheduled during hydrate. Those callbacks can fire after jsdom teardown and crash the run (`window is not defined`).

## 🚀 New behavior

- Track `setTimeout` / `setInterval` during the smoke and clear them in `finally`
- Unmount the hydrated root before removing the container

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [ ] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [ ] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

## 📝 Additional Information

Existing `*.ssr.test.tsx` files go through this helper.