### PR TITLE
fix(select): add ClearButton that does not nest buttons in Trigger

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(pickers)/select.mdx
+++ b/apps/docs/content/docs/cn/react/components/(pickers)/select.mdx
@@ -26,6 +26,7 @@ export default () => (
     <Label />
     <Select.Trigger>
       <Select.Value />
+      <Select.ClearButton />
       <Select.Indicator />
     </Select.Trigger>
     <Description />
@@ -107,6 +108,14 @@ Select 组件支持两种视觉变体：
 
 <ComponentPreview name="select-custom-indicator" />
 
+### 带清除按钮
+
+`Select.Trigger` 本身是 button，因此不能再嵌套 `<button>` 来实现清除。请在触发器内组合 `Select.ClearButton` — 它渲染为非 button 控件，且不会打开菜单。
+
+<ComponentPreview name="select-with-clear-button" />
+
+由于 ARIA 将 button 的子节点视为纯展示内容，清除控件无法获得焦点，因此它带有 `aria-hidden`，仅作为指针操作的可视入口。当组合了 `Select.ClearButton` 时，触发器同时支持按 `Backspace` 或 `Delete` 清除，这是键盘与屏幕阅读器用户的清除方式。两种方式都会调用 `onClear`。
+
 ### 自定义展示值
 
 <ComponentPreview name="select-custom-value" />
@@ -170,6 +179,7 @@ Select 组件使用以下 CSS 类（[查看源码样式](https://github.com/hero
 - `.select` - Select 根容器
 - `.select__trigger` - 打开下拉的触发按钮
 - `.select__value` - 当前显示的值或占位符
+- `.select__clear-button` - 触发器内的可选清除控件
 - `.select__indicator` - 下拉指示图标
 - `.select__popover` - 弹出层容器
 
@@ -184,6 +194,7 @@ Select 组件使用以下 CSS 类（[查看源码样式](https://github.com/hero
 - `.select__trigger[data-focus-visible="true"]` - 触发器聚焦状态
 - `.select__trigger[data-disabled="true"]` - 触发器禁用状态
 - `.select__value[data-placeholder="true"]` - 占位符状态
+- `.select__clear-button[data-empty="true"]` - 无选中项时隐藏清除控件
 - `.select__indicator[data-open="true"]` - 展开时的指示器状态
 
 ### 交互状态
@@ -210,6 +221,7 @@ Select 组件使用以下 CSS 类（[查看源码样式](https://github.com/hero
 | `value`         | `Key \| Key[] \| null`                  | -                 | 当前值（受控）。                                  |
 | `defaultValue`  | `Key \| Key[] \| null`                  | -                 | 默认值（非受控）。                                |
 | `onChange`      | `(value: Key \| Key[] \| null) => void` | -                 | 值变化时的事件处理函数。                          |
+| `onClear`       | `() => void`                            | -                 | 清除选择时的事件处理函数。                        |
 | `isRequired`    | `boolean`                               | -                 | 用户输入是否必填。                                |
 | `isInvalid`     | `boolean`                               | -                 | Select 的值是否无效。                             |
 | `name`          | `string`                                | -                 | 输入框名称，用于提交 HTML 表单。                  |
@@ -238,6 +250,15 @@ Select 组件使用以下 CSS 类（[查看源码样式](https://github.com/hero
 | ----------- | ----------- | ------ | ----------------- |
 | `className` | `string`    | -      | 额外的 CSS 类。   |
 | `children`  | `ReactNode` | -      | 自定义指示器内容。 |
+
+### Select.ClearButton
+| Prop        | 类型                      | 默认值 | 描述                            |
+| ----------- | ------------------------- | ------ | ------------------------------- |
+| `className` | `string`                  | -      | 额外的 CSS 类。                 |
+| `children`  | `ReactNode`               | -      | 自定义内容，替代默认图标。      |
+| `onClick`   | `(e: MouseEvent) => void` | -      | 点击清除控件时的事件处理函数。  |
+
+`Select.ClearButton` 渲染为 `span`，因此可以放在 `Select.Trigger`（button）内部而不会形成嵌套 button。选择为空时会自动隐藏。
 
 ### Select.Popover
 | Prop        | 类型                                                                                                                                                                                                                                                                                                                     | 默认值    | 描述                                      |

--- a/apps/docs/content/docs/cn/react/migration/(components)/select.mdx
+++ b/apps/docs/content/docs/cn/react/migration/(components)/select.mdx
@@ -59,7 +59,7 @@ export default function App() {
 ### 1. 组件结构
 
 **v2：** 简单的 Select，子节点为 `SelectItem`  
-**v3：** 复合组件（`Select.Trigger`、`Select.Value`、`Select.Indicator`、`Select.Popover`）与用于菜单项的 `ListBox`
+**v3：** 复合组件（`Select.Trigger`、`Select.Value`、`Select.ClearButton`、`Select.Indicator`、`Select.Popover`）与用于菜单项的 `ListBox`
 
 ### 2. 菜单项组件
 
@@ -84,7 +84,7 @@ export default function App() {
 | `startContent` | — | 直接自定义 `Select.Trigger` |
 | `endContent` | — | 直接自定义 `Select.Trigger` |
 | `selectorIcon` | — | 自定义 `Select.Indicator` 的 children |
-| `isClearable` | — | 手动实现清除按钮 |
+| `isClearable` | `Select.ClearButton` | 内置子组件；不要在 `Select.Trigger` 内嵌套 `<button>` |
 | `renderValue` | — | 使用 `Select.Value` 的渲染 prop |
 | `labelPlacement` | — | 标签始终在外部 |
 | `isRequired` | `isRequired` | 仍然可用 |
@@ -483,6 +483,7 @@ Select (Root)
   ├── Label (optional)
   ├── Select.Trigger
   │   ├── Select.Value
+  │   ├── Select.ClearButton（可选）
   │   └── Select.Indicator
   ├── Description (optional)
   ├── Select.Popover
@@ -512,15 +513,15 @@ Select (Root)
 
 ### 清除按钮
 
-`isClearable` prop 已移除。若要实现清除按钮：
+`isClearable` prop 已移除。请在 `Select.Trigger` 内使用 `Select.ClearButton`。不要在触发器内嵌套 `<button>` — `Select.Trigger` 本身已经是 button。
+
+清除控件面向指针操作；触发器同时支持按 `Backspace` 或 `Delete` 清除，以便键盘与屏幕阅读器用户使用。
 
 ```tsx
 <Select value={value} onChange={setValue}>
   <Select.Trigger>
     <Select.Value />
-    {value && (
-      <button onClick={() => setValue(null)}>Clear</button>
-    )}
+    <Select.ClearButton />
     <Select.Indicator />
   </Select.Trigger>
   {/* ... */}
@@ -529,7 +530,7 @@ Select (Root)
 
 ## 总结
 
-1. **组件结构**：必须使用复合组件（`Select.Trigger`、`Select.Value`、`Select.Indicator`、`Select.Popover`）。  
+1. **组件结构**：必须使用复合组件（`Select.Trigger`、`Select.Value`、`Select.ClearButton`、`Select.Indicator`、`Select.Popover`）。  
 2. **菜单项组件**：`SelectItem` → `ListBox.Item`，`SelectSection` → `ListBox.Section`（分组标题用 `Header`，分组之间用 `Separator`）。  
 3. **标签 / 描述 / 错误**：使用独立组件，而不是对应 prop。  
 4. **选择相关 prop**：`selectedKeys` / `onSelectionChange` → `value` / `onChange`。  
@@ -539,5 +540,5 @@ Select (Root)
 8. **样式**：`variant` 仅保留 `primary` \| `secondary`；`color`、`size`、`radius` 已移除，请用 Tailwind CSS 扩展。  
 9. **classNames 已移除**：在各子组件上使用 `className` prop。  
 10. **内容类 prop 已移除**：`startContent`、`endContent` 需通过自定义触发器实现。  
-11. **清除按钮**：`isClearable` 已移除，需手动实现。  
+11. **清除按钮**：`isClearable` 已移除，请在 `Select.Trigger` 内使用 `Select.ClearButton`（不要嵌套 `<button>`）。  
 12. **自定义值**：用 `Select.Value` 的渲染 prop 替代 `renderValue`。

--- a/apps/docs/content/docs/en/react/components/(pickers)/select.mdx
+++ b/apps/docs/content/docs/en/react/components/(pickers)/select.mdx
@@ -27,6 +27,7 @@ export default () => (
     <Label />
     <Select.Trigger>
       <Select.Value />
+      <Select.ClearButton />
       <Select.Indicator />
     </Select.Trigger>
     <Description />
@@ -108,6 +109,14 @@ The Select component supports two visual variants:
 
 <ComponentPreview name="select-custom-indicator" />
 
+### With Clear Button
+
+`Select.Trigger` is a button, so a nested `<button>` cannot be used for clear. Compose `Select.ClearButton` inside the trigger instead — it renders as a non-button control and does not open the menu.
+
+<ComponentPreview name="select-with-clear-button" />
+
+Because ARIA treats the children of a button as presentational, the clear control cannot take focus. It is therefore `aria-hidden` and acts as a pointer affordance only. When a `Select.ClearButton` is composed, the trigger also clears on `Backspace` or `Delete`, which is how keyboard and screen reader users clear the selection. Both paths call `onClear`.
+
 ### Custom Value
 
 <ComponentPreview name="select-custom-value" />
@@ -173,6 +182,7 @@ The Select component uses these CSS classes ([View source styles](https://github
 - `.select` - Base select container
 - `.select__trigger` - The button that triggers the select
 - `.select__value` - The displayed value or placeholder
+- `.select__clear-button` - The optional clear control inside the trigger
 - `.select__indicator` - The dropdown indicator icon
 - `.select__popover` - The popover container
 
@@ -187,6 +197,7 @@ The Select component uses these CSS classes ([View source styles](https://github
 - `.select__trigger[data-focus-visible="true"]` - Focused trigger state
 - `.select__trigger[data-disabled="true"]` - Disabled trigger state
 - `.select__value[data-placeholder="true"]` - Placeholder state
+- `.select__clear-button[data-empty="true"]` - Clear button hidden when no selection
 - `.select__indicator[data-open="true"]` - Open indicator state
 
 ### Interactive States
@@ -214,6 +225,7 @@ The component supports both CSS pseudo-classes and data attributes for flexibili
 | `value`         | `Key \| Key[] \| null`                  | -                  | Current value (controlled)                               |
 | `defaultValue`  | `Key \| Key[] \| null`                  | -                  | Default value (uncontrolled)                             |
 | `onChange`      | `(value: Key \| Key[] \| null) => void` | -                  | Handler called when the value changes                    |
+| `onClear`       | `() => void`                            | -                  | Handler called when the selection is cleared             |
 | `isRequired`    | `boolean`                               | -                  | Whether user input is required                           |
 | `isInvalid`     | `boolean`                               | -                  | Whether the select value is invalid                      |
 | `name`          | `string`                                | -                  | The name of the input, used when submitting an HTML form |
@@ -245,6 +257,16 @@ The component supports both CSS pseudo-classes and data attributes for flexibili
 | ----------- | ----------- | ------- | ------------------------ |
 | `className` | `string`    | -       | Additional CSS classes   |
 | `children`  | `ReactNode` | -       | Custom indicator content |
+
+### Select.ClearButton
+
+| Prop        | Type                      | Default | Description                                |
+| ----------- | ------------------------- | ------- | ------------------------------------------ |
+| `className` | `string`                  | -       | Additional CSS classes                     |
+| `children`  | `ReactNode`               | -       | Custom content, replacing the default icon |
+| `onClick`   | `(e: MouseEvent) => void` | -       | Handler called when the control is clicked |
+
+`Select.ClearButton` renders as a `span` so it can live inside `Select.Trigger` (a button) without nesting buttons. It is visually hidden when the selection is empty.
 
 ### Select.Popover
 

--- a/apps/docs/content/docs/en/react/migration/(components)/select.mdx
+++ b/apps/docs/content/docs/en/react/migration/(components)/select.mdx
@@ -59,7 +59,7 @@ export default function App() {
 ### 1. Component Structure
 
 **v2:** Simple Select with `SelectItem` children  
-**v3:** Compound components (`Select.Trigger`, `Select.Value`, `Select.Indicator`, `Select.Popover`) with `ListBox` for items
+**v3:** Compound components (`Select.Trigger`, `Select.Value`, `Select.ClearButton`, `Select.Indicator`, `Select.Popover`) with `ListBox` for items
 
 ### 2. Item Components
 
@@ -84,7 +84,7 @@ export default function App() {
 | `startContent` | — | Customize `Select.Trigger` directly |
 | `endContent` | — | Customize `Select.Trigger` directly |
 | `selectorIcon` | — | Customize `Select.Indicator` children |
-| `isClearable` | — | Implement clear button manually |
+| `isClearable` | `Select.ClearButton` | Built-in subcomponent; do not nest a `<button>` in `Select.Trigger` |
 | `renderValue` | — | Use `Select.Value` render prop |
 | `labelPlacement` | — | Labels are always outside |
 | `isRequired` | `isRequired` | Still exists |
@@ -483,6 +483,7 @@ Select (Root)
   ├── Label (optional)
   ├── Select.Trigger
   │   ├── Select.Value
+  │   ├── Select.ClearButton (optional)
   │   └── Select.Indicator
   ├── Description (optional)
   ├── Select.Popover
@@ -512,15 +513,15 @@ Select (Root)
 
 ### Clear Button
 
-The `isClearable` prop has been removed. To implement a clear button:
+The `isClearable` prop has been removed. Use `Select.ClearButton` inside `Select.Trigger`. Do not nest a `<button>` in the trigger — `Select.Trigger` is already a button.
+
+The clear control is a pointer affordance; the trigger also clears on `Backspace` or `Delete` for keyboard and screen reader users.
 
 ```tsx
 <Select value={value} onChange={setValue}>
   <Select.Trigger>
     <Select.Value />
-    {value && (
-      <button onClick={() => setValue(null)}>Clear</button>
-    )}
+    <Select.ClearButton />
     <Select.Indicator />
   </Select.Trigger>
   {/* ... */}
@@ -529,7 +530,7 @@ The `isClearable` prop has been removed. To implement a clear button:
 
 ## Summary
 
-1. **Component Structure**: Must use compound components (`Select.Trigger`, `Select.Value`, `Select.Indicator`, `Select.Popover`)
+1. **Component Structure**: Must use compound components (`Select.Trigger`, `Select.Value`, `Select.ClearButton`, `Select.Indicator`, `Select.Popover`)
 2. **Item Components**: `SelectItem` → `ListBox.Item`, `SelectSection` → `ListBox.Section` (use `Header` for section titles and `Separator` between sections)
 3. **Label/Description/Error**: Use separate components instead of props
 4. **Selection Props**: `selectedKeys`/`onSelectionChange` → `value`/`onChange`
@@ -539,5 +540,5 @@ The `isClearable` prop has been removed. To implement a clear button:
 8. **Styling**: `variant` simplified to `primary` \| `secondary`; `color`, `size`, `radius` removed - use Tailwind for more
 9. **ClassNames Removed**: Use `className` props on individual components
 10. **Content Props Removed**: `startContent`, `endContent` - customize trigger directly
-11. **Clear Button**: `isClearable` removed - implement manually
+11. **Clear Button**: `isClearable` removed - use `Select.ClearButton` inside `Select.Trigger` (do not nest a `<button>`)
 12. **Custom Value**: Use `Select.Value` render prop instead of `renderValue`

--- a/apps/docs/src/demos/cn/index.ts
+++ b/apps/docs/src/demos/cn/index.ts
@@ -2103,6 +2103,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./select/custom-indicator").then((m) => m.CustomIndicator),
     file: "cn/select/custom-indicator.tsx",
   },
+  "select-with-clear-button": {
+    loader: () => import("./select/with-clear-button").then((m) => m.WithClearButton),
+    file: "cn/select/with-clear-button.tsx",
+  },
   "select-custom-value": {
     loader: () => import("./select/custom-value").then((m) => m.CustomValue),
     file: "cn/select/custom-value.tsx",

--- a/apps/docs/src/demos/cn/select/index.ts
+++ b/apps/docs/src/demos/cn/select/index.ts
@@ -13,6 +13,7 @@ export {MultipleSelect} from "./multiple-select";
 export {OnSurface} from "./on-surface";
 export {Required} from "./required";
 export {Variants} from "./variants";
+export {WithClearButton} from "./with-clear-button";
 export {WithDescription} from "./with-description";
 export {WithDisabledOptions} from "./with-disabled-options";
 export {WithSections} from "./with-sections";

--- a/apps/docs/src/demos/cn/select/with-clear-button.tsx
+++ b/apps/docs/src/demos/cn/select/with-clear-button.tsx
@@ -1,0 +1,42 @@
+import {Label, ListBox, Select} from "@heroui/react";
+
+export function WithClearButton() {
+  return (
+    <Select className="w-[256px]" defaultValue="california" placeholder="Select one">
+      <Label>State</Label>
+      <Select.Trigger>
+        <Select.Value />
+        <Select.ClearButton />
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          <ListBox.Item id="florida" textValue="Florida">
+            Florida
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="delaware" textValue="Delaware">
+            Delaware
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="california" textValue="California">
+            California
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="texas" textValue="Texas">
+            Texas
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="new-york" textValue="New York">
+            New York
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="washington" textValue="Washington">
+            Washington
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+}

--- a/apps/docs/src/demos/en/index.ts
+++ b/apps/docs/src/demos/en/index.ts
@@ -2154,6 +2154,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./select/custom-indicator").then((m) => m.CustomIndicator),
     file: "en/select/custom-indicator.tsx",
   },
+  "select-with-clear-button": {
+    loader: () => import("./select/with-clear-button").then((m) => m.WithClearButton),
+    file: "en/select/with-clear-button.tsx",
+  },
   "select-custom-value": {
     loader: () => import("./select/custom-value").then((m) => m.CustomValue),
     file: "en/select/custom-value.tsx",

--- a/apps/docs/src/demos/en/select/index.ts
+++ b/apps/docs/src/demos/en/select/index.ts
@@ -14,6 +14,7 @@ export {MultipleSelect} from "./multiple-select";
 export {OnSurface} from "./on-surface";
 export {Required} from "./required";
 export {Variants} from "./variants";
+export {WithClearButton} from "./with-clear-button";
 export {WithDescription} from "./with-description";
 export {WithDisabledOptions} from "./with-disabled-options";
 export {WithSections} from "./with-sections";

--- a/apps/docs/src/demos/en/select/with-clear-button.tsx
+++ b/apps/docs/src/demos/en/select/with-clear-button.tsx
@@ -1,0 +1,42 @@
+import {Label, ListBox, Select} from "@heroui/react";
+
+export function WithClearButton() {
+  return (
+    <Select className="w-[256px]" defaultValue="california" placeholder="Select one">
+      <Label>State</Label>
+      <Select.Trigger>
+        <Select.Value />
+        <Select.ClearButton />
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          <ListBox.Item id="florida" textValue="Florida">
+            Florida
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="delaware" textValue="Delaware">
+            Delaware
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="california" textValue="California">
+            California
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="texas" textValue="Texas">
+            Texas
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="new-york" textValue="New York">
+            New York
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="washington" textValue="Washington">
+            Washington
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+}

--- a/packages/react/src/components/select/index.ts
+++ b/packages/react/src/components/select/index.ts
@@ -1,6 +1,13 @@
 import type {ComponentProps} from "react";
 
-import {SelectIndicator, SelectPopover, SelectRoot, SelectTrigger, SelectValue} from "./select";
+import {
+  SelectClearButton,
+  SelectIndicator,
+  SelectPopover,
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
 
 /* -------------------------------------------------------------------------------------------------
  * Compound Component
@@ -10,6 +17,7 @@ export const Select = Object.assign(SelectRoot, {
   Trigger: SelectTrigger,
   Value: SelectValue,
   Indicator: SelectIndicator,
+  ClearButton: SelectClearButton,
   Popover: SelectPopover,
 });
 
@@ -19,13 +27,14 @@ export type Select<T extends object = object> = {
   TriggerProps: ComponentProps<typeof SelectTrigger>;
   ValueProps: ComponentProps<typeof SelectValue>;
   IndicatorProps: ComponentProps<typeof SelectIndicator>;
+  ClearButtonProps: ComponentProps<typeof SelectClearButton>;
   PopoverProps: ComponentProps<typeof SelectPopover>;
 };
 
 /* -------------------------------------------------------------------------------------------------
  * Named Component
  * -----------------------------------------------------------------------------------------------*/
-export {SelectIndicator, SelectPopover, SelectRoot, SelectTrigger, SelectValue};
+export {SelectClearButton, SelectIndicator, SelectPopover, SelectRoot, SelectTrigger, SelectValue};
 
 export type {
   SelectRootProps,
@@ -33,6 +42,7 @@ export type {
   SelectTriggerProps,
   SelectValueProps,
   SelectIndicatorProps,
+  SelectClearButtonProps,
   SelectPopoverProps,
 } from "./select";
 

--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -355,6 +355,47 @@ export const WithDisabledOptions: Story = {
   ),
 };
 
+export const WithClearButton: Story = {
+  render: () => (
+    <Select className="w-[256px]" defaultValue="california" placeholder="Select one">
+      <Label>State</Label>
+      <Select.Trigger>
+        <Select.Value />
+        <Select.ClearButton />
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          <ListBox.Item id="florida" textValue="Florida">
+            Florida
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="delaware" textValue="Delaware">
+            Delaware
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="california" textValue="California">
+            California
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="texas" textValue="Texas">
+            Texas
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="new-york" textValue="New York">
+            New York
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          <ListBox.Item id="washington" textValue="Washington">
+            Washington
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  ),
+};
+
 export const CustomIndicator: Story = {
   render: () => (
     <Select className="w-[256px]" placeholder="Select one">

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -4,7 +4,8 @@ import type {Booleanish} from "../../utils/assertion";
 import type {DOMRenderProps} from "../../utils/dom";
 import type {SurfaceVariants} from "../surface";
 import type {SelectVariants} from "@heroui/styles";
-import type {ComponentPropsWithRef} from "react";
+import type {KeyboardEvent as AriaKeyboardEvent} from "@react-types/shared";
+import type {ComponentPropsWithRef, ReactNode} from "react";
 
 import {selectVariants} from "@heroui/styles";
 import React, {createContext, use} from "react";
@@ -18,18 +19,44 @@ import {
 
 import {dataAttr} from "../../utils/assertion";
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
+import {dom} from "../../utils/dom";
 import {FieldSlotsGate} from "../../utils/field-slots-gate";
-import {IconChevronDown} from "../icons";
+import {CloseIcon, IconChevronDown} from "../icons";
 import {SurfaceContext} from "../surface";
 
 /* -------------------------------------------------------------------------------------------------
  * Select Context
  * -----------------------------------------------------------------------------------------------*/
+type SelectState = React.ContextType<typeof SelectStateContext>;
+
 type SelectContext = {
   slots?: ReturnType<typeof selectVariants>;
+  onClear?: () => void;
+  isDisabled?: boolean;
+  /**
+   * Whether a `Select.ClearButton` is mounted, which enables the trigger's clear
+   * shortcut. Read at event time so registration never triggers a re-render.
+   */
+  hasClearButton?: () => boolean;
+  /** Called by `Select.ClearButton` on mount. Returns its own cleanup. */
+  registerClearButton?: () => () => void;
 };
 
 const SelectContext = createContext<SelectContext>({});
+
+/**
+ * Exposes the trigger's resolved disabled state, which accounts for both the root's
+ * `isDisabled` and a `Select.Trigger`-level override.
+ */
+const SelectTriggerContext = createContext<{isDisabled?: boolean}>({});
+
+const isSelectionEmpty = (state: SelectState) =>
+  (state?.selectionManager.selectedKeys.size ?? 0) === 0;
+
+const clearSelection = (state: SelectState, onClear?: () => void) => {
+  state?.selectionManager.setSelectedKeys(new Set());
+  onClear?.();
+};
 
 /* -------------------------------------------------------------------------------------------------
  * Select Root
@@ -37,24 +64,47 @@ const SelectContext = createContext<SelectContext>({});
 interface SelectRootProps<T extends object, M extends "single" | "multiple" = "single">
   extends ComponentPropsWithRef<typeof SelectPrimitive<T, M>>, SelectVariants {
   items?: Iterable<T, M>;
+  /** Handler that is called when the selection is cleared. */
+  onClear?: () => void;
 }
 
 const SelectRoot = <T extends object = object, M extends "single" | "multiple" = "single">({
   children,
   className,
   fullWidth,
+  isDisabled,
+  onClear,
   variant,
   ...props
 }: SelectRootProps<T, M>) => {
   const slots = React.useMemo(() => selectVariants({fullWidth, variant}), [fullWidth, variant]);
+  const clearButtonCount = React.useRef(0);
+
+  // Counted rather than a boolean so unmounting one clear button cannot switch the
+  // shortcut off while another is still mounted.
+  const registerClearButton = React.useCallback(() => {
+    clearButtonCount.current += 1;
+
+    return () => {
+      clearButtonCount.current -= 1;
+    };
+  }, []);
+
+  const hasClearButton = React.useCallback(() => clearButtonCount.current > 0, []);
+
+  const context = React.useMemo<SelectContext>(
+    () => ({hasClearButton, isDisabled, onClear, registerClearButton, slots}),
+    [hasClearButton, isDisabled, onClear, registerClearButton, slots],
+  );
 
   return (
     <FieldSlotsGate>
-      <SelectContext value={{slots}}>
+      <SelectContext value={context}>
         <SelectPrimitive
           data-slot="select"
           {...props}
           className={composeTwRenderProps(className, slots?.base())}
+          isDisabled={isDisabled}
         >
           {(values) => <>{typeof children === "function" ? children(values) : children}</>}
         </SelectPrimitive>
@@ -68,16 +118,43 @@ const SelectRoot = <T extends object = object, M extends "single" | "multiple" =
  * -----------------------------------------------------------------------------------------------*/
 interface SelectTriggerProps extends ComponentPropsWithRef<typeof ButtonPrimitive> {}
 
-const SelectTrigger = ({children, className, ...props}: SelectTriggerProps) => {
-  const {slots} = use(SelectContext);
+const SelectTrigger = ({children, className, onKeyDown, ...props}: SelectTriggerProps) => {
+  const {hasClearButton, onClear, slots} = use(SelectContext);
+  const state = use(SelectStateContext);
+
+  // ARIA treats the children of a button as presentational, so Select.ClearButton can
+  // never take focus. This shortcut is the only pointer-free way to clear, and it is
+  // gated on a clear button being composed so a plain Select stays non-clearable.
+  const handleKeyDown = (e: AriaKeyboardEvent) => {
+    onKeyDown?.(e);
+
+    const isClearKey = e.key === "Backspace" || e.key === "Delete";
+    const canClear = Boolean(hasClearButton?.()) && !isSelectionEmpty(state);
+
+    if (!isClearKey || !canClear || state?.isOpen) {
+      // react-aria's useKeyboard swallows propagation unless a handler opts back in,
+      // and the trigger had no keydown handler at all before this shortcut existed.
+      e.continuePropagation();
+
+      return;
+    }
+
+    e.preventDefault();
+    clearSelection(state, onClear);
+  };
 
   return (
     <ButtonPrimitive
       className={composeTwRenderProps(className, slots?.trigger())}
       data-slot="select-trigger"
       {...props}
+      onKeyDown={handleKeyDown}
     >
-      {(values) => <>{typeof children === "function" ? children(values) : children}</>}
+      {(values) => (
+        <SelectTriggerContext value={{isDisabled: values.isDisabled}}>
+          {typeof children === "function" ? children(values) : children}
+        </SelectTriggerContext>
+      )}
     </ButtonPrimitive>
   );
 };
@@ -147,6 +224,72 @@ const SelectIndicator = <E extends keyof React.JSX.IntrinsicElements = "svg">({
 };
 
 /* -------------------------------------------------------------------------------------------------
+ * Select Clear Button
+ * -----------------------------------------------------------------------------------------------*/
+interface SelectClearButtonProps<
+  E extends keyof React.JSX.IntrinsicElements = "span",
+> extends DOMRenderProps<E, undefined> {
+  children?: ReactNode;
+  className?: string;
+}
+
+const SelectClearButton = <E extends keyof React.JSX.IntrinsicElements = "span">({
+  children,
+  className,
+  onClick,
+  onPointerDown,
+  ...props
+}: SelectClearButtonProps<E> &
+  Omit<React.JSX.IntrinsicElements[E], keyof SelectClearButtonProps<E>>) => {
+  const {isDisabled: rootDisabled, onClear, registerClearButton, slots} = use(SelectContext);
+  const {isDisabled: triggerDisabled} = use(SelectTriggerContext);
+  const state = use(SelectStateContext);
+
+  const isDisabled = triggerDisabled ?? rootDisabled ?? false;
+  const isEmpty = isSelectionEmpty(state);
+
+  // Opts the trigger into the Backspace/Delete shortcut, which is how keyboard and
+  // screen reader users clear. See SelectTrigger.
+  React.useEffect(() => registerClearButton?.(), [registerClearButton]);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLSpanElement>) => {
+    // Select.Trigger is a <button>, and nesting a <button> in one is invalid HTML, so
+    // this control is a span. Keep the press off the trigger so the menu stays closed.
+    // The default is left intact so focus still lands on the trigger, which is where
+    // the clear shortcut lives.
+    e.stopPropagation();
+    onPointerDown?.(e as any);
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Clearing happens here rather than on pointer down so that only a primary-button
+    // click clears; `pointerdown` also fires for secondary and middle buttons.
+    if (!isDisabled && !isEmpty) {
+      clearSelection(state, onClear);
+    }
+
+    onClick?.(e as any);
+  };
+
+  return (
+    <dom.span
+      aria-hidden
+      className={slots?.clearButton({className})}
+      data-empty={dataAttr(isEmpty)}
+      data-slot="select-clear-button"
+      {...(props as any)}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
+    >
+      {children ?? <CloseIcon data-slot="select-clear-button-icon" />}
+    </dom.span>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
  * Select Popover
  * -----------------------------------------------------------------------------------------------*/
 interface SelectPopoverProps extends Omit<
@@ -185,12 +328,13 @@ const SelectPopover = ({
 /* -------------------------------------------------------------------------------------------------
  * Exports
  * -----------------------------------------------------------------------------------------------*/
-export {SelectRoot, SelectTrigger, SelectValue, SelectIndicator, SelectPopover};
+export {SelectRoot, SelectTrigger, SelectValue, SelectIndicator, SelectClearButton, SelectPopover};
 
 export type {
   SelectRootProps,
   SelectTriggerProps,
   SelectValueProps,
   SelectIndicatorProps,
+  SelectClearButtonProps,
   SelectPopoverProps,
 };

--- a/packages/react/tests/components/select/fixtures.tsx
+++ b/packages/react/tests/components/select/fixtures.tsx
@@ -1,4 +1,5 @@
 import type {Key} from "@react-types/shared";
+import type {ReactNode} from "react";
 
 import {FieldError} from "@/components/field-error";
 import {Label} from "@/components/label";
@@ -8,10 +9,14 @@ import {Select} from "@/components/select";
 export type SelectFixtureProps = {
   defaultOpen?: boolean;
   isDisabled?: boolean;
+  isTriggerDisabled?: boolean;
   isInvalid?: boolean;
   value?: string;
   defaultValue?: string;
   onChange?: (key: Key | null) => void;
+  onClear?: () => void;
+  withClearButton?: boolean;
+  clearButtonChildren?: ReactNode;
 };
 
 export const SelectFixture = (props: SelectFixtureProps = {}) => (
@@ -24,10 +29,16 @@ export const SelectFixture = (props: SelectFixtureProps = {}) => (
     placeholder="Select one"
     value={props.value}
     onChange={props.onChange}
+    onClear={props.onClear}
   >
     <Label>State</Label>
-    <Select.Trigger>
+    <Select.Trigger isDisabled={props.isTriggerDisabled}>
       <Select.Value />
+      {props.withClearButton ? (
+        <Select.ClearButton data-testid="select-clear-button">
+          {props.clearButtonChildren}
+        </Select.ClearButton>
+      ) : null}
       <Select.Indicator />
     </Select.Trigger>
     <Select.Popover>

--- a/packages/react/tests/components/select/select.browser.test.tsx
+++ b/packages/react/tests/components/select/select.browser.test.tsx
@@ -25,4 +25,35 @@ describe("Select (browser)", () => {
     await expect.element(listbox).not.toBeInTheDocument();
     await expect.element(trigger).toHaveFocus();
   });
+
+  describe("clear button", () => {
+    it("clears on click, leaves the listbox closed, and focuses the trigger", async () => {
+      await render(<SelectFixture withClearButton defaultValue="california" />);
+
+      const trigger = page.getByRole("button", {name: "State"});
+
+      await expect.element(trigger).toHaveTextContent("California");
+
+      await page.getByTestId("select-clear-button").click();
+
+      await expect.element(trigger).toHaveTextContent("Select one");
+      await expect.element(page.getByRole("listbox")).not.toBeInTheDocument();
+      await expect.element(trigger).toHaveFocus();
+    });
+
+    it("clears with the Backspace shortcut", async () => {
+      await render(<SelectFixture withClearButton defaultValue="california" />);
+
+      const trigger = page.getByRole("button", {name: "State"});
+
+      await trigger.click();
+      await userEvent.keyboard("{Escape}");
+      await expect.element(trigger).toHaveFocus();
+
+      await userEvent.keyboard("{Backspace}");
+
+      await expect.element(trigger).toHaveTextContent("Select one");
+      await expect.element(page.getByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/react/tests/components/select/select.ssr.test.tsx
+++ b/packages/react/tests/components/select/select.ssr.test.tsx
@@ -10,4 +10,8 @@ describe("Select SSR", () => {
   it("renders without hydration mismatch when defaultOpen", async () => {
     await ssrSmoke(<SelectFixture defaultOpen />);
   });
+
+  it("renders without hydration mismatch with a clear button", async () => {
+    await ssrSmoke(<SelectFixture withClearButton defaultValue="california" />);
+  });
 });

--- a/packages/react/tests/components/select/select.test.tsx
+++ b/packages/react/tests/components/select/select.test.tsx
@@ -1,12 +1,22 @@
-import {User, cleanup, render, runAllTimers, screen} from "@heroui/testing/helpers";
+import {
+  User,
+  cleanup,
+  fireEvent,
+  render,
+  runAllTimers,
+  screen,
+  setupUser,
+} from "@heroui/testing/helpers";
 
 import {SelectFixture} from "./fixtures";
 
 describe("Select", () => {
   let testUtilUser: User;
+  let user: ReturnType<typeof setupUser>;
 
   beforeEach(() => {
     vi.useFakeTimers({shouldAdvanceTime: true});
+    user = setupUser({advanceTimers: vi.advanceTimersByTime});
     testUtilUser = new User({
       interactionType: "mouse",
       advanceTimer: vi.advanceTimersByTime,
@@ -109,5 +119,185 @@ describe("Select", () => {
     expect(screen.getByText("Please choose a state")).toBeInTheDocument();
     expect(document.querySelector('[data-slot="field-error"]')).not.toBeNull();
     expect(screen.getByTestId("select")).toHaveAttribute("data-invalid", "true");
+  });
+
+  describe("clear button", () => {
+    const getClearButton = () => document.querySelector('[data-slot="select-clear-button"]')!;
+
+    it("renders as a span so the trigger never nests a button", () => {
+      render(<SelectFixture withClearButton defaultValue="california" />);
+
+      const trigger = document.querySelector('[data-slot="select-trigger"]')!;
+
+      expect(getClearButton()).not.toBeNull();
+      expect(getClearButton().tagName).toBe("SPAN");
+      expect(trigger.contains(getClearButton())).toBe(true);
+      expect(trigger.querySelectorAll("button")).toHaveLength(0);
+    });
+
+    it("clears the selection on click without opening the listbox", async () => {
+      const onChange = vi.fn();
+      const onClear = vi.fn();
+
+      render(
+        <SelectFixture
+          withClearButton
+          defaultValue="california"
+          onChange={onChange}
+          onClear={onClear}
+        />,
+      );
+
+      await user.click(getClearButton());
+      runAllTimers();
+
+      expect(onClear).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(null);
+      expect(document.querySelector('[data-slot="select-popover"]')).toBeNull();
+      expect(screen.getByTestId("select")).toHaveTextContent("Select one");
+      expect(document.querySelector('[data-slot="select-value"]')).toHaveAttribute(
+        "data-placeholder",
+        "true",
+      );
+    });
+
+    it("does not clear on secondary or middle pointer buttons", async () => {
+      const onClear = vi.fn();
+
+      render(<SelectFixture withClearButton defaultValue="california" onClear={onClear} />);
+
+      await user.pointer({keys: "[MouseRight]", target: getClearButton()});
+      await user.pointer({keys: "[MouseMiddle]", target: getClearButton()});
+      runAllTimers();
+
+      expect(onClear).not.toHaveBeenCalled();
+      expect(screen.getByTestId("select")).toHaveTextContent("California");
+    });
+
+    it("exposes an empty state and ignores clicks with no selection", async () => {
+      const onClear = vi.fn();
+
+      render(<SelectFixture withClearButton onClear={onClear} />);
+
+      expect(getClearButton()).toHaveAttribute("data-empty", "true");
+
+      await user.click(getClearButton());
+      runAllTimers();
+
+      expect(onClear).not.toHaveBeenCalled();
+    });
+
+    it("does not clear when the select is disabled", () => {
+      const onClear = vi.fn();
+
+      render(
+        <SelectFixture isDisabled withClearButton defaultValue="california" onClear={onClear} />,
+      );
+
+      fireEvent.click(getClearButton());
+      runAllTimers();
+
+      expect(onClear).not.toHaveBeenCalled();
+      expect(screen.getByTestId("select")).toHaveTextContent("California");
+    });
+
+    it("does not clear when only the trigger is disabled", () => {
+      const onClear = vi.fn();
+
+      render(
+        <SelectFixture
+          isTriggerDisabled
+          withClearButton
+          defaultValue="california"
+          onClear={onClear}
+        />,
+      );
+
+      fireEvent.click(getClearButton());
+      runAllTimers();
+
+      expect(onClear).not.toHaveBeenCalled();
+      expect(screen.getByTestId("select")).toHaveTextContent("California");
+    });
+
+    it("renders custom children in place of the default icon", () => {
+      render(
+        <SelectFixture
+          withClearButton
+          clearButtonChildren={<span data-testid="custom-clear-icon" />}
+          defaultValue="california"
+        />,
+      );
+
+      expect(screen.getByTestId("custom-clear-icon")).toBeInTheDocument();
+      expect(document.querySelector('[data-slot="select-clear-button-icon"]')).toBeNull();
+    });
+  });
+
+  describe("clear shortcut", () => {
+    const getTrigger = () =>
+      document.querySelector('[data-slot="select-trigger"]') as HTMLButtonElement;
+
+    const focusTriggerAndPress = async (key: string) => {
+      getTrigger().focus();
+      expect(getTrigger()).toHaveFocus();
+
+      await user.keyboard(key);
+      runAllTimers();
+    };
+
+    it("clears the selection with Backspace", async () => {
+      const onChange = vi.fn();
+      const onClear = vi.fn();
+
+      render(
+        <SelectFixture
+          withClearButton
+          defaultValue="california"
+          onChange={onChange}
+          onClear={onClear}
+        />,
+      );
+
+      await focusTriggerAndPress("{Backspace}");
+
+      expect(onClear).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(null);
+      expect(screen.getByTestId("select")).toHaveTextContent("Select one");
+      expect(document.querySelector('[data-slot="select-popover"]')).toBeNull();
+    });
+
+    it("clears the selection with Delete", async () => {
+      const onChange = vi.fn();
+
+      render(<SelectFixture withClearButton defaultValue="california" onChange={onChange} />);
+
+      await focusTriggerAndPress("{Delete}");
+
+      expect(onChange).toHaveBeenCalledWith(null);
+      expect(screen.getByTestId("select")).toHaveTextContent("Select one");
+    });
+
+    it("does not clear when no clear button is composed", async () => {
+      const onChange = vi.fn();
+
+      render(<SelectFixture defaultValue="california" onChange={onChange} />);
+
+      await focusTriggerAndPress("{Backspace}");
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByTestId("select")).toHaveTextContent("California");
+    });
+
+    it("leaves other keys to the select", async () => {
+      const onChange = vi.fn();
+
+      render(<SelectFixture withClearButton defaultValue="california" onChange={onChange} />);
+
+      await focusTriggerAndPress("{ArrowDown}");
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(document.querySelector('[data-slot="select-popover"]')).not.toBeNull();
+    });
   });
 });

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -38,10 +38,10 @@
     @apply pe-7;
   }
 
-  /* Hover state */
+  /* Hover state - exclude when clear button is hovered to prevent double hover effect */
   @media (hover: hover) {
-    &:hover,
-    &[data-hovered="true"] {
+    &:hover:not(:has(.select__clear-button:hover)),
+    &[data-hovered="true"]:not(:has(.select__clear-button:hover)) {
       @apply bg-field-hover;
       border-color: var(--field-border-hover);
     }
@@ -88,9 +88,10 @@
   --select-trigger-bg-hover: var(--default-hover);
   --select-trigger-bg-focus: var(--default);
 
+  /* Exclude when clear button is hovered to prevent double hover effect */
   @media (hover: hover) {
-    &:hover,
-    &[data-hovered="true"] {
+    &:hover:not(:has(.select__clear-button:hover)),
+    &[data-hovered="true"]:not(:has(.select__clear-button:hover)) {
       background-color: var(--select-trigger-bg-hover);
     }
   }
@@ -123,6 +124,49 @@
   }
 }
 
+/* Clear Button styles */
+.select__clear-button {
+  @apply relative isolate inline-flex size-5 shrink-0 origin-center transform-gpu items-center justify-center self-center rounded-xl bg-transparent p-1 text-muted select-none no-highlight;
+
+  /* Cursor */
+  cursor: var(--cursor-interactive);
+
+  /**
+   * The visible box stays at 20px so it fits inside the trigger's 36px min-height
+   * without growing it. Expand the pointer target to the 24px floor in WCAG 2.5.8.
+   */
+  &::after {
+    @apply absolute -inset-0.5;
+    content: "";
+  }
+
+  /* Transition only when visible - disappears immediately when cleared */
+  &:not([data-empty="true"]) {
+    transition: opacity 150ms var(--ease-smooth);
+    @apply motion-reduce:transition-none;
+  }
+
+  &[data-empty="true"] {
+    @apply pointer-events-none opacity-0;
+  }
+
+  [data-slot="select-clear-button-icon"] {
+    @apply size-3.5;
+  }
+
+  @media (hover: hover) {
+    &:hover,
+    &[data-hovered="true"] {
+      @apply bg-default-hover;
+    }
+  }
+
+  &:active,
+  &[data-pressed="true"] {
+    transform: scale(0.93);
+  }
+}
+
 .select__indicator {
   @apply absolute inset-y-0 end-2 my-auto flex shrink-0 items-center justify-center text-field-placeholder transition duration-150;
 
@@ -137,7 +181,7 @@
 
 /* Similar to popover content styles */
 .select__popover {
-  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 overflow-y-auto overscroll-contain bg-overlay p-0 text-sm scrollbar;
+  @apply min-w-(--trigger-width) origin-(--trigger-anchor-point) scroll-py-1 scrollbar overflow-y-auto overscroll-contain bg-overlay p-0 text-sm;
   border-radius: min(32px, var(--radius-3xl));
   box-shadow: var(--shadow-overlay);
 

--- a/packages/styles/src/components/select/select.styles.ts
+++ b/packages/styles/src/components/select/select.styles.ts
@@ -9,6 +9,7 @@ export const selectVariants = tv({
   },
   slots: {
     base: "select",
+    clearButton: "select__clear-button",
     indicator: "select__indicator",
     popover: "select__popover",
     trigger: "select__trigger",


### PR DESCRIPTION
Closes #6405.

### Problem

v2's `isClearable` prop was dropped in v3 with no replacement, and it can't simply be rebuilt: `Select.Trigger` renders a `<button>`, so a nested `<button>` for the clear affordance is invalid HTML and breaks press handling.

### What this adds

`Select.ClearButton`, a new compound part composed inside the trigger:

```jsx
<Select onClear={handleClear}>
  <Select.Trigger>
    <Select.Value />
    <Select.ClearButton />
    <Select.Indicator />
  </Select.Trigger>
  {/* ... */}
</Select>
```

Public surface: `Select.ClearButton`, the named export `SelectClearButton`, the `SelectClearButtonProps` type, `Select<T>["ClearButtonProps"]`, an `onClear` prop on the root, and a `clearButton` slot on `selectVariants`. The part is polymorphic through `DOMRenderProps` (defaulting to `span`), accepts `children` to replace the default close icon, and exposes `data-slot="select-clear-button"`, `data-slot="select-clear-button-icon"`, and `data-empty`.

### Interaction and accessibility decisions

It renders a `span`, not a button, so the trigger never nests interactive elements. `pointerdown` only calls `stopPropagation` to keep the menu closed — the default is left intact so focus still lands on the trigger. The mutation itself happens on `click`, so secondary and middle presses no longer wipe the selection (`pointerdown` fires for those too).

ARIA treats the children of a button as presentational, so this control can never take focus or be announced. It is therefore `aria-hidden` and is strictly a pointer affordance. To give keyboard and screen reader users a way to clear, `Select.Trigger` handles `Backspace` and `Delete` whenever a `Select.ClearButton` is composed, the selection is non-empty, and the popover is closed; every other key calls `continuePropagation()` so normal Select behavior is untouched. Both paths route through one `clearSelection` helper, so `onClear` fires identically.

`aria-keyshortcuts` is deliberately **not** set. React Aria's `Button` filters props through `filterDOMProps`, which drops the attribute before it reaches the DOM — verified by dumping the rendered trigger's attributes. Rather than force it in imperatively via a merged ref and `setAttribute`, the shortcut is documented, since the attribute has inconsistent NVDA/JAWS/VoiceOver support and the workaround would fight the framework on the hottest part of Select. This is the one accessibility trade-off worth a reviewer's attention.

Disabled state resolves trigger-first, then root, so disabling either the `Select` or just the `Trigger` makes the control inert. Registration is tracked as a ref-backed count read at event time, so mounting a clear button costs no extra render and there is no window where the shortcut appears off before effects flush.

### Styling

The visible box stays 20px so it fits the trigger's 36px min-height without growing it, while an `::after` pseudo-element expands the pointer target to the 24px floor in WCAG 2.5.8. The control is hidden and non-interactive when the selection is empty, with the opacity transition applied only while visible so clearing disappears instantly, and `motion-reduce` respected. Trigger hover is excluded via `:not(:has(.select__clear-button:hover))` to avoid a double hover effect.

### Tests

23 select tests, all passing. 11 new jsdom cases cover span rendering with no nested button, click clearing without opening the listbox, secondary/middle button rejection, the empty state, root-disabled and trigger-only-disabled, custom children, `Backspace`, `Delete`, the no-op when no clear button is composed, and `ArrowDown` still reaching the Select. One new SSR case covers hydration with a clear button, and two browser cases assert in a real browser that clicking clear focuses the trigger and leaves the listbox closed — the pointer and focus semantics jsdom can only approximate.

### Docs

EN and CN component pages document the composition, the `aria-hidden` pointer-only nature of the control, and the `Backspace`/`Delete` keyboard path; both migration guides note the shortcut alongside the `isClearable` removal. Added the missing `children` row to the `Select.ClearButton` prop tables, corrected the `onClear` description in both languages (it fires on any clear, not just a button press), added a `WithClearButton` demo in both locales, and a Storybook story.

### Test plan

- [x] `pnpm --filter @heroui/react exec vitest run tests/components/select` — 23 passed
- [x] Full package suite, jsdom + browser — 586 passed across 119 files
- [x] `pnpm lint` and `pnpm typecheck` clean
- [x] `@heroui/styles` builds
- [x] Manual check that clear doesn't open the menu and focus lands on the trigger across browsers