### PR TITLE
fix(styles): restore native focus-visible selectors

### DIFF
--- a/packages/styles/components/accordion.css
+++ b/packages/styles/components/accordion.css
@@ -81,7 +81,7 @@
   }
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -21,7 +21,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -37,7 +37,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
     border-color: var(--field-border-focus);
@@ -85,7 +85,7 @@
     }
   }
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     background-color: var(--autocomplete-trigger-bg-focus);
   }
@@ -136,7 +136,6 @@
 
   &:focus,
   &:focus-visible,
-  &:focus-visible:not(:focus),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -61,7 +61,7 @@
 }
 
 /* Raise focused button so its outward focus ring + gap shows above adjacent buttons */
-.button-group .button:focus-visible:not(:focus),
+.button-group .button:focus-visible,
 .button-group .button[data-focus-visible="true"] {
   @apply z-10;
 }

--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -27,7 +27,7 @@
   color: var(--button-fg);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/calendar.css
+++ b/packages/styles/components/calendar.css
@@ -198,7 +198,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/close-button.css
+++ b/packages/styles/components/close-button.css
@@ -19,7 +19,7 @@
   @apply transform-gpu motion-reduce:transition-none;
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/color-picker.css
+++ b/packages/styles/components/color-picker.css
@@ -31,7 +31,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -56,7 +56,7 @@
   @apply flex flex-col gap-3;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/combo-box.css
+++ b/packages/styles/components/combo-box.css
@@ -70,7 +70,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply rounded ring-2 ring-focus ring-offset-2 ring-offset-background outline-none;
   }
@@ -104,7 +104,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/date-picker.css
+++ b/packages/styles/components/date-picker.css
@@ -23,7 +23,7 @@
   transition: box-shadow 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -46,7 +46,7 @@
   box-shadow: var(--shadow-overlay);
   border-radius: min(32px, calc(var(--radius) * 2.5));
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/date-range-picker.css
+++ b/packages/styles/components/date-range-picker.css
@@ -23,7 +23,7 @@
   transition: box-shadow 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -50,7 +50,7 @@
   box-shadow: var(--shadow-overlay);
   border-radius: min(32px, calc(var(--radius) * 2.5));
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/disclosure.css
+++ b/packages/styles/components/disclosure.css
@@ -12,7 +12,7 @@
   @apply inline-block no-highlight;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -20,7 +20,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -24,7 +24,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -54,7 +54,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/input.css
+++ b/packages/styles/components/input.css
@@ -31,7 +31,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 
@@ -75,7 +75,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -39,7 +39,7 @@
   }
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
 

--- a/packages/styles/components/list-box-item.css
+++ b/packages/styles/components/list-box-item.css
@@ -32,7 +32,7 @@
   }
 
   /* Focus visible state (keyboard focus only) */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -72,7 +72,7 @@
    ========================================================================== */
 
 .list-box-item__indicator {
-  @apply absolute top-1/2 end-2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-default-foreground;
+  @apply absolute end-2 top-1/2 flex size-4 shrink-0 -translate-y-1/2 items-center justify-center text-default-foreground;
 
   /**
    * Transitions

--- a/packages/styles/components/menu-item.css
+++ b/packages/styles/components/menu-item.css
@@ -41,7 +41,7 @@
   }
 
   /* Focus visible state (keyboard focus only) */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -20,7 +20,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -152,7 +152,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -86,7 +86,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/range-calendar.css
+++ b/packages/styles/components/range-calendar.css
@@ -205,7 +205,7 @@
   }
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply z-2;
 

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -48,7 +48,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
     border-color: var(--field-border-focus);
@@ -96,7 +96,7 @@
     }
   }
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     background-color: var(--select-trigger-bg-focus);
   }
@@ -186,7 +186,7 @@
   box-shadow: var(--shadow-overlay);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -164,7 +164,7 @@
   }
 
   /* Focus states - comprehensive fallback */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/textarea.css
+++ b/packages/styles/components/textarea.css
@@ -34,7 +34,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 
@@ -77,7 +77,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/toggle-button-group.css
+++ b/packages/styles/components/toggle-button-group.css
@@ -73,7 +73,7 @@
 }
 
 /* Override focus ring to use inset style so it stays within button bounds */
-.toggle-button-group .toggle-button:focus-visible:not(:focus),
+.toggle-button-group .toggle-button:focus-visible,
 .toggle-button-group .toggle-button[data-focus-visible="true"] {
   --tw-ring-offset-width: 0px;
   @apply ring-inset;

--- a/packages/styles/components/toggle-button.css
+++ b/packages/styles/components/toggle-button.css
@@ -35,7 +35,7 @@
   color: var(--toggle-button-fg);
 
   /* Focus state */
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -74,7 +74,7 @@
     box-shadow 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
 
-  &:focus-visible:not(:focus),
+  &:focus-visible,
   &[data-focus-visible="true"] {
     @apply status-focused;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6804

## 📝 Description

Replace the impossible `:focus-visible:not(:focus)` selector in package component styles with native `:focus-visible`, while retaining the React Aria `[data-focus-visible="true"]` path.

## ⛳️ Current behavior (updates)

`:focus-visible:not(:focus)` cannot match because every `:focus-visible` element is focused. Native anchors and buttons using exported HeroUI variants therefore receive no HeroUI keyboard focus ring.

## 🚀 New behavior

Native keyboard focus activates the existing focus styles through `:focus-visible`, while React Aria components continue to use `[data-focus-visible="true"]`. All package CSS copies of the impossible selector are corrected without changing their rule bodies.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] `pnpm --filter @heroui/styles build`
- [x] Built Button and Link CSS retain both `:focus-visible` and `[data-focus-visible="true"]`
- [x] `pnpm --filter @heroui/react exec vitest run button link` — 7 files, 64 tests passed
- [x] `pnpm lint` — passes with one pre-existing docs import-order warning
- [x] `pnpm typecheck`
- [x] Chromium Tab-focus demo for a native anchor using `buttonVariants` and a HeroUI Button
- [ ] `pnpm test` — all 122 files and 632 tests pass, but Vitest exits nonzero on two unrelated asynchronous `input-otp` `window is not defined` errors after completion

## 📝 Additional Information

The fix is intentionally limited to package CSS selectors that copied the same impossible pattern.

<a href="https://cursor.com/agents/bc-94ca5c7f-9c7b-4665-aeac-494aa6f20ea4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnative_anchor_and_heroui_button_tab_focus.mp4"><img src="https://cursor.com/artifacts/c/art-7c24409b-49b8-425d-ba2c-e9b3b9074b42" alt="native_anchor_and_heroui_button_tab_focus.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94ca5c7f-9c7b-4665-aeac-494aa6f20ea4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94ca5c7f-9c7b-4665-aeac-494aa6f20ea4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

