### PR TITLE
fix(toast): preserve region CSS variables when custom style prop is passed to ToastProvider (#6793)

### DIFF
--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -370,6 +370,7 @@ const ToastProvider = <T extends object = ToastContentValue>({
   placement = "bottom",
   queue: queueProp,
   scaleFactor = DEFAULT_SCALE_FACTOR,
+  style,
   width = DEFAULT_TOAST_WIDTH,
   ...rest
 }: ToastProviderProps<T>) => {
@@ -469,6 +470,7 @@ const ToastProvider = <T extends object = ToastContentValue>({
         "--placement": placement,
         "--scale-factor": scaleFactor,
         "--toast-width": typeof width === "number" ? `${width}px` : width,
+        ...style,
       }}
       {...rest}
     >


### PR DESCRIPTION
## Description
Fixes #6793.

Currently, if a developer passes a custom `style` prop to `ToastProvider` (e.g. `style={{ zIndex: 100 }}`), it completely overrides the dynamically generated CSS variables on the `ToastRegionPrimitive` (such as `--gap`, `--placement`, `--toast-width`, and `--scale-factor`). This results in visually broken toast layouts where toasts lose their intended spacing, width, and positioning.

This PR fixes the issue by destructuring the `style` prop from `ToastProviderProps` and merging it gracefully alongside the internal CSS variables.

## Changes Made
- Destructured `style` from `ToastProviderProps` to prevent it from bleeding into the `...rest` spread.
- Spread `...style` inside the computed `style={{ ... }}` object passed to `ToastRegionPrimitive`, ensuring both the user's custom styles and the internal CSS variables coexist.

## Testing
- [x] Verified in a local sandbox that passing `style={{ zIndex: 999 }}` successfully renders while maintaining the `--gap` and `--placement` CSS variables in the DOM.
- [x] Ensured TypeScript typings remain strict and do not throw any regression errors.
