### PR TITLE
fix(react): render nested Label as span in Checkbox/Switch/Radio content

### DIFF
--- a/apps/docs/src/demos/cn/checkbox/render-function.tsx
+++ b/apps/docs/src/demos/cn/checkbox/render-function.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import {Checkbox, Label} from "@heroui/react";
+import {Checkbox} from "@heroui/react";
 
 export function RenderFunction() {
   return (
-    <div className="flex items-center gap-3">
-      <Checkbox id="basic-terms" render={(props) => <div {...props} data-custom="bar" />}>
-        <Checkbox.Content>
-          <Checkbox.Control>
-            <Checkbox.Indicator />
-          </Checkbox.Control>
-        </Checkbox.Content>
-      </Checkbox>
-      <Label htmlFor="basic-terms">接受条款与条件</Label>
-    </div>
+    <Checkbox render={(props) => <div {...props} data-custom="bar" />}>
+      <Checkbox.Content>
+        <Checkbox.Control>
+          <Checkbox.Indicator />
+        </Checkbox.Control>
+        接受条款与条件
+      </Checkbox.Content>
+    </Checkbox>
   );
 }

--- a/apps/docs/src/demos/cn/switch/custom-styles.tsx
+++ b/apps/docs/src/demos/cn/switch/custom-styles.tsx
@@ -10,7 +10,7 @@ export function CustomStyles() {
           <Switch.Thumb />
         </Switch.Control>
         <div className="flex flex-col gap-0.5">
-          <Label htmlFor="autosave">自动保存草稿</Label>
+          <Label>自动保存草稿</Label>
           <Description>输入时会自动保存更改。</Description>
         </div>
       </Switch.Content>

--- a/apps/docs/src/demos/en/checkbox/render-function.tsx
+++ b/apps/docs/src/demos/en/checkbox/render-function.tsx
@@ -1,18 +1,16 @@
 "use client";
 
-import {Checkbox, Label} from "@heroui/react";
+import {Checkbox} from "@heroui/react";
 
 export function RenderFunction() {
   return (
-    <div className="flex items-center gap-3">
-      <Checkbox id="basic-terms" render={(props) => <div {...props} data-custom="bar" />}>
-        <Checkbox.Content>
-          <Checkbox.Control>
-            <Checkbox.Indicator />
-          </Checkbox.Control>
-        </Checkbox.Content>
-      </Checkbox>
-      <Label htmlFor="basic-terms">Accept terms and conditions</Label>
-    </div>
+    <Checkbox render={(props) => <div {...props} data-custom="bar" />}>
+      <Checkbox.Content>
+        <Checkbox.Control>
+          <Checkbox.Indicator />
+        </Checkbox.Control>
+        Accept terms and conditions
+      </Checkbox.Content>
+    </Checkbox>
   );
 }

--- a/apps/docs/src/demos/en/switch/custom-styles.tsx
+++ b/apps/docs/src/demos/en/switch/custom-styles.tsx
@@ -10,7 +10,7 @@ export function CustomStyles() {
           <Switch.Thumb />
         </Switch.Control>
         <div className="flex flex-col gap-0.5">
-          <Label htmlFor="autosave">Auto-save drafts</Label>
+          <Label>Auto-save drafts</Label>
           <Description>Changes are saved as you type.</Description>
         </div>
       </Switch.Content>

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -14,6 +14,7 @@ import {
   CheckboxButton as CheckboxButtonPrimitive,
   CheckboxField as CheckboxFieldPrimitive,
 } from "react-aria-components/Checkbox";
+import {LabelContext} from "react-aria-components/Label";
 
 import {composeSlotClassName, composeTwRenderProps} from "../../utils/compose";
 import {dom} from "../../utils/dom";
@@ -75,7 +76,11 @@ const CheckboxContent = ({children, className, ...props}: CheckboxContentProps) 
       {...props}
       className={composeTwRenderProps(className, slots?.content())}
     >
-      {children}
+      {(state) => (
+        <LabelContext value={{elementType: "span"}}>
+          {typeof children === "function" ? children(state) : children}
+        </LabelContext>
+      )}
     </CheckboxButtonPrimitive>
   );
 };

--- a/packages/react/src/components/radio/radio.tsx
+++ b/packages/react/src/components/radio/radio.tsx
@@ -6,6 +6,7 @@ import type {RadioButtonRenderProps, RadioFieldRenderProps} from "react-aria-com
 
 import {radioVariants} from "@heroui/styles";
 import React, {createContext, use} from "react";
+import {LabelContext} from "react-aria-components/Label";
 import {
   RadioButton as RadioButtonPrimitive,
   RadioField as RadioFieldPrimitive,
@@ -64,7 +65,11 @@ const RadioContent = ({children, className, ...props}: RadioContentProps) => {
       {...props}
       className={composeTwRenderProps(className, slots?.content())}
     >
-      {children}
+      {(state) => (
+        <LabelContext value={{elementType: "span"}}>
+          {typeof children === "function" ? children(state) : children}
+        </LabelContext>
+      )}
     </RadioButtonPrimitive>
   );
 };

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -7,6 +7,7 @@ import type {SwitchButtonRenderProps, SwitchFieldRenderProps} from "react-aria-c
 
 import {switchVariants} from "@heroui/styles";
 import React, {createContext, use} from "react";
+import {LabelContext} from "react-aria-components/Label";
 import {
   SwitchButton as SwitchButtonPrimitive,
   SwitchField as SwitchFieldPrimitive,
@@ -63,7 +64,11 @@ const SwitchContent = ({children, className, ...props}: SwitchContentProps) => {
       {...props}
       className={composeTwRenderProps(className, slots?.content())}
     >
-      {children}
+      {(state) => (
+        <LabelContext value={{elementType: "span"}}>
+          {typeof children === "function" ? children(state) : children}
+        </LabelContext>
+      )}
     </SwitchButtonPrimitive>
   );
 };

--- a/packages/react/tests/components/checkbox-group/checkbox-group.test.tsx
+++ b/packages/react/tests/components/checkbox-group/checkbox-group.test.tsx
@@ -67,6 +67,38 @@ describe("CheckboxGroup", () => {
     expect(screen.getByText("Choose all that apply")).toBeInTheDocument();
   });
 
+  it("keeps item Label ids from colliding with the group Label id", () => {
+    render(
+      <CheckboxGroup name="interests">
+        <Label>Select your interests</Label>
+        <Checkbox value="coding">
+          <Checkbox.Content>
+            <Checkbox.Control>
+              <Checkbox.Indicator />
+            </Checkbox.Control>
+            <Label>Coding</Label>
+          </Checkbox.Content>
+        </Checkbox>
+        <Checkbox value="design">
+          <Checkbox.Content>
+            <Checkbox.Control>
+              <Checkbox.Indicator />
+            </Checkbox.Control>
+            <Label>Design</Label>
+          </Checkbox.Content>
+        </Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const groupLabelId = screen.getByText("Select your interests").id;
+
+    expect(groupLabelId).toBeTruthy();
+    expect(screen.getByText("Coding")).not.toHaveAttribute("id", groupLabelId);
+    expect(screen.getByText("Design")).not.toHaveAttribute("id", groupLabelId);
+    expect(screen.getByRole("group", {name: "Select your interests"})).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", {name: "Coding"})).toBeInTheDocument();
+  });
+
   it("exposes variant BEM modifier", () => {
     renderInterests({variant: "secondary"});
 

--- a/packages/react/tests/components/checkbox/checkbox.test.tsx
+++ b/packages/react/tests/components/checkbox/checkbox.test.tsx
@@ -41,6 +41,17 @@ describe("Checkbox", () => {
     expect(document.querySelector('[data-slot="checkbox-indicator"]')).not.toBeNull();
   });
 
+  it("renders a nested Label as a span so the content label has no descendant label", () => {
+    renderCheckbox();
+
+    const label = screen.getByText("Accept terms");
+    const content = document.querySelector('[data-slot="checkbox-content"]');
+
+    expect(label.tagName).toBe("SPAN");
+    expect(content?.tagName).toBe("LABEL");
+    expect(content?.querySelector("label")).toBeNull();
+  });
+
   it("supports data attribute passthrough on the field", () => {
     render(
       <Checkbox data-testid="terms">

--- a/packages/react/tests/components/radio-group/radio-group.test.tsx
+++ b/packages/react/tests/components/radio-group/radio-group.test.tsx
@@ -74,6 +74,38 @@ describe("RadioGroup", () => {
     );
   });
 
+  it("keeps item Label ids from colliding with the group Label id", () => {
+    render(
+      <RadioGroup name="plan">
+        <Label>Plan</Label>
+        <Radio value="a">
+          <Radio.Content>
+            <Radio.Control>
+              <Radio.Indicator />
+            </Radio.Control>
+            <Label>Basic</Label>
+          </Radio.Content>
+        </Radio>
+        <Radio value="b">
+          <Radio.Content>
+            <Radio.Control>
+              <Radio.Indicator />
+            </Radio.Control>
+            <Label>Premium</Label>
+          </Radio.Content>
+        </Radio>
+      </RadioGroup>,
+    );
+
+    const groupLabelId = screen.getByText("Plan").id;
+
+    expect(groupLabelId).toBeTruthy();
+    expect(screen.getByText("Basic")).not.toHaveAttribute("id", groupLabelId);
+    expect(screen.getByText("Premium")).not.toHaveAttribute("id", groupLabelId);
+    expect(screen.getByRole("radiogroup", {name: "Plan"})).toBeInTheDocument();
+    expect(screen.getByRole("radio", {name: "Basic"})).toBeInTheDocument();
+  });
+
   it("supports selection via createTester", async () => {
     const onChange = vi.fn();
 

--- a/packages/react/tests/components/switch/switch.test.tsx
+++ b/packages/react/tests/components/switch/switch.test.tsx
@@ -41,6 +41,17 @@ describe("Switch", () => {
     expect(document.querySelector('[data-slot="switch-thumb"]')).not.toBeNull();
   });
 
+  it("renders a nested Label as a span so the content label has no descendant label", () => {
+    renderSwitch();
+
+    const label = screen.getByText("Enable notifications");
+    const content = document.querySelector('[data-slot="switch-content"]');
+
+    expect(label.tagName).toBe("SPAN");
+    expect(content?.tagName).toBe("LABEL");
+    expect(content?.querySelector("label")).toBeNull();
+  });
+
   it("supports data attribute passthrough on the field", () => {
     render(
       <Switch data-testid="notifications">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #6434

## 📝 Description

<!--- Add a brief description -->

`Checkbox.Content`, `Switch.Content`, and `Radio.Content` map to React Aria's `CheckboxButton` / `SwitchButton` / `RadioButton`, which render a `<label>` wrapping the visually-hidden `<input>`. None of the `*Field` or `*Button` primitives provide `LabelContext`, so a `Label` composed inside them fell back to `elementType: "label"`.

Each `*.Content` now provides its own `LabelContext` with `elementType: "span"`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Two problems, both verified by rendering the documented compositions:

**Nested `<label>`.** A `Label` inside `*.Content` renders a `<label>` inside a `<label>`, which the HTML spec disallows — `<label>`'s content model is phrasing content with no descendant label elements.
```html
<label data-slot="switch-content">
  <span><input id="autosave" role="switch" type="checkbox"></span>
  <span class="switch__control">…</span>
  <label class="label" for="autosave">Auto-save drafts</label>
</label>
```
This is the composition the docs recommend ("Put `Checkbox.Control` and the `Label` inside it"). Most demos sidestep it by passing the label as plain text children, but the `switch/custom-styles` demo shipped with it.

**Duplicate IDs in groups.** `CheckboxGroup` and `RadioGroup` provide `LabelContext` carrying their own `labelProps`. Since `*Field` never overrides it, every item `Label` reused the group label's `id`:
```html
<div role="group" aria-labelledby="react-aria-_r_7_">
  <span class="label" id="react-aria-_r_7_">Interests</span>
  <span class="label" id="react-aria-_r_7_">Coding</span>
</div>
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

A `Label` inside `*.Content` renders as a `<span>`. Association is unaffected — the `<input>` is already a descendant of the wrapping clickable `<label>`, so it is implicit and `htmlFor` is unnecessary. The fresh context also stops group `labelProps` (id and slot ref) from leaking into item labels, so IDs are unique and the group's `aria-labelledby` resolves to its own label alone.

Not changed, because it was already fixed by the `*Field` migration in #6614: the `aria-describedby` / duplicate-description part of the issue thread. Each `*Field` provides its own `TextContext`, so item descriptions get unique IDs and `useCheckboxGroupItem` appends the group description after the item's own.


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

## 📝 Additional Information
