### PR TITLE
fix(scroll-shadow): derive fade from scroll timeline to avoid SSR flicker

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(utilities)/scroll-shadow.mdx
+++ b/apps/docs/content/docs/cn/react/components/(utilities)/scroll-shadow.mdx
@@ -92,6 +92,7 @@ ScrollShadow 组件使用 CSS 变量设置渐变遮罩尺寸，并为可见的�
 | 变量                              | 默认值                                 | 描述                                                                                                               |
 | --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `--scroll-shadow-size`            | `40px`                                 | 控制渐变阴影尺寸。该值由 `size` prop 设置。                                                                         |
+| `--scroll-shadow-offset`          | `0px`                                  | 开始显示渐变之前需要滚动的距离。该值由 `offset` prop 设置。                                                         |
 | `--scroll-shadow-scrollbar-size`  | `10px`（`hideScrollBar` 时为 `0px`）   | 为原生滚动条保留一段实色遮罩区域，避免渐变覆盖滚动条。使用更宽的自定义滚动条时可以覆盖该值。                       |
 
 ### Data 属性
@@ -102,6 +103,18 @@ ScrollShadow 组件使用 CSS 变量设置渐变遮罩尺寸，并为可见的�
 - **组合状态**：`[data-top-bottom-scroll]`、`[data-left-right-scroll]` — 当内容可向两个方向滚动时应用
 - **方向**：`[data-orientation="vertical"]` 或 `[data-orientation="horizontal"]` — 表示滚动方向
 - **尺寸**：`[data-scroll-shadow-size]` — 阴影渐变尺寸数值
+- **阴影模式**：`[data-scroll-shadow-mode]` — 渐变由滚动位置推导时为 `"auto"`；`visibility` 受控或 `isEnabled` 为 `false` 时为 `"manual"`
+
+### 滚动驱动的渐变
+
+在 `auto` 模式下，支持[滚动驱动动画](https://developer.mozilla.org/zh-CN/docs/Web/CSS/animation-timeline)的浏览器会直接在 CSS
+中根据滚动位置推导渐变。因此遮罩在首次绘制时就是正确的，无需测量，也不会在 hydration 期间出现未渐变内容的闪烁。
+不支持的浏览器会回退到上面的 `[data-*-scroll]` 属性，这些属性在 hydration 之后才写入。自定义样式时需要注意两点：
+
+- 在 `auto` 模式下，即使没有可滚动内容，根元素也始终会解析出 `mask-image`。这会使其成为层叠上下文，
+  并成为 `position: fixed` 后代元素的包含块。如需退出该行为，请显式设置 `visibility`。
+- 滚动驱动的渐变依赖根元素上的 `animation` 属性。在同一元素上使用 `animate-*` 工具类会覆盖它，导致渐变消失。
+  请改为对外层容器应用动画。
 
 ## API 参考
 

--- a/apps/docs/content/docs/en/react/components/(utilities)/scroll-shadow.mdx
+++ b/apps/docs/content/docs/en/react/components/(utilities)/scroll-shadow.mdx
@@ -93,6 +93,7 @@ The ScrollShadow component uses CSS variables to size the fade mask and reserve 
 | Variable                         | Default                             | Description                                                                                                      |
 | -------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `--scroll-shadow-size`           | `40px`                              | Controls the fade gradient size. This is set from the `size` prop.                                               |
+| `--scroll-shadow-offset`         | `0px`                               | How far the container must be scrolled before the fade starts. This is set from the `offset` prop.               |
 | `--scroll-shadow-scrollbar-size` | `10px` (`0px` when `hideScrollBar`) | Reserves a solid mask gutter for the native scrollbar so the fade does not cover it. Override for wider scrollbars. |
 
 ### Data Attributes
@@ -103,6 +104,21 @@ The component uses data attributes to control shadow visibility:
 - **Combined States**: `[data-top-bottom-scroll]`, `[data-left-right-scroll]` - Applied when content can be scrolled in both directions
 - **Orientation**: `[data-orientation="vertical"]` or `[data-orientation="horizontal"]` - Indicates scroll direction
 - **Size**: `[data-scroll-shadow-size]` - Contains the shadow gradient size value
+- **Shadow Mode**: `[data-scroll-shadow-mode]` - `"auto"` when the fade is derived from the scroll position, `"manual"` when `visibility` is controlled or `isEnabled` is `false`
+
+### Scroll-Driven Fade
+
+In `auto` mode, browsers that support [scroll-driven animations](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline)
+derive the fade from the scroll position in CSS. The mask is therefore correct on the very
+first paint, with no measurement and no flash of unfaded content during hydration. Browsers
+without support fall back to the `[data-*-scroll]` attributes above, which are written after
+hydration. Two things to keep in mind when customizing:
+
+- In `auto` mode the root always resolves a `mask-image`, even when there is nothing to scroll.
+  That makes it a stacking context and a containing block for `position: fixed` descendants.
+  Set `visibility` explicitly if you need to opt out.
+- The scroll-driven fade uses the `animation` property on the root. Applying an `animate-*`
+  utility to the same element replaces it and leaves no fade. Animate a wrapper instead.
 
 ## API Reference
 

--- a/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
@@ -114,10 +114,10 @@ export const ScrollShadowRoot = ({
       ref={mergeRefs(internalRef, ref)}
       className={slots.base({className})}
       data-orientation={orientation}
-      data-scroll-shadow-size={size}
       // Selects the scroll-driven fade where supported. Controlled and disabled modes stay
       // attribute-driven, matching what the hook does for the same combination of props.
-      data-shadow-mode={isEnabled && visibility === "auto" ? "auto" : "manual"}
+      data-scroll-shadow-mode={isEnabled && visibility === "auto" ? "auto" : "manual"}
+      data-scroll-shadow-size={size}
       data-slot="scroll-shadow"
       style={style}
       {...props}

--- a/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
@@ -55,6 +55,7 @@ export const ScrollShadowRoot = ({
   orientation = "vertical",
   ref,
   size = 40,
+  style: styleProp,
   variant = "fade",
   visibility = "auto",
   ...props
@@ -104,7 +105,8 @@ export const ScrollShadowRoot = ({
 
   const style = {
     "--scroll-shadow-size": `${size}px`,
-    ...props.style,
+    "--scroll-shadow-offset": `${offset}px`,
+    ...styleProp,
   } as React.CSSProperties;
 
   return (
@@ -113,6 +115,8 @@ export const ScrollShadowRoot = ({
       className={slots.base({className})}
       data-orientation={orientation}
       data-scroll-shadow-size={size}
+      // Selects the scroll-driven fade where supported; controlled mode stays attribute-driven
+      data-shadow-mode={visibility === "auto" ? "auto" : "manual"}
       data-slot="scroll-shadow"
       style={style}
       {...props}

--- a/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/packages/react/src/components/scroll-shadow/scroll-shadow.tsx
@@ -115,8 +115,9 @@ export const ScrollShadowRoot = ({
       className={slots.base({className})}
       data-orientation={orientation}
       data-scroll-shadow-size={size}
-      // Selects the scroll-driven fade where supported; controlled mode stays attribute-driven
-      data-shadow-mode={visibility === "auto" ? "auto" : "manual"}
+      // Selects the scroll-driven fade where supported. Controlled and disabled modes stay
+      // attribute-driven, matching what the hook does for the same combination of props.
+      data-shadow-mode={isEnabled && visibility === "auto" ? "auto" : "manual"}
       data-slot="scroll-shadow"
       style={style}
       {...props}

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.browser.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.browser.test.tsx
@@ -1,0 +1,217 @@
+import {render} from "@heroui/testing/browser";
+import {page} from "vitest/browser";
+
+import {ScrollShadow} from "@/components/scroll-shadow";
+
+// The fade lives entirely in CSS, so this suite needs the compiled stylesheet rather than
+// the Tailwind sources. Every `pnpm test*` entry point builds `@heroui/styles` first.
+import "../../../../styles/dist/heroui.min.css";
+
+const SHADOW_SIZE = 40;
+const VIEWPORT = 240;
+
+const supportsScrollTimelines = () => CSS.supports("animation-timeline", "scroll(self)");
+
+/** Lets the compositor apply the scroll-driven animation before styles are read. */
+const nextFrames = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+
+const fadesOf = async (element: Element) => {
+  await nextFrames();
+  const computed = getComputedStyle(element);
+
+  return {
+    start: computed.getPropertyValue("--scroll-shadow-start-fade").trim(),
+    end: computed.getPropertyValue("--scroll-shadow-end-fade").trim(),
+  };
+};
+
+const Overflowing = ({offset}: {offset?: number} = {}) => (
+  <ScrollShadow
+    data-testid="scroller"
+    offset={offset}
+    size={SHADOW_SIZE}
+    style={{height: VIEWPORT}}
+  >
+    <div style={{height: 1200}}>Tall content</div>
+  </ScrollShadow>
+);
+
+const Fitting = () => (
+  <ScrollShadow data-testid="scroller" size={SHADOW_SIZE} style={{height: VIEWPORT}}>
+    <div>Short content</div>
+  </ScrollShadow>
+);
+
+const OverflowingRow = () => (
+  <ScrollShadow
+    data-testid="scroller"
+    orientation="horizontal"
+    size={SHADOW_SIZE}
+    style={{width: VIEWPORT}}
+  >
+    <div style={{width: 1200}}>Wide content</div>
+  </ScrollShadow>
+);
+
+const FittingRow = () => (
+  <ScrollShadow
+    data-testid="scroller"
+    orientation="horizontal"
+    size={SHADOW_SIZE}
+    style={{width: VIEWPORT}}
+  >
+    <div style={{width: 20}}>Narrow</div>
+  </ScrollShadow>
+);
+
+const scrollerOf = () => page.getByTestId("scroller").element();
+
+describe("ScrollShadow (browser)", () => {
+  describe("scroll-driven fade", () => {
+    it("fades only the end edge while resting at the start", async () => {
+      await render(<Overflowing />);
+
+      if (!supportsScrollTimelines()) return;
+
+      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
+    });
+
+    it("fades both edges once scrolled into the middle", async () => {
+      await render(<Overflowing />);
+
+      if (!supportsScrollTimelines()) return;
+
+      const scroller = scrollerOf();
+
+      scroller.scrollTop = 400;
+
+      expect(await fadesOf(scroller)).toEqual({
+        start: `${SHADOW_SIZE}px`,
+        end: `${SHADOW_SIZE}px`,
+      });
+    });
+
+    it("fades only the start edge at the end of the scroll range", async () => {
+      await render(<Overflowing />);
+
+      if (!supportsScrollTimelines()) return;
+
+      const scroller = scrollerOf();
+
+      scroller.scrollTop = scroller.scrollHeight;
+
+      expect(await fadesOf(scroller)).toEqual({start: `${SHADOW_SIZE}px`, end: "0px"});
+    });
+
+    it("scrubs the start fade in across the shadow size", async () => {
+      await render(<Overflowing />);
+
+      if (!supportsScrollTimelines()) return;
+
+      const scroller = scrollerOf();
+
+      scroller.scrollTop = SHADOW_SIZE / 2;
+
+      expect((await fadesOf(scroller)).start).toBe(`${SHADOW_SIZE / 2}px`);
+    });
+
+    it("holds the start fade back until the offset is passed", async () => {
+      await render(<Overflowing offset={80} />);
+
+      if (!supportsScrollTimelines()) return;
+
+      const scroller = scrollerOf();
+
+      scroller.scrollTop = 80;
+
+      expect((await fadesOf(scroller)).start).toBe("0px");
+    });
+
+    // The server cannot measure overflow, so the markup assumes an end-edge shadow. An
+    // inactive scroll timeline must collapse it rather than fade content that fits.
+    it("renders no fade when the content fits", async () => {
+      await render(<Fitting />);
+
+      if (!supportsScrollTimelines()) return;
+
+      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+    });
+
+    // The hook still writes the state attributes, so the attribute rules match too. The
+    // scroll-driven rules have to win the cascade, including the prefixed properties.
+    it("resolves the mask from the scroll-driven gradient, not the attribute fallback", async () => {
+      await render(<Overflowing />);
+
+      if (!supportsScrollTimelines()) return;
+
+      const scroller = scrollerOf();
+
+      await nextFrames();
+      expect(scroller).toHaveAttribute("data-bottom-scroll", "true");
+
+      const computed = getComputedStyle(scroller);
+
+      // The scroll-driven gradient opens with a transparent stop; the fallback opens with black.
+      expect(computed.maskImage).toMatch(/^linear-gradient\(rgba\(0, 0, 0, 0\)/);
+      expect(computed.webkitMaskImage).toMatch(/^linear-gradient\(rgba\(0, 0, 0, 0\)/);
+    });
+
+    it("keeps the shadow size and offset when a style prop is supplied", async () => {
+      await render(<Overflowing offset={80} />);
+
+      const computed = getComputedStyle(scrollerOf());
+
+      expect(computed.getPropertyValue("--scroll-shadow-size").trim()).toBe(`${SHADOW_SIZE}px`);
+      expect(computed.getPropertyValue("--scroll-shadow-offset").trim()).toBe("80px");
+    });
+  });
+
+  // The inline axis drives Tabs' scroller, which is the common non-overflowing case.
+  describe("horizontal orientation", () => {
+    it("fades only the end edge while resting at the start", async () => {
+      await render(<OverflowingRow />);
+
+      if (!supportsScrollTimelines()) return;
+
+      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
+    });
+
+    it("fades only the start edge at the end of the scroll range", async () => {
+      await render(<OverflowingRow />);
+
+      if (!supportsScrollTimelines()) return;
+
+      const scroller = scrollerOf();
+
+      scroller.scrollLeft = scroller.scrollWidth;
+
+      expect(await fadesOf(scroller)).toEqual({start: `${SHADOW_SIZE}px`, end: "0px"});
+    });
+
+    it("renders no fade when the content fits", async () => {
+      await render(<FittingRow />);
+
+      if (!supportsScrollTimelines()) return;
+
+      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+    });
+  });
+
+  describe("controlled visibility", () => {
+    it("keeps using the attribute-driven mask", async () => {
+      await render(
+        <ScrollShadow data-testid="scroller" size={SHADOW_SIZE} visibility="both">
+          <div style={{height: 20}}>Short content</div>
+        </ScrollShadow>,
+      );
+
+      const scroller = scrollerOf();
+
+      expect(scroller).toHaveAttribute("data-shadow-mode", "manual");
+      expect(getComputedStyle(scroller).maskImage).toContain("linear-gradient");
+    });
+  });
+});

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.browser.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.browser.test.tsx
@@ -130,8 +130,8 @@ describe("ScrollShadow (browser)", () => {
       expect((await fadesOf(scroller)).start).toBe("0px");
     });
 
-    // The server cannot measure overflow, so the markup assumes an end-edge shadow. An
-    // inactive scroll timeline must collapse it rather than fade content that fits.
+    // A container without overflow has an inactive timeline, which has to hold both fades
+    // at 0px rather than fade content that fits.
     it("renders no fade when the content fits", async () => {
       await render(<Fitting />);
 
@@ -197,6 +197,27 @@ describe("ScrollShadow (browser)", () => {
       if (!supportsScrollTimelines()) return;
 
       expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+    });
+  });
+
+  describe("disabled detection", () => {
+    it("renders no fade when detection is turned off", async () => {
+      await render(
+        <ScrollShadow
+          data-testid="scroller"
+          isEnabled={false}
+          size={SHADOW_SIZE}
+          style={{height: VIEWPORT}}
+        >
+          <div style={{height: 1200}}>Tall content</div>
+        </ScrollShadow>,
+      );
+
+      const scroller = scrollerOf();
+
+      await nextFrames();
+
+      expect(getComputedStyle(scroller).maskImage).toBe("none");
     });
   });
 

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.browser.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.browser.test.tsx
@@ -10,7 +10,9 @@ import "../../../../styles/dist/heroui.min.css";
 const SHADOW_SIZE = 40;
 const VIEWPORT = 240;
 
-const supportsScrollTimelines = () => CSS.supports("animation-timeline", "scroll(self)");
+// Read once at module scope so the groups below skip visibly instead of passing vacuously
+// on an engine without scroll timelines.
+const supportsScrollTimelines = CSS.supports("animation-timeline", "scroll(self)");
 
 /** Lets the compositor apply the scroll-driven animation before styles are read. */
 const nextFrames = () =>
@@ -18,8 +20,7 @@ const nextFrames = () =>
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
   });
 
-const fadesOf = async (element: Element) => {
-  await nextFrames();
+const fadesOf = (element: Element) => {
   const computed = getComputedStyle(element);
 
   return {
@@ -28,7 +29,11 @@ const fadesOf = async (element: Element) => {
   };
 };
 
-const Overflowing = ({offset}: {offset?: number} = {}) => (
+/** Interpolated lengths land on device pixels, so compare them numerically. */
+const startFadePxOf = (element: Element) =>
+  Number.parseFloat(getComputedStyle(element).getPropertyValue("--scroll-shadow-start-fade"));
+
+const Overflowing = ({offset}: {offset?: number}) => (
   <ScrollShadow
     data-testid="scroller"
     offset={offset}
@@ -45,15 +50,17 @@ const Fitting = () => (
   </ScrollShadow>
 );
 
-const OverflowingRow = () => (
-  <ScrollShadow
-    data-testid="scroller"
-    orientation="horizontal"
-    size={SHADOW_SIZE}
-    style={{width: VIEWPORT}}
-  >
-    <div style={{width: 1200}}>Wide content</div>
-  </ScrollShadow>
+const OverflowingRow = ({dir}: {dir?: "ltr" | "rtl"}) => (
+  <div dir={dir}>
+    <ScrollShadow
+      data-testid="scroller"
+      orientation="horizontal"
+      size={SHADOW_SIZE}
+      style={{width: VIEWPORT}}
+    >
+      <div style={{width: 1200}}>Wide content</div>
+    </ScrollShadow>
+  </div>
 );
 
 const FittingRow = () => (
@@ -69,65 +76,65 @@ const FittingRow = () => (
 
 const scrollerOf = () => page.getByTestId("scroller").element();
 
+const maxScrollTopOf = (element: Element) => element.scrollHeight - element.clientHeight;
+
+const maxScrollLeftOf = (element: Element) => element.scrollWidth - element.clientWidth;
+
 describe("ScrollShadow (browser)", () => {
-  describe("scroll-driven fade", () => {
+  describe.skipIf(!supportsScrollTimelines)("scroll-driven fade", () => {
     it("fades only the end edge while resting at the start", async () => {
       await render(<Overflowing />);
 
-      if (!supportsScrollTimelines()) return;
-
-      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
+      await expect
+        .poll(() => fadesOf(scrollerOf()))
+        .toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
     });
 
     it("fades both edges once scrolled into the middle", async () => {
       await render(<Overflowing />);
 
-      if (!supportsScrollTimelines()) return;
-
       const scroller = scrollerOf();
 
       scroller.scrollTop = 400;
 
-      expect(await fadesOf(scroller)).toEqual({
-        start: `${SHADOW_SIZE}px`,
-        end: `${SHADOW_SIZE}px`,
-      });
+      await expect
+        .poll(() => fadesOf(scroller))
+        .toEqual({start: `${SHADOW_SIZE}px`, end: `${SHADOW_SIZE}px`});
     });
 
     it("fades only the start edge at the end of the scroll range", async () => {
       await render(<Overflowing />);
 
-      if (!supportsScrollTimelines()) return;
-
       const scroller = scrollerOf();
 
-      scroller.scrollTop = scroller.scrollHeight;
+      scroller.scrollTop = maxScrollTopOf(scroller);
 
-      expect(await fadesOf(scroller)).toEqual({start: `${SHADOW_SIZE}px`, end: "0px"});
+      await expect.poll(() => fadesOf(scroller)).toEqual({start: `${SHADOW_SIZE}px`, end: "0px"});
     });
 
     it("scrubs the start fade in across the shadow size", async () => {
       await render(<Overflowing />);
 
-      if (!supportsScrollTimelines()) return;
-
       const scroller = scrollerOf();
 
       scroller.scrollTop = SHADOW_SIZE / 2;
 
-      expect((await fadesOf(scroller)).start).toBe(`${SHADOW_SIZE / 2}px`);
+      await expect.poll(() => startFadePxOf(scroller)).toBeCloseTo(SHADOW_SIZE / 2, 0);
     });
 
     it("holds the start fade back until the offset is passed", async () => {
       await render(<Overflowing offset={80} />);
 
-      if (!supportsScrollTimelines()) return;
-
       const scroller = scrollerOf();
 
       scroller.scrollTop = 80;
+      await nextFrames();
 
-      expect((await fadesOf(scroller)).start).toBe("0px");
+      expect(startFadePxOf(scroller)).toBe(0);
+
+      scroller.scrollTop = 80 + SHADOW_SIZE / 2;
+
+      await expect.poll(() => startFadePxOf(scroller)).toBeCloseTo(SHADOW_SIZE / 2, 0);
     });
 
     // A container without overflow has an inactive timeline, which has to hold both fades
@@ -135,9 +142,20 @@ describe("ScrollShadow (browser)", () => {
     it("renders no fade when the content fits", async () => {
       await render(<Fitting />);
 
-      if (!supportsScrollTimelines()) return;
+      await nextFrames();
 
-      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+      expect(fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+    });
+
+    // Deriving the mask from CSS alone means auto mode resolves a `mask-image` even with
+    // nothing to scroll, so the root is always a stacking context. That is the deliberate
+    // cost of not measuring overflow; the fade itself still collapses to a no-op.
+    it("keeps a no-op mask rather than dropping it when the content fits", async () => {
+      await render(<Fitting />);
+
+      await nextFrames();
+
+      expect(getComputedStyle(scrollerOf()).maskImage).toContain("linear-gradient");
     });
 
     // The hook still writes the state attributes, so the attribute rules match too. The
@@ -145,12 +163,9 @@ describe("ScrollShadow (browser)", () => {
     it("resolves the mask from the scroll-driven gradient, not the attribute fallback", async () => {
       await render(<Overflowing />);
 
-      if (!supportsScrollTimelines()) return;
-
       const scroller = scrollerOf();
 
-      await nextFrames();
-      expect(scroller).toHaveAttribute("data-bottom-scroll", "true");
+      await expect.poll(() => scroller.getAttribute("data-bottom-scroll")).toBe("true");
 
       const computed = getComputedStyle(scroller);
 
@@ -158,45 +173,70 @@ describe("ScrollShadow (browser)", () => {
       expect(computed.maskImage).toMatch(/^linear-gradient\(rgba\(0, 0, 0, 0\)/);
       expect(computed.webkitMaskImage).toMatch(/^linear-gradient\(rgba\(0, 0, 0, 0\)/);
     });
+  });
 
-    it("keeps the shadow size and offset when a style prop is supplied", async () => {
-      await render(<Overflowing offset={80} />);
+  it("keeps the shadow size and offset when a style prop is supplied", async () => {
+    await render(<Overflowing offset={80} />);
 
-      const computed = getComputedStyle(scrollerOf());
+    const computed = getComputedStyle(scrollerOf());
 
-      expect(computed.getPropertyValue("--scroll-shadow-size").trim()).toBe(`${SHADOW_SIZE}px`);
-      expect(computed.getPropertyValue("--scroll-shadow-offset").trim()).toBe("80px");
-    });
+    expect(computed.getPropertyValue("--scroll-shadow-size").trim()).toBe(`${SHADOW_SIZE}px`);
+    expect(computed.getPropertyValue("--scroll-shadow-offset").trim()).toBe("80px");
+    expect(computed.height).toBe(`${VIEWPORT}px`);
   });
 
   // The inline axis drives Tabs' scroller, which is the common non-overflowing case.
-  describe("horizontal orientation", () => {
+  describe.skipIf(!supportsScrollTimelines)("horizontal orientation", () => {
     it("fades only the end edge while resting at the start", async () => {
       await render(<OverflowingRow />);
 
-      if (!supportsScrollTimelines()) return;
-
-      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
+      await expect
+        .poll(() => fadesOf(scrollerOf()))
+        .toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
     });
 
     it("fades only the start edge at the end of the scroll range", async () => {
       await render(<OverflowingRow />);
 
-      if (!supportsScrollTimelines()) return;
-
       const scroller = scrollerOf();
 
-      scroller.scrollLeft = scroller.scrollWidth;
+      scroller.scrollLeft = maxScrollLeftOf(scroller);
 
-      expect(await fadesOf(scroller)).toEqual({start: `${SHADOW_SIZE}px`, end: "0px"});
+      await expect.poll(() => fadesOf(scroller)).toEqual({start: `${SHADOW_SIZE}px`, end: "0px"});
     });
 
     it("renders no fade when the content fits", async () => {
       await render(<FittingRow />);
 
-      if (!supportsScrollTimelines()) return;
+      await nextFrames();
 
-      expect(await fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+      expect(fadesOf(scrollerOf())).toEqual({start: "0px", end: "0px"});
+    });
+
+    // Inline-axis progress runs right-to-left in RTL, so the physical gradient has to flip
+    // or the start fade would be painted on the wrong edge.
+    it("points the gradient at the left edge in LTR", async () => {
+      await render(<OverflowingRow dir="ltr" />);
+
+      await nextFrames();
+
+      expect(getComputedStyle(scrollerOf()).maskImage).toContain("90deg");
+    });
+
+    it("flips the gradient to the right edge in RTL", async () => {
+      await render(<OverflowingRow dir="rtl" />);
+
+      await nextFrames();
+
+      expect(getComputedStyle(scrollerOf()).maskImage).toContain("270deg");
+    });
+
+    it("still fades only the end edge while resting at the start in RTL", async () => {
+      await render(<OverflowingRow dir="rtl" />);
+
+      await expect
+        .poll(() => fadesOf(scrollerOf()))
+        .toEqual({start: "0px", end: `${SHADOW_SIZE}px`});
     });
   });
 
@@ -215,6 +255,8 @@ describe("ScrollShadow (browser)", () => {
 
       const scroller = scrollerOf();
 
+      expect(scroller).toHaveAttribute("data-scroll-shadow-mode", "manual");
+
       await nextFrames();
 
       expect(getComputedStyle(scroller).maskImage).toBe("none");
@@ -231,8 +273,10 @@ describe("ScrollShadow (browser)", () => {
 
       const scroller = scrollerOf();
 
-      expect(scroller).toHaveAttribute("data-shadow-mode", "manual");
-      expect(getComputedStyle(scroller).maskImage).toContain("linear-gradient");
+      expect(scroller).toHaveAttribute("data-scroll-shadow-mode", "manual");
+
+      // The fallback gradient opens with black; the scroll-driven one opens transparent.
+      expect(getComputedStyle(scroller).maskImage).toMatch(/^linear-gradient\(rgb\(0, 0, 0\)/);
     });
   });
 });

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.ssr.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.ssr.test.tsx
@@ -10,4 +10,35 @@ describe("ScrollShadow SSR", () => {
 
     expect(html).toContain('data-slot="scroll-shadow"');
   });
+
+  // The server cannot measure overflow, so the scroll-state attributes only arrive after
+  // hydration. Shipping the mode attribute is what lets CSS paint the correct fade first.
+  it("ships the auto shadow mode so the fade needs no measurement", async () => {
+    const {html} = await ssrSmoke(
+      <ScrollShadow data-testid="scroll-shadow">Scrollable content</ScrollShadow>,
+    );
+
+    expect(html).toContain('data-scroll-shadow-mode="auto"');
+  });
+
+  it("ships the shadow size and offset variables", async () => {
+    const {html} = await ssrSmoke(
+      <ScrollShadow data-testid="scroll-shadow" offset={20} size={64}>
+        Scrollable content
+      </ScrollShadow>,
+    );
+
+    expect(html).toContain("--scroll-shadow-size:64px");
+    expect(html).toContain("--scroll-shadow-offset:20px");
+  });
+
+  it("ships the manual shadow mode when visibility is controlled", async () => {
+    const {html} = await ssrSmoke(
+      <ScrollShadow data-testid="scroll-shadow" visibility="both">
+        Scrollable content
+      </ScrollShadow>,
+    );
+
+    expect(html).toContain('data-scroll-shadow-mode="manual"');
+  });
 });

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
@@ -41,6 +41,56 @@ describe("ScrollShadow", () => {
     );
   });
 
+  describe("shadow mode", () => {
+    it("exposes the auto mode that drives the scroll-timeline fade", () => {
+      render(<ScrollShadow data-testid="scroll-shadow">Content</ScrollShadow>);
+
+      expect(screen.getByTestId("scroll-shadow")).toHaveAttribute(
+        "data-scroll-shadow-mode",
+        "auto",
+      );
+    });
+
+    it("falls back to manual mode when visibility is controlled", () => {
+      render(
+        <ScrollShadow data-testid="scroll-shadow" visibility="both">
+          Content
+        </ScrollShadow>,
+      );
+
+      expect(screen.getByTestId("scroll-shadow")).toHaveAttribute(
+        "data-scroll-shadow-mode",
+        "manual",
+      );
+    });
+
+    it("falls back to manual mode when detection is disabled", () => {
+      render(
+        <ScrollShadow data-testid="scroll-shadow" isEnabled={false}>
+          Content
+        </ScrollShadow>,
+      );
+
+      expect(screen.getByTestId("scroll-shadow")).toHaveAttribute(
+        "data-scroll-shadow-mode",
+        "manual",
+      );
+    });
+  });
+
+  it("keeps the shadow size and offset variables when a style prop is supplied", () => {
+    render(
+      <ScrollShadow data-testid="scroll-shadow" offset={20} size={64} style={{height: 240}}>
+        Content
+      </ScrollShadow>,
+    );
+    const scrollShadow = screen.getByTestId("scroll-shadow");
+
+    expect(scrollShadow.style.getPropertyValue("--scroll-shadow-size")).toBe("64px");
+    expect(scrollShadow.style.getPropertyValue("--scroll-shadow-offset")).toBe("20px");
+    expect(scrollShadow.style.height).toBe("240px");
+  });
+
   it("supports data attribute passthrough", () => {
     render(
       <ScrollShadow data-foo="bar" data-testid="scroll-shadow">

--- a/packages/styles/components/scroll-shadow.css
+++ b/packages/styles/components/scroll-shadow.css
@@ -3,6 +3,39 @@
   @apply relative;
   --scroll-shadow-size: 40px;
   --scroll-shadow-scrollbar-size: 10px;
+  --scroll-shadow-offset: 0px;
+}
+
+/* Fade sizes for the scroll-driven variant below. They stay at 0px whenever the scroll
+   timeline is inactive, which is exactly the state of a container without overflow. */
+@property --scroll-shadow-start-fade {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --scroll-shadow-end-fade {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@keyframes scroll-shadow-start-fade {
+  from {
+    --scroll-shadow-start-fade: 0px;
+  }
+  to {
+    --scroll-shadow-start-fade: var(--scroll-shadow-size);
+  }
+}
+
+@keyframes scroll-shadow-end-fade {
+  from {
+    --scroll-shadow-end-fade: var(--scroll-shadow-size);
+  }
+  to {
+    --scroll-shadow-end-fade: 0px;
+  }
 }
 
 /* Orientation: Vertical */
@@ -17,7 +50,15 @@
 
 /* Variant: Fade - Vertical */
 .scroll-shadow--fade.scroll-shadow--vertical {
-  &:where([data-top-scroll="true"], [data-bottom-scroll="true"], [data-top-bottom-scroll="true"]) {
+  /* `[data-shadow-mode="auto"]` lets the scroll-driven variant below reuse this plumbing.
+     It only paints once `--scroll-linear-gradient` is set, since an undefined variable
+     makes `mask-image` invalid at computed-value time, which resolves to `none`. */
+  &:where(
+    [data-top-scroll="true"],
+    [data-bottom-scroll="true"],
+    [data-top-bottom-scroll="true"],
+    [data-shadow-mode="auto"]
+  ) {
     mask-image: linear-gradient(var(--scroll-linear-gradient)), linear-gradient(#000, #000);
     mask-position:
       left top,
@@ -53,7 +94,12 @@
 
 /* Variant: Fade - Horizontal */
 .scroll-shadow--fade.scroll-shadow--horizontal {
-  &:where([data-left-scroll="true"], [data-right-scroll="true"], [data-left-right-scroll="true"]) {
+  &:where(
+    [data-left-scroll="true"],
+    [data-right-scroll="true"],
+    [data-left-right-scroll="true"],
+    [data-shadow-mode="auto"]
+  ) {
     mask-image: linear-gradient(var(--scroll-linear-gradient)), linear-gradient(#000, #000);
     mask-position:
       left top,
@@ -100,4 +146,45 @@
 .scroll-shadow--hide-scrollbar {
   @apply scrollbar-none;
   --scroll-shadow-scrollbar-size: 0px;
+}
+
+/* Variant: Fade - scroll-driven
+   Where scroll timelines are available the fade is derived from the real scroll state,
+   so it is already correct on the first paint and needs no measurement or hydration.
+   A container without overflow has an inactive timeline, which leaves both fades at 0px
+   and collapses the mask to a no-op. The attribute-driven rules above remain the
+   fallback for engines without scroll timelines, and keep serving controlled mode. */
+@supports (animation-timeline: scroll(self)) {
+  /* These gradients must stay after the attribute rules above: they carry the same
+     specificity, so source order is what lets the scrubbed values win in auto mode. */
+  .scroll-shadow--fade[data-shadow-mode="auto"] {
+    animation:
+      scroll-shadow-start-fade linear both,
+      scroll-shadow-end-fade linear both;
+    animation-range:
+      var(--scroll-shadow-offset) calc(var(--scroll-shadow-offset) + var(--scroll-shadow-size)),
+      calc(100% - var(--scroll-shadow-size) - var(--scroll-shadow-offset))
+        calc(100% - var(--scroll-shadow-offset));
+  }
+
+  .scroll-shadow--fade.scroll-shadow--vertical[data-shadow-mode="auto"] {
+    animation-timeline: scroll(self block), scroll(self block);
+    --scroll-linear-gradient:
+      180deg, transparent 0, #000 var(--scroll-shadow-start-fade),
+      #000 calc(100% - var(--scroll-shadow-end-fade)), transparent 100%;
+  }
+
+  .scroll-shadow--fade.scroll-shadow--horizontal[data-shadow-mode="auto"] {
+    animation-timeline: scroll(self inline), scroll(self inline);
+    --scroll-linear-gradient:
+      90deg, transparent 0, #000 var(--scroll-shadow-start-fade),
+      #000 calc(100% - var(--scroll-shadow-end-fade)), transparent 100%;
+
+    /* Inline-axis progress starts at the right edge in RTL, so flip the physical direction */
+    &:dir(rtl) {
+      --scroll-linear-gradient:
+        270deg, transparent 0, #000 var(--scroll-shadow-start-fade),
+        #000 calc(100% - var(--scroll-shadow-end-fade)), transparent 100%;
+    }
+  }
 }

--- a/packages/styles/components/scroll-shadow.css
+++ b/packages/styles/components/scroll-shadow.css
@@ -50,14 +50,14 @@
 
 /* Variant: Fade - Vertical */
 .scroll-shadow--fade.scroll-shadow--vertical {
-  /* `[data-shadow-mode="auto"]` lets the scroll-driven variant below reuse this plumbing.
-     It only paints once `--scroll-linear-gradient` is set, since an undefined variable
-     makes `mask-image` invalid at computed-value time, which resolves to `none`. */
+  /* `[data-scroll-shadow-mode="auto"]` lets the scroll-driven variant below reuse this
+     plumbing. It only paints once `--scroll-linear-gradient` is set, since an undefined
+     variable makes `mask-image` invalid at computed-value time, which resolves to `none`. */
   &:where(
     [data-top-scroll="true"],
     [data-bottom-scroll="true"],
     [data-top-bottom-scroll="true"],
-    [data-shadow-mode="auto"]
+    [data-scroll-shadow-mode="auto"]
   ) {
     mask-image: linear-gradient(var(--scroll-linear-gradient)), linear-gradient(#000, #000);
     mask-position:
@@ -98,7 +98,7 @@
     [data-left-scroll="true"],
     [data-right-scroll="true"],
     [data-left-right-scroll="true"],
-    [data-shadow-mode="auto"]
+    [data-scroll-shadow-mode="auto"]
   ) {
     mask-image: linear-gradient(var(--scroll-linear-gradient)), linear-gradient(#000, #000);
     mask-position:
@@ -153,11 +153,18 @@
    so it is already correct on the first paint and needs no measurement or hydration.
    A container without overflow has an inactive timeline, which leaves both fades at 0px
    and collapses the mask to a no-op. The attribute-driven rules above remain the
-   fallback for engines without scroll timelines, and keep serving controlled mode. */
+   fallback for engines without scroll timelines, and keep serving controlled mode.
+
+   Two consequences of deriving the mask from CSS alone:
+   - Auto mode always resolves a `mask-image`, even with nothing to scroll, so the root is
+     always a stacking context and a containing block for fixed descendants. Gating that on
+     overflow would need a measurement, which is the flicker this variant exists to avoid.
+   - The `animation` shorthand here lives in the components layer, so an `animate-*` utility
+     on the root replaces it and pins both fades at 0px, leaving no fade at all. */
 @supports (animation-timeline: scroll(self)) {
-  /* These gradients must stay after the attribute rules above: they carry the same
-     specificity, so source order is what lets the scrubbed values win in auto mode. */
-  .scroll-shadow--fade[data-shadow-mode="auto"] {
+  /* `.scroll-shadow` is repeated so these rules outrank the attribute-driven gradients
+     above on specificity rather than on source order, which a re-ordering could break. */
+  .scroll-shadow.scroll-shadow--fade[data-scroll-shadow-mode="auto"] {
     animation:
       scroll-shadow-start-fade linear both,
       scroll-shadow-end-fade linear both;
@@ -167,14 +174,16 @@
         calc(100% - var(--scroll-shadow-offset));
   }
 
-  .scroll-shadow--fade.scroll-shadow--vertical[data-shadow-mode="auto"] {
+  /* The orientation rules also outrank the `animation` shorthand above, which resets
+     `animation-timeline` to `auto`, so the timeline survives regardless of order. */
+  .scroll-shadow.scroll-shadow--fade.scroll-shadow--vertical[data-scroll-shadow-mode="auto"] {
     animation-timeline: scroll(self block), scroll(self block);
     --scroll-linear-gradient:
       180deg, transparent 0, #000 var(--scroll-shadow-start-fade),
       #000 calc(100% - var(--scroll-shadow-end-fade)), transparent 100%;
   }
 
-  .scroll-shadow--fade.scroll-shadow--horizontal[data-shadow-mode="auto"] {
+  .scroll-shadow.scroll-shadow--fade.scroll-shadow--horizontal[data-scroll-shadow-mode="auto"] {
     animation-timeline: scroll(self inline), scroll(self inline);
     --scroll-linear-gradient:
       90deg, transparent 0, #000 var(--scroll-shadow-start-fade),


### PR DESCRIPTION
Closes # <!-- reported in Discord, no GitHub issue -->

## 📝 Description

- Originally reported in [discord](https://discord.com/channels/856545348885676062/1526417634365800470)

`ScrollShadow` decided its fade from JavaScript measurements taken after hydration. Where the browser supports scroll timelines, the fade is now derived from the real scroll position in CSS, so it is correct on the very first paint.

## ⛳️ Current behavior (updates)

Server-rendered markup carries no scroll state, so the first paint has no fade at all. The hook measures overflow after hydration and writes `data-*` attributes, at which point the fade pops in. On a slow connection the gap between the two paints is clearly visible.

Two smaller issues surfaced while testing this:

- A consumer `style` prop overwrote the component's own `--scroll-shadow-size`, so `<ScrollShadow size={40} style={{height: 240}} />` silently lost its shadow size.
- `isEnabled={false}` did not suppress the new CSS fade, because the attribute selecting it only accounted for `visibility`.

## 🚀 New behavior

- The fade scrubs from a scroll progress timeline, so it is already correct at first paint with no measurement and no hydration step.
- A container without overflow has an inactive timeline, which holds both fades at `0px`. Content that fits is never faded, so no assumption about overflow is baked into the markup.
- The existing attribute-driven rules are untouched and still serve engines without scroll timelines, controlled `visibility`, and `isEnabled={false}`.
- Consumer `style` props are merged instead of replacing the component's CSS variables, and `offset` is now exposed as `--scroll-shadow-offset` so both code paths honour it identically.

## 💣 Is this a breaking change (Yes/No):

No. The root element gains a `data-shadow-mode` attribute (`"auto"` / `"manual"`) used internally to select the code path.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

Added `scroll-shadow.browser.test.tsx`, covering the fade at rest, mid-scroll, at the end of the range, with a custom `offset`, with content that fits, with detection disabled, and in both orientations. It also asserts the resolved mask comes from the scrubbed gradient rather than the attribute fallback, since both rules match in auto mode.

## 📝 Additional Information

Verified in Chromium and in WebKit 26.5 (Safari 26), which produce identical fade values in every case. Firefox has not shipped scroll timelines as of v156, so it keeps today's attribute-driven behaviour unchanged via the `@supports` guard.