### PR TITLE
fix(toast): merge Provider style with region CSS vars

### DIFF
--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -16,6 +16,7 @@ import React, {
   useMemo,
   useRef,
 } from "react";
+import {composeRenderProps} from "react-aria-components/composeRenderProps";
 import {Text as TextPrimitive} from "react-aria-components/Text";
 import {
   UNSTABLE_ToastContent as ToastContentPrimitive,
@@ -370,6 +371,7 @@ const ToastProvider = <T extends object = ToastContentValue>({
   placement = "bottom",
   queue: queueProp,
   scaleFactor = DEFAULT_SCALE_FACTOR,
+  style,
   width = DEFAULT_TOAST_WIDTH,
   ...rest
 }: ToastProviderProps<T>) => {
@@ -458,18 +460,24 @@ const ToastProvider = <T extends object = ToastContentValue>({
     [isMobile, placement, scaleFactor],
   );
 
+  const regionStyle = composeRenderProps(
+    style,
+    (userStyle) =>
+      ({
+        "--gap": `${gap}px`,
+        "--placement": placement,
+        "--scale-factor": scaleFactor,
+        "--toast-width": typeof width === "number" ? `${width}px` : width,
+        ...userStyle,
+      }) as CSSProperties,
+  );
+
   return (
     <ToastRegionPrimitive<T>
       className={composeTwRenderProps(className, slots?.region())}
       data-slot="toast-region"
       queue={toastQueue}
-      style={{
-        // @ts-expect-error - CSS variables
-        "--gap": `${gap}px`,
-        "--placement": placement,
-        "--scale-factor": scaleFactor,
-        "--toast-width": typeof width === "number" ? `${width}px` : width,
-      }}
+      style={regionStyle}
       {...rest}
     >
       {(renderProps) => {

--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -72,6 +72,7 @@ const Toast = <T extends object = ToastContentValue>({
   className,
   placement,
   scaleFactor = DEFAULT_SCALE_FACTOR,
+  style,
   toast,
   variant,
   ...rest
@@ -130,7 +131,7 @@ const Toast = <T extends object = ToastContentValue>({
     }
   }, [isFrontmost]);
 
-  const style = useMemo<CSSProperties>(() => {
+  const stackingStyle = useMemo<CSSProperties>(() => {
     const frontToastKey = visibleToasts[0]?.key;
 
     const frontHeight =
@@ -152,7 +153,6 @@ const Toast = <T extends object = ToastContentValue>({
         : null),
       opacity: isHidden ? 0 : 1,
       pointerEvents: isHidden ? "none" : "auto",
-      ...rest.style,
     } as const;
   }, [
     finalScaleFactor,
@@ -162,11 +162,19 @@ const Toast = <T extends object = ToastContentValue>({
     isBottom,
     isFrontmost,
     isHidden,
-    rest.style,
     toast?.key,
     toastHeight,
     visibleToasts,
   ]);
+
+  const toastStyle = composeRenderProps(
+    style,
+    (userStyle) =>
+      ({
+        ...stackingStyle,
+        ...userStyle,
+      }) as CSSProperties,
+  );
 
   return (
     <ToastPrimitive
@@ -177,7 +185,7 @@ const Toast = <T extends object = ToastContentValue>({
       data-hidden={dataAttr(isHidden)}
       data-index={index}
       data-slot="toast"
-      style={style}
+      style={toastStyle}
       toast={toast}
       {...rest}
     >

--- a/packages/react/tests/components/toast/toast.test.tsx
+++ b/packages/react/tests/components/toast/toast.test.tsx
@@ -1,3 +1,5 @@
+import type {CSSProperties} from "react";
+
 import {act, cleanup, render, runAllTimers, screen, setupUser} from "@heroui/testing/helpers";
 
 import {Toast, ToastQueue} from "@/components/toast";
@@ -37,6 +39,54 @@ describe("Toast", () => {
 
     expect(region).toHaveAttribute("data-slot", "toast-region");
     expect(region).toHaveAttribute("aria-label", "1 notification.");
+  });
+
+  it("merges custom styles with the default region variables", () => {
+    const queue = new ToastQueue();
+
+    render(<Toast.Provider queue={queue} style={{zIndex: 100_000}} />);
+
+    act(() => {
+      queue.add({title: "Saved"});
+    });
+
+    expect(screen.getByRole("region")).toHaveStyle({
+      "--gap": "12px",
+      "--placement": "bottom",
+      "--scale-factor": "0.05",
+      "--toast-width": "460px",
+      "z-index": "100000",
+    });
+  });
+
+  it("supports overriding a region variable through custom styles", () => {
+    const queue = new ToastQueue();
+
+    render(<Toast.Provider queue={queue} style={{"--gap": "24px"} as CSSProperties} />);
+
+    act(() => {
+      queue.add({title: "Saved"});
+    });
+
+    expect(screen.getByRole("region")).toHaveStyle({
+      "--gap": "24px",
+      "--toast-width": "460px",
+    });
+  });
+
+  it("supports the width prop alongside custom styles", () => {
+    const queue = new ToastQueue();
+
+    render(<Toast.Provider queue={queue} style={{zIndex: 100_000}} width={520} />);
+
+    act(() => {
+      queue.add({title: "Saved"});
+    });
+
+    expect(screen.getByRole("region")).toHaveStyle({
+      "--toast-width": "520px",
+      "z-index": "100000",
+    });
   });
 
   it("renders default children with alertdialog role, title, description, and close button", () => {

--- a/packages/react/tests/components/toast/toast.test.tsx
+++ b/packages/react/tests/components/toast/toast.test.tsx
@@ -62,15 +62,17 @@ describe("Toast", () => {
   it("supports overriding a region variable through custom styles", () => {
     const queue = new ToastQueue();
 
-    render(<Toast.Provider queue={queue} style={{"--gap": "24px"} as CSSProperties} />);
+    render(<Toast.Provider queue={queue} style={{"--toast-width": "320px"} as CSSProperties} />);
 
     act(() => {
       queue.add({title: "Saved"});
     });
 
     expect(screen.getByRole("region")).toHaveStyle({
-      "--gap": "24px",
-      "--toast-width": "460px",
+      "--gap": "12px",
+      "--placement": "bottom",
+      "--scale-factor": "0.05",
+      "--toast-width": "320px",
     });
   });
 
@@ -85,6 +87,21 @@ describe("Toast", () => {
 
     expect(screen.getByRole("region")).toHaveStyle({
       "--toast-width": "520px",
+      "z-index": "100000",
+    });
+  });
+
+  it("supports a style render function on the region", () => {
+    const queue = new ToastQueue();
+
+    render(<Toast.Provider queue={queue} style={() => ({zIndex: 100_000}) as CSSProperties} />);
+
+    act(() => {
+      queue.add({title: "Saved"});
+    });
+
+    expect(screen.getByRole("region")).toHaveStyle({
+      "--toast-width": "460px",
       "z-index": "100000",
     });
   });
@@ -236,6 +253,33 @@ describe("Toast", () => {
 
     expect(screen.getByTestId("custom-toast")).toBeInTheDocument();
     expect(screen.getByText("Custom layout")).toBeInTheDocument();
+  });
+
+  it("merges custom styles with the toast stacking styles", () => {
+    const queue = new ToastQueue();
+
+    render(
+      <Toast.Provider queue={queue}>
+        {({toast: toastItem}) => (
+          <Toast data-testid="custom-toast" style={{marginTop: 8}} toast={toastItem}>
+            <Toast.Content>
+              <Toast.Title>Custom layout</Toast.Title>
+            </Toast.Content>
+          </Toast>
+        )}
+      </Toast.Provider>,
+    );
+
+    act(() => {
+      queue.add({title: "ignored"});
+    });
+
+    expect(screen.getByTestId("custom-toast")).toHaveStyle({
+      "margin-top": "8px",
+      opacity: "1",
+      "pointer-events": "auto",
+      "z-index": "1",
+    });
   });
 
   it("exposes placement BEM modifiers on the region and toast", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6793

## 📝 Description

Merge `Toast.Provider` custom styles with the region's computed CSS variables instead of allowing the trailing props spread to replace them.

## ⛳️ Current behavior (updates)

Passing any `style` prop to `Toast.Provider` replaces `--toast-width`, `--gap`, `--scale-factor`, and `--placement`. Without `--toast-width`, the toast region collapses to icon width.

## 🚀 New behavior

- Region variables remain present when custom styles such as `zIndex` are supplied.
- Custom styles still apply and can override an individual region variable.
- The `width` prop continues to set `--toast-width` when used with `style`.
- Static and render-function styles are composed through React Aria's render-prop helper.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Focused Toast jsdom suite — 15 tests passed
- [x] Focused Toast Chromium suite — 1 test passed
- [x] `pnpm lint` — passed with one pre-existing docs import-order warning
- [x] `pnpm typecheck` — passed
- [x] `pnpm test` — 119 files and 570 tests passed
- [x] Manual Chromium before/after — 32px collapsed toast with missing variables becomes 460px while `z-index: 100000` remains applied

## 📝 Additional Information

<a href="https://cursor.com/agents/bc-c75150ca-96bd-4ce0-bc9f-710ff300b090/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoast_provider_style_before_after.mp4"><img src="https://cursor.com/artifacts/c/art-3bd0ac52-c05b-42ce-a1fe-e0771e726468" alt="toast_provider_style_before_after.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c75150ca-96bd-4ce0-bc9f-710ff300b090?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c75150ca-96bd-4ce0-bc9f-710ff300b090&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

