### PR TITLE
fix(docs): redirect /agents paths to heroui.pro/agents

### DIFF
--- a/apps/docs/next-redirects.ts
+++ b/apps/docs/next-redirects.ts
@@ -149,6 +149,23 @@ export async function getRedirects(): Promise<Redirect[]> {
     source: "/en",
   });
 
+  // HeroUI Agents product page lives on heroui.pro. Docs and npm still link to
+  // heroui.com/agents, so send those legacy paths to the live product URL.
+  const agentsProductUrl = "https://heroui.pro/agents";
+
+  redirects.push(
+    {
+      destination: agentsProductUrl,
+      permanent: true,
+      source: "/agents",
+    },
+    {
+      destination: agentsProductUrl,
+      permanent: true,
+      source: "/:lang(en|cn)/agents",
+    },
+  );
+
   // Theme builder redirect - redirect /theme to /themes
   redirects.push({
     destination: "/themes",

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -35,6 +35,7 @@ const PERMANENT_LOCALIZED_PREFIXES = ["/blog", "/docs", "/showcase", "/themes"];
 // Routes that live outside `app/[lang]` and must never receive a locale prefix.
 const LOCALE_REDIRECT_EXCLUDED_PREFIXES = [
   ...MARKDOWN_EXCLUDED_PREFIXES,
+  "/agents",
   "/install",
   "/native",
   "/react",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Legacy links to `heroui.com/agents` (and locale-prefixed variants) were 404ing because the docs site had no route or redirect for that path. Middleware was also rewriting bare `/agents` to `/en/agents`, which still 404'd.

This adds permanent external redirects to the live HeroUI Agents product page at `https://heroui.pro/agents`.

## Current behavior

- `/agents` → middleware rewrites to `/en/agents` → bare 404
- `/en/agents` and `/cn/agents` → bare 404

## New behavior

- `/agents`, `/en/agents`, and `/cn/agents` → `308 Permanent Redirect` to `https://heroui.pro/agents`
- `/agents` is excluded from locale-prefix middleware so it redirects directly instead of bouncing through `/en/agents`

## Is this a breaking change (Yes/No):

No

## Testing

Verified locally with the docs dev server:

```bash
curl -sI http://localhost:3000/agents      # 308 → https://heroui.pro/agents
curl -sI http://localhost:3000/en/agents   # 308 → https://heroui.pro/agents
curl -sI http://localhost:3000/cn/agents   # 308 → https://heroui.pro/agents
```

- [x] `pnpm --filter @heroui/docs typecheck` passes
- [ ] No React component or docs content changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b52739-9f7c-4558-9c82-f29be4fb1826?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b52739-9f7c-4558-9c82-f29be4fb1826&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

