### PR TITLE
fix(docs): add accessible names to icon-only buttons in examples

### DIFF
--- a/apps/docs/content/docs/cn/native/components/(buttons)/button.mdx
+++ b/apps/docs/content/docs/cn/native/components/(buttons)/button.mdx
@@ -71,7 +71,7 @@ import { Button } from 'heroui-native';
 使用 `isIconOnly` 创建方形纯图标按钮。
 
 ```tsx
-<Button isIconOnly>
+<Button isIconOnly accessibilityLabel="喜欢">
   <Icon name="heart" size={18} />
 </Button>
 ```
@@ -277,17 +277,22 @@ export default function ButtonExample() {
       </Button>
 
       <View className="flex-row gap-4">
-        <Button size="sm" isIconOnly>
+        <Button size="sm" isIconOnly accessibilityLabel="喜欢">
           <Ionicons name="heart" size={16} color={themeColorAccentForeground} />
         </Button>
-        <Button size="sm" variant="secondary" isIconOnly>
+        <Button
+          size="sm"
+          variant="secondary"
+          isIconOnly
+          accessibilityLabel="收藏"
+        >
           <Ionicons
             name="bookmark"
             size={16}
             color={themeColorAccentSoftForeground}
           />
         </Button>
-        <Button size="sm" variant="danger" isIconOnly>
+        <Button size="sm" variant="danger" isIconOnly accessibilityLabel="删除">
           <Ionicons name="trash" size={16} color={themeColorDangerForeground} />
         </Button>
       </View>

--- a/apps/docs/content/docs/cn/react/components/(forms)/input-group.mdx
+++ b/apps/docs/content/docs/cn/react/components/(forms)/input-group.mdx
@@ -169,7 +169,7 @@ function Example() {
         </InputGroup.Prefix>
         <InputGroup.Input placeholder="name@email.com" />
         <InputGroup.Suffix>
-          <Button isIconOnly size="sm" variant="ghost">
+          <Button isIconOnly aria-label="Confirm" size="sm" variant="ghost">
             <Icon icon="gravity-ui:check" />
           </Button>
         </InputGroup.Suffix>

--- a/apps/docs/content/docs/cn/react/getting-started/(handbook)/composition.mdx
+++ b/apps/docs/content/docs/cn/react/getting-started/(handbook)/composition.mdx
@@ -282,7 +282,7 @@ function IconButton({ icon, label, ...props }) {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <Button isIconOnly {...props}>
+        <Button isIconOnly aria-label={label} {...props}>
           <Icon icon={icon} />
         </Button>
       </Tooltip.Trigger>

--- a/apps/docs/content/docs/cn/react/migration/(components)/button.mdx
+++ b/apps/docs/content/docs/cn/react/migration/(components)/button.mdx
@@ -130,10 +130,10 @@ export default function App() {
 <Tabs items={["v2", "v3"]}>
   <Tab value="v2">
     ```tsx
-    <Button isIconOnly color="danger" variant="flat">
+    <Button isIconOnly aria-label="Like" color="danger" variant="flat">
       <HeartIcon />
     </Button>
-    <Button isIconOnly color="primary" variant="bordered" size="sm">
+    <Button isIconOnly aria-label="Search" color="primary" variant="bordered" size="sm">
       <SearchIcon />
     </Button>
     ```
@@ -142,10 +142,10 @@ export default function App() {
     ```tsx
     import { Icon } from "@iconify/react";
 
-    <Button isIconOnly variant="danger-soft">
+    <Button isIconOnly aria-label="Like" variant="danger-soft">
       <Icon icon="gravity-ui:heart" />
     </Button>
-    <Button isIconOnly variant="secondary" size="sm">
+    <Button isIconOnly aria-label="Search" variant="secondary" size="sm">
       <Icon icon="gravity-ui:magnifier" />
     </Button>
     ```
@@ -254,7 +254,7 @@ export default function App() {
 <Tabs items={["v2", "v3"]}>
   <Tab value="v2">
     ```tsx
-    <Button isIconOnly color="danger">
+    <Button isIconOnly aria-label="Like" color="danger">
       <HeartIcon />
     </Button>
     ```
@@ -263,7 +263,7 @@ export default function App() {
     ```tsx
     import { Icon } from "@iconify/react";
 
-    <Button isIconOnly variant="danger">
+    <Button isIconOnly aria-label="Like" variant="danger">
       <Icon icon="gravity-ui:heart" />
     </Button>
     ```

--- a/apps/docs/content/docs/en/native/components/(buttons)/button.mdx
+++ b/apps/docs/content/docs/en/native/components/(buttons)/button.mdx
@@ -71,7 +71,7 @@ Combine icons with labels for enhanced visual communication.
 Create square icon-only buttons using the isIconOnly prop.
 
 ```tsx
-<Button isIconOnly>
+<Button isIconOnly accessibilityLabel="Like">
   <Icon name="heart" size={18} />
 </Button>
 ```
@@ -277,17 +277,27 @@ export default function ButtonExample() {
       </Button>
 
       <View className="flex-row gap-4">
-        <Button size="sm" isIconOnly>
+        <Button size="sm" isIconOnly accessibilityLabel="Like">
           <Ionicons name="heart" size={16} color={themeColorAccentForeground} />
         </Button>
-        <Button size="sm" variant="secondary" isIconOnly>
+        <Button
+          size="sm"
+          variant="secondary"
+          isIconOnly
+          accessibilityLabel="Bookmark"
+        >
           <Ionicons
             name="bookmark"
             size={16}
             color={themeColorAccentSoftForeground}
           />
         </Button>
-        <Button size="sm" variant="danger" isIconOnly>
+        <Button
+          size="sm"
+          variant="danger"
+          isIconOnly
+          accessibilityLabel="Delete"
+        >
           <Ionicons name="trash" size={16} color={themeColorDangerForeground} />
         </Button>
       </View>

--- a/apps/docs/content/docs/en/react/components/(forms)/input-group.mdx
+++ b/apps/docs/content/docs/en/react/components/(forms)/input-group.mdx
@@ -169,7 +169,7 @@ function Example() {
         </InputGroup.Prefix>
         <InputGroup.Input placeholder="name@email.com" />
         <InputGroup.Suffix>
-          <Button isIconOnly size="sm" variant="ghost">
+          <Button isIconOnly aria-label="Confirm" size="sm" variant="ghost">
             <Icon icon="gravity-ui:check" />
           </Button>
         </InputGroup.Suffix>

--- a/apps/docs/content/docs/en/react/getting-started/(handbook)/composition.mdx
+++ b/apps/docs/content/docs/en/react/getting-started/(handbook)/composition.mdx
@@ -282,7 +282,7 @@ function IconButton({ icon, label, ...props }) {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <Button isIconOnly {...props}>
+        <Button isIconOnly aria-label={label} {...props}>
           <Icon icon={icon} />
         </Button>
       </Tooltip.Trigger>

--- a/apps/docs/content/docs/en/react/migration/(components)/button.mdx
+++ b/apps/docs/content/docs/en/react/migration/(components)/button.mdx
@@ -130,10 +130,10 @@ The `isIconOnly` prop is available in both v2 and v3. It renders a square button
 <Tabs items={["v2", "v3"]}>
   <Tab value="v2">
     ```tsx
-    <Button isIconOnly color="danger" variant="flat">
+    <Button isIconOnly aria-label="Like" color="danger" variant="flat">
       <HeartIcon />
     </Button>
-    <Button isIconOnly color="primary" variant="bordered" size="sm">
+    <Button isIconOnly aria-label="Search" color="primary" variant="bordered" size="sm">
       <SearchIcon />
     </Button>
     ```
@@ -142,10 +142,10 @@ The `isIconOnly` prop is available in both v2 and v3. It renders a square button
     ```tsx
     import { Icon } from "@iconify/react";
 
-    <Button isIconOnly variant="danger-soft">
+    <Button isIconOnly aria-label="Like" variant="danger-soft">
       <Icon icon="gravity-ui:heart" />
     </Button>
-    <Button isIconOnly variant="secondary" size="sm">
+    <Button isIconOnly aria-label="Search" variant="secondary" size="sm">
       <Icon icon="gravity-ui:magnifier" />
     </Button>
     ```
@@ -254,7 +254,7 @@ The `isIconOnly` prop is available in both v2 and v3. It renders a square button
 <Tabs items={["v2", "v3"]}>
   <Tab value="v2">
     ```tsx
-    <Button isIconOnly color="danger">
+    <Button isIconOnly aria-label="Like" color="danger">
       <HeartIcon />
     </Button>
     ```
@@ -263,7 +263,7 @@ The `isIconOnly` prop is available in both v2 and v3. It renders a square button
     ```tsx
     import { Icon } from "@iconify/react";
 
-    <Button isIconOnly variant="danger">
+    <Button isIconOnly aria-label="Like" variant="danger">
       <Icon icon="gravity-ui:heart" />
     </Button>
     ```

--- a/apps/docs/src/demos/cn/button-group/basic.tsx
+++ b/apps/docs/src/demos/cn/button-group/basic.tsx
@@ -73,13 +73,13 @@ export function Basic() {
                 24
               </Chip>
             </Button>
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="更多复刻选项">
               <ButtonGroup.Separator />
               <ChevronDown />
             </Button>
           </ButtonGroup>
           <ButtonGroup variant="tertiary">
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="显示二维码">
               <QrCode />
             </Button>
             <Button>
@@ -92,7 +92,7 @@ export function Basic() {
               <ThumbsUp />
               <span className="text-xs font-semibold">2.4K</span>
             </Button>
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="点踩">
               <ButtonGroup.Separator />
               <ThumbsDown />
             </Button>
@@ -114,7 +114,7 @@ export function Basic() {
               <Pin />
               已置顶
             </Button>
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="更多置顶选项">
               <ButtonGroup.Separator />
               <ChevronDown />
             </Button>
@@ -174,18 +174,18 @@ export function Basic() {
       {/* 仅图标：对齐 */}
       <div className="flex flex-col gap-2">
         <ButtonGroup variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="左对齐">
             <TextAlignLeft />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="居中对齐">
             <ButtonGroup.Separator />
             <TextAlignCenter />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="右对齐">
             <ButtonGroup.Separator />
             <TextAlignRight />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="两端对齐">
             <ButtonGroup.Separator />
             <TextAlignJustify />
           </Button>

--- a/apps/docs/src/demos/cn/button-group/full-width.tsx
+++ b/apps/docs/src/demos/cn/button-group/full-width.tsx
@@ -16,14 +16,14 @@ export function FullWidth() {
         </Button>
       </ButtonGroup>
       <ButtonGroup fullWidth>
-        <Button isIconOnly>
+        <Button isIconOnly aria-label="左对齐">
           <TextAlignLeft />
         </Button>
-        <Button isIconOnly>
+        <Button isIconOnly aria-label="居中对齐">
           <ButtonGroup.Separator />
           <TextAlignCenter />
         </Button>
-        <Button isIconOnly>
+        <Button isIconOnly aria-label="右对齐">
           <ButtonGroup.Separator />
           <TextAlignRight />
         </Button>

--- a/apps/docs/src/demos/cn/button-group/orientation.tsx
+++ b/apps/docs/src/demos/cn/button-group/orientation.tsx
@@ -7,18 +7,18 @@ export function Orientation() {
       <div className="flex flex-col gap-2">
         <span className="text-sm text-muted">横向</span>
         <ButtonGroup orientation="horizontal" variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="左对齐">
             <TextAlignLeft />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="居中对齐">
             <ButtonGroup.Separator />
             <TextAlignCenter />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="右对齐">
             <ButtonGroup.Separator />
             <TextAlignRight />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="两端对齐">
             <ButtonGroup.Separator />
             <TextAlignJustify />
           </Button>
@@ -27,18 +27,18 @@ export function Orientation() {
       <div className="flex flex-col gap-2">
         <span className="text-sm text-muted">纵向</span>
         <ButtonGroup orientation="vertical" variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="左对齐">
             <TextAlignLeft />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="居中对齐">
             <ButtonGroup.Separator />
             <TextAlignCenter />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="右对齐">
             <ButtonGroup.Separator />
             <TextAlignRight />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="两端对齐">
             <ButtonGroup.Separator />
             <TextAlignJustify />
           </Button>

--- a/apps/docs/src/demos/cn/button-group/with-icons.tsx
+++ b/apps/docs/src/demos/cn/button-group/with-icons.tsx
@@ -26,14 +26,14 @@ export function WithIcons() {
       <div className="flex flex-col items-start gap-2">
         <p className="text-sm text-muted">仅图标按钮</p>
         <ButtonGroup variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="搜索">
             <Globe />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="添加">
             <ButtonGroup.Separator />
             <Plus />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="删除">
             <ButtonGroup.Separator />
             <TrashBin />
           </Button>

--- a/apps/docs/src/demos/cn/button/icon-only.tsx
+++ b/apps/docs/src/demos/cn/button/icon-only.tsx
@@ -4,13 +4,13 @@ import {Button} from "@heroui/react";
 export function IconOnly() {
   return (
     <div className="flex gap-3">
-      <Button isIconOnly variant="tertiary">
+      <Button isIconOnly aria-label="更多选项" variant="tertiary">
         <Ellipsis />
       </Button>
-      <Button isIconOnly variant="secondary">
+      <Button isIconOnly aria-label="设置" variant="secondary">
         <Gear />
       </Button>
-      <Button isIconOnly variant="danger">
+      <Button isIconOnly aria-label="删除" variant="danger">
         <TrashBin />
       </Button>
     </div>

--- a/apps/docs/src/demos/cn/popover/with-arrow.tsx
+++ b/apps/docs/src/demos/cn/popover/with-arrow.tsx
@@ -16,7 +16,7 @@ export function PopoverWithArrow() {
       </Popover>
 
       <Popover>
-        <Button isIconOnly variant="tertiary">
+        <Button isIconOnly aria-label="更多选项" variant="tertiary">
           <Ellipsis />
         </Button>
         <Popover.Content className="max-w-64" offset={10}>

--- a/apps/docs/src/demos/cn/table/custom-cells.tsx
+++ b/apps/docs/src/demos/cn/table/custom-cells.tsx
@@ -153,7 +153,7 @@ export function CustomCells() {
                 <Table.Cell className="font-medium">
                   <div className="flex items-center gap-2">
                     #{user.id.toString()}{" "}
-                    <Button isIconOnly size="sm" variant="ghost">
+                    <Button isIconOnly aria-label={`复制 ID #${user.id}`} size="sm" variant="ghost">
                       <Icon className="size-4 text-muted" icon="gravity-ui:copy" />
                     </Button>
                   </div>
@@ -183,13 +183,28 @@ export function CustomCells() {
                 </Table.Cell>
                 <Table.Cell>
                   <div className="flex items-center gap-1">
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button
+                      isIconOnly
+                      aria-label={`查看 ${user.name}`}
+                      size="sm"
+                      variant="tertiary"
+                    >
                       <Icon className="size-4" icon="gravity-ui:eye" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button
+                      isIconOnly
+                      aria-label={`编辑 ${user.name}`}
+                      size="sm"
+                      variant="tertiary"
+                    >
                       <Icon className="size-4" icon="gravity-ui:pencil" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="danger-soft">
+                    <Button
+                      isIconOnly
+                      aria-label={`删除 ${user.name}`}
+                      size="sm"
+                      variant="danger-soft"
+                    >
                       <Icon className="size-4" icon="gravity-ui:trash-bin" />
                     </Button>
                   </div>

--- a/apps/docs/src/demos/cn/tooltip/basic.tsx
+++ b/apps/docs/src/demos/cn/tooltip/basic.tsx
@@ -12,7 +12,7 @@ export function TooltipBasic() {
       </Tooltip>
 
       <Tooltip delay={0}>
-        <Button isIconOnly variant="tertiary">
+        <Button isIconOnly aria-label="更多信息" variant="tertiary">
           <CircleInfo />
         </Button>
         <Tooltip.Content>

--- a/apps/docs/src/demos/cn/tooltip/render-function.tsx
+++ b/apps/docs/src/demos/cn/tooltip/render-function.tsx
@@ -14,7 +14,7 @@ export function RenderFunction() {
       </Tooltip>
 
       <Tooltip delay={0}>
-        <Button isIconOnly variant="tertiary">
+        <Button isIconOnly aria-label="更多信息" variant="tertiary">
           <CircleInfo />
         </Button>
         <Tooltip.Content render={(props) => <div {...props} data-custom="foo" />}>

--- a/apps/docs/src/demos/en/button-group/basic.tsx
+++ b/apps/docs/src/demos/en/button-group/basic.tsx
@@ -80,13 +80,13 @@ export function Basic() {
                 24
               </Chip>
             </Button>
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="More fork options">
               <ButtonGroup.Separator />
               <ChevronDown />
             </Button>
           </ButtonGroup>
           <ButtonGroup variant="tertiary">
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="Show QR code">
               <QrCode />
             </Button>
             <Button>
@@ -99,7 +99,7 @@ export function Basic() {
               <ThumbsUp />
               <span className="text-xs font-semibold">2.4K</span>
             </Button>
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="Dislike">
               <ButtonGroup.Separator />
               <ThumbsDown />
             </Button>
@@ -121,7 +121,7 @@ export function Basic() {
               <Pin />
               Pinned
             </Button>
-            <Button isIconOnly>
+            <Button isIconOnly aria-label="More pin options">
               <ButtonGroup.Separator />
               <ChevronDown />
             </Button>
@@ -181,18 +181,18 @@ export function Basic() {
       {/* Icon-Only Alignment Button Group */}
       <div className="flex flex-col gap-2">
         <ButtonGroup variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align left">
             <TextAlignLeft />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align center">
             <ButtonGroup.Separator />
             <TextAlignCenter />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align right">
             <ButtonGroup.Separator />
             <TextAlignRight />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Justify">
             <ButtonGroup.Separator />
             <TextAlignJustify />
           </Button>

--- a/apps/docs/src/demos/en/button-group/full-width.tsx
+++ b/apps/docs/src/demos/en/button-group/full-width.tsx
@@ -16,14 +16,14 @@ export function FullWidth() {
         </Button>
       </ButtonGroup>
       <ButtonGroup fullWidth>
-        <Button isIconOnly>
+        <Button isIconOnly aria-label="Align left">
           <TextAlignLeft />
         </Button>
-        <Button isIconOnly>
+        <Button isIconOnly aria-label="Align center">
           <ButtonGroup.Separator />
           <TextAlignCenter />
         </Button>
-        <Button isIconOnly>
+        <Button isIconOnly aria-label="Align right">
           <ButtonGroup.Separator />
           <TextAlignRight />
         </Button>

--- a/apps/docs/src/demos/en/button-group/orientation.tsx
+++ b/apps/docs/src/demos/en/button-group/orientation.tsx
@@ -7,18 +7,18 @@ export function Orientation() {
       <div className="flex flex-col gap-2">
         <span className="text-sm text-muted">Horizontal</span>
         <ButtonGroup orientation="horizontal" variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align left">
             <TextAlignLeft />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align center">
             <ButtonGroup.Separator />
             <TextAlignCenter />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align right">
             <ButtonGroup.Separator />
             <TextAlignRight />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Justify">
             <ButtonGroup.Separator />
             <TextAlignJustify />
           </Button>
@@ -27,18 +27,18 @@ export function Orientation() {
       <div className="flex flex-col gap-2">
         <span className="text-sm text-muted">Vertical</span>
         <ButtonGroup orientation="vertical" variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align left">
             <TextAlignLeft />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align center">
             <ButtonGroup.Separator />
             <TextAlignCenter />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Align right">
             <ButtonGroup.Separator />
             <TextAlignRight />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Justify">
             <ButtonGroup.Separator />
             <TextAlignJustify />
           </Button>

--- a/apps/docs/src/demos/en/button-group/with-icons.tsx
+++ b/apps/docs/src/demos/en/button-group/with-icons.tsx
@@ -26,14 +26,14 @@ export function WithIcons() {
       <div className="flex flex-col items-start gap-2">
         <p className="text-sm text-muted">Icon only buttons</p>
         <ButtonGroup variant="tertiary">
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Search">
             <Globe />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Add">
             <ButtonGroup.Separator />
             <Plus />
           </Button>
-          <Button isIconOnly>
+          <Button isIconOnly aria-label="Delete">
             <ButtonGroup.Separator />
             <TrashBin />
           </Button>

--- a/apps/docs/src/demos/en/button/icon-only.tsx
+++ b/apps/docs/src/demos/en/button/icon-only.tsx
@@ -4,13 +4,13 @@ import {Button} from "@heroui/react";
 export function IconOnly() {
   return (
     <div className="flex gap-3">
-      <Button isIconOnly variant="tertiary">
+      <Button isIconOnly aria-label="More options" variant="tertiary">
         <Ellipsis />
       </Button>
-      <Button isIconOnly variant="secondary">
+      <Button isIconOnly aria-label="Settings" variant="secondary">
         <Gear />
       </Button>
-      <Button isIconOnly variant="danger">
+      <Button isIconOnly aria-label="Delete" variant="danger">
         <TrashBin />
       </Button>
     </div>

--- a/apps/docs/src/demos/en/popover/with-arrow.tsx
+++ b/apps/docs/src/demos/en/popover/with-arrow.tsx
@@ -18,7 +18,7 @@ export function PopoverWithArrow() {
       </Popover>
 
       <Popover>
-        <Button isIconOnly variant="tertiary">
+        <Button isIconOnly aria-label="More options" variant="tertiary">
           <Ellipsis />
         </Button>
         <Popover.Content className="max-w-64" offset={10}>

--- a/apps/docs/src/demos/en/table/custom-cells.tsx
+++ b/apps/docs/src/demos/en/table/custom-cells.tsx
@@ -153,7 +153,7 @@ export function CustomCells() {
                 <Table.Cell className="font-medium">
                   <div className="flex items-center gap-2">
                     #{user.id.toString()}{" "}
-                    <Button isIconOnly size="sm" variant="ghost">
+                    <Button isIconOnly aria-label={`Copy ID #${user.id}`} size="sm" variant="ghost">
                       <Icon className="size-4 text-muted" icon="gravity-ui:copy" />
                     </Button>
                   </div>
@@ -183,13 +183,28 @@ export function CustomCells() {
                 </Table.Cell>
                 <Table.Cell>
                   <div className="flex items-center gap-1">
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button
+                      isIconOnly
+                      aria-label={`View ${user.name}`}
+                      size="sm"
+                      variant="tertiary"
+                    >
                       <Icon className="size-4" icon="gravity-ui:eye" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="tertiary">
+                    <Button
+                      isIconOnly
+                      aria-label={`Edit ${user.name}`}
+                      size="sm"
+                      variant="tertiary"
+                    >
                       <Icon className="size-4" icon="gravity-ui:pencil" />
                     </Button>
-                    <Button isIconOnly size="sm" variant="danger-soft">
+                    <Button
+                      isIconOnly
+                      aria-label={`Delete ${user.name}`}
+                      size="sm"
+                      variant="danger-soft"
+                    >
                       <Icon className="size-4" icon="gravity-ui:trash-bin" />
                     </Button>
                   </div>

--- a/apps/docs/src/demos/en/tooltip/basic.tsx
+++ b/apps/docs/src/demos/en/tooltip/basic.tsx
@@ -12,7 +12,7 @@ export function TooltipBasic() {
       </Tooltip>
 
       <Tooltip delay={0}>
-        <Button isIconOnly variant="tertiary">
+        <Button isIconOnly aria-label="More information" variant="tertiary">
           <CircleInfo />
         </Button>
         <Tooltip.Content>

--- a/apps/docs/src/demos/en/tooltip/render-function.tsx
+++ b/apps/docs/src/demos/en/tooltip/render-function.tsx
@@ -14,7 +14,7 @@ export function RenderFunction() {
       </Tooltip>
 
       <Tooltip delay={0}>
-        <Button isIconOnly variant="tertiary">
+        <Button isIconOnly aria-label="More information" variant="tertiary">
           <CircleInfo />
         </Button>
         <Tooltip.Content render={(props) => <div {...props} data-custom="foo" />}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6427

## 📝 Description

<!--- Add a brief description -->

Icon-only buttons across the documentation examples rendered an SVG with no aria-label, aria-labelledby, or visible text, so screen readers announced them as a bare "button". This is a WCAG 2.1 Level A failure under SC 4.1.2 (Name, Role, Value), and because these examples are what developers copy, the gap propagated into downstream apps.

Label all 88 unlabeled icon-only buttons across 26 files:
- table/custom-cells: the 4 row actions (copy, view, edit, delete) reported in the issue. Labels carry row context, e.g. `Edit ${user.name}`, so the 5 repeated rows are distinguishable rather than 5 identical "Edit" buttons.
- button/icon-only and the button-group demos (basic, orientation,
  full-width, with-icons).
- tooltip and popover triggers. A tooltip supplies aria-describedby, which is a description and not a name, so these triggers were nameless despite having visible tooltip text.
- MDX samples in input-group, the composition handbook, and the react and native migration pages.

Labels follow each file's own localization convention: cn/ demos are fully translated so they get Chinese labels, while cn/ React MDX keeps code-sample strings in English to match the surrounding snippets. The native docs use accessibilityLabel rather than aria-label.

Docs-only change; Button already forwarded aria-label correctly.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## ✅ Testing

- [ ] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [ ] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [ ] `pnpm test` passes locally

## 📝 Additional Information
