### PR TITLE
fix(autocomplete): label example search fields

### DIFF
--- a/apps/docs/src/demos/cn/autocomplete/allows-empty-collection.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/allows-empty-collection.tsx
@@ -20,7 +20,7 @@ export function AllowsEmptyCollection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/asynchronous-filtering.tsx
@@ -38,7 +38,13 @@ export function AsynchronousFiltering() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="搜索角色"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索角色…" />

--- a/apps/docs/src/demos/cn/autocomplete/controlled-multiple.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/controlled-multiple.tsx
@@ -35,7 +35,7 @@ export function ControlledMultiple() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/controlled-open-state.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/controlled-open-state.tsx
@@ -41,7 +41,7 @@ export function ControlledOpenState() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/controlled.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/controlled.tsx
@@ -37,7 +37,7 @@ export function Controlled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/custom-indicator.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/custom-indicator.tsx
@@ -37,7 +37,7 @@ export function CustomIndicator() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/custom-styles.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/custom-styles.tsx
@@ -79,7 +79,7 @@ export function CustomStyles() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover className="overflow-hidden rounded-xl border border-border/80 bg-surface shadow-xl ring-1 ring-black/3 dark:border-border/90 dark:bg-surface dark:ring-white/5">
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="按姓名或角色搜索" name="search" variant="secondary">
               <SearchField.Group className="border-b border-separator bg-surface-secondary/50">
                 <SearchField.SearchIcon className="text-muted" />
                 <SearchField.Input placeholder="按姓名或角色搜索..." />

--- a/apps/docs/src/demos/cn/autocomplete/default.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索选项" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/cn/autocomplete/disabled.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/disabled.tsx
@@ -40,7 +40,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />
@@ -73,7 +73,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索国家" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索国家…" />

--- a/apps/docs/src/demos/cn/autocomplete/email-recipients.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/email-recipients.tsx
@@ -73,7 +73,7 @@ export function EmailRecipients() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索邮箱" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索邮箱…" />

--- a/apps/docs/src/demos/cn/autocomplete/full-width.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/full-width.tsx
@@ -44,7 +44,7 @@ export function FullWidth() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/location-search.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/location-search.tsx
@@ -61,7 +61,7 @@ export function LocationSearch() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={customFilter}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索城市" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索城市…" />

--- a/apps/docs/src/demos/cn/autocomplete/multiple-select.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/multiple-select.tsx
@@ -73,7 +73,7 @@ export function MultipleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索选项" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/cn/autocomplete/on-surface.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/on-surface.tsx
@@ -44,7 +44,7 @@ export function OnSurface() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/required.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/required.tsx
@@ -63,7 +63,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索州名…" />
@@ -97,7 +97,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="搜索国家" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="搜索国家…" />

--- a/apps/docs/src/demos/cn/autocomplete/tag-group-selection.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/tag-group-selection.tsx
@@ -75,7 +75,7 @@ export function TagGroupSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索标签" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索标签…" />

--- a/apps/docs/src/demos/cn/autocomplete/user-selection-multiple.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/user-selection-multiple.tsx
@@ -113,7 +113,7 @@ export function UserSelectionMultiple() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索用户" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索用户…" />

--- a/apps/docs/src/demos/cn/autocomplete/user-selection.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/user-selection.tsx
@@ -102,7 +102,7 @@ export function UserSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索用户" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索用户…" />

--- a/apps/docs/src/demos/cn/autocomplete/variants.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/variants.tsx
@@ -57,7 +57,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索选项" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />
@@ -91,7 +91,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索选项" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />
@@ -156,7 +156,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索选项" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />
@@ -216,7 +216,7 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField autoFocus aria-label="搜索选项" name="search" variant="secondary">
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="搜索…" />

--- a/apps/docs/src/demos/cn/autocomplete/virtualization.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/virtualization.tsx
@@ -115,7 +115,13 @@ export function Virtualization() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="搜索用户"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索用户…" />

--- a/apps/docs/src/demos/cn/autocomplete/with-description.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/with-description.tsx
@@ -42,7 +42,7 @@ export function WithDescription() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索州名" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索州名…" />

--- a/apps/docs/src/demos/cn/autocomplete/with-disabled-options.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/with-disabled-options.tsx
@@ -26,7 +26,7 @@ export function WithDisabledOptions() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索动物" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索动物…" />

--- a/apps/docs/src/demos/cn/autocomplete/with-sections.tsx
+++ b/apps/docs/src/demos/cn/autocomplete/with-sections.tsx
@@ -34,7 +34,7 @@ export function WithSections() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="搜索国家" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="搜索国家…" />

--- a/apps/docs/src/demos/en/autocomplete/allows-empty-collection.tsx
+++ b/apps/docs/src/demos/en/autocomplete/allows-empty-collection.tsx
@@ -20,7 +20,7 @@ export function AllowsEmptyCollection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/asynchronous-filtering.tsx
+++ b/apps/docs/src/demos/en/autocomplete/asynchronous-filtering.tsx
@@ -38,7 +38,13 @@ export function AsynchronousFiltering() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="Search characters"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search characters..." />

--- a/apps/docs/src/demos/en/autocomplete/controlled-multiple.tsx
+++ b/apps/docs/src/demos/en/autocomplete/controlled-multiple.tsx
@@ -35,7 +35,7 @@ export function ControlledMultiple() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/controlled-open-state.tsx
+++ b/apps/docs/src/demos/en/autocomplete/controlled-open-state.tsx
@@ -41,7 +41,7 @@ export function ControlledOpenState() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/controlled.tsx
+++ b/apps/docs/src/demos/en/autocomplete/controlled.tsx
@@ -37,7 +37,7 @@ export function Controlled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/custom-indicator.tsx
+++ b/apps/docs/src/demos/en/autocomplete/custom-indicator.tsx
@@ -37,7 +37,7 @@ export function CustomIndicator() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/custom-styles.tsx
+++ b/apps/docs/src/demos/en/autocomplete/custom-styles.tsx
@@ -79,7 +79,12 @@ export function CustomStyles() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover className="overflow-hidden rounded-xl border border-border/80 bg-surface shadow-xl ring-1 ring-black/3 dark:border-border/90 dark:bg-surface dark:ring-white/5">
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField
+              autoFocus
+              aria-label="Search by name or role"
+              name="search"
+              variant="secondary"
+            >
               <SearchField.Group className="border-b border-separator bg-surface-secondary/50">
                 <SearchField.SearchIcon className="text-muted" />
                 <SearchField.Input placeholder="Search by name or role..." />

--- a/apps/docs/src/demos/en/autocomplete/default.tsx
+++ b/apps/docs/src/demos/en/autocomplete/default.tsx
@@ -73,7 +73,7 @@ export default function Default() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search options" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/en/autocomplete/disabled.tsx
+++ b/apps/docs/src/demos/en/autocomplete/disabled.tsx
@@ -40,7 +40,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -73,7 +73,7 @@ export function Disabled() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search countries" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />

--- a/apps/docs/src/demos/en/autocomplete/email-recipients.tsx
+++ b/apps/docs/src/demos/en/autocomplete/email-recipients.tsx
@@ -73,7 +73,7 @@ export function EmailRecipients() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search emails" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search emails..." />

--- a/apps/docs/src/demos/en/autocomplete/full-width.tsx
+++ b/apps/docs/src/demos/en/autocomplete/full-width.tsx
@@ -44,7 +44,7 @@ export function FullWidth() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/location-search.tsx
+++ b/apps/docs/src/demos/en/autocomplete/location-search.tsx
@@ -61,7 +61,7 @@ export function LocationSearch() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={customFilter}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search cities" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search cities..." />

--- a/apps/docs/src/demos/en/autocomplete/multiple-select.tsx
+++ b/apps/docs/src/demos/en/autocomplete/multiple-select.tsx
@@ -73,7 +73,7 @@ export function MultipleSelect() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search options" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/en/autocomplete/on-surface.tsx
+++ b/apps/docs/src/demos/en/autocomplete/on-surface.tsx
@@ -44,7 +44,7 @@ export function OnSurface() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/required.tsx
+++ b/apps/docs/src/demos/en/autocomplete/required.tsx
@@ -63,7 +63,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -97,7 +97,7 @@ export function Required() {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search countries" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />

--- a/apps/docs/src/demos/en/autocomplete/tag-group-selection.tsx
+++ b/apps/docs/src/demos/en/autocomplete/tag-group-selection.tsx
@@ -75,7 +75,7 @@ export function TagGroupSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search tags" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search tags..." />

--- a/apps/docs/src/demos/en/autocomplete/user-selection-multiple.tsx
+++ b/apps/docs/src/demos/en/autocomplete/user-selection-multiple.tsx
@@ -113,7 +113,7 @@ export function UserSelectionMultiple() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search users" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/en/autocomplete/user-selection.tsx
+++ b/apps/docs/src/demos/en/autocomplete/user-selection.tsx
@@ -102,7 +102,7 @@ export function UserSelection() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search users" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/en/autocomplete/variants.tsx
+++ b/apps/docs/src/demos/en/autocomplete/variants.tsx
@@ -57,7 +57,12 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField
+                  autoFocus
+                  aria-label="Search options"
+                  name="search"
+                  variant="secondary"
+                >
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -91,7 +96,12 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField
+                  autoFocus
+                  aria-label="Search options"
+                  name="search"
+                  variant="secondary"
+                >
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -156,7 +166,12 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField
+                  autoFocus
+                  aria-label="Search options"
+                  name="search"
+                  variant="secondary"
+                >
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />
@@ -216,7 +231,12 @@ export function Variants() {
             </Autocomplete.Trigger>
             <Autocomplete.Popover>
               <Autocomplete.Filter filter={contains}>
-                <SearchField autoFocus name="search" variant="secondary">
+                <SearchField
+                  autoFocus
+                  aria-label="Search options"
+                  name="search"
+                  variant="secondary"
+                >
                   <SearchField.Group>
                     <SearchField.SearchIcon />
                     <SearchField.Input placeholder="Search..." />

--- a/apps/docs/src/demos/en/autocomplete/virtualization.tsx
+++ b/apps/docs/src/demos/en/autocomplete/virtualization.tsx
@@ -115,7 +115,13 @@ export function Virtualization() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
-          <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+          <SearchField
+            autoFocus
+            aria-label="Search users"
+            className="sticky top-0 z-10"
+            name="search"
+            variant="secondary"
+          >
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search users..." />

--- a/apps/docs/src/demos/en/autocomplete/with-description.tsx
+++ b/apps/docs/src/demos/en/autocomplete/with-description.tsx
@@ -42,7 +42,7 @@ export function WithDescription() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search states..." />

--- a/apps/docs/src/demos/en/autocomplete/with-disabled-options.tsx
+++ b/apps/docs/src/demos/en/autocomplete/with-disabled-options.tsx
@@ -26,7 +26,7 @@ export function WithDisabledOptions() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search animals" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search animals..." />

--- a/apps/docs/src/demos/en/autocomplete/with-sections.tsx
+++ b/apps/docs/src/demos/en/autocomplete/with-sections.tsx
@@ -34,7 +34,7 @@ export function WithSections() {
       </Autocomplete.Trigger>
       <Autocomplete.Popover>
         <Autocomplete.Filter filter={contains}>
-          <SearchField autoFocus name="search" variant="secondary">
+          <SearchField autoFocus aria-label="Search countries" name="search" variant="secondary">
             <SearchField.Group>
               <SearchField.SearchIcon />
               <SearchField.Input placeholder="Search countries..." />

--- a/packages/react/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.stories.tsx
@@ -67,7 +67,7 @@ export const Default: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search animals" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -119,7 +119,7 @@ export const WithClearButton: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search animals" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -184,7 +184,7 @@ export const WithOnClearCallback: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search animals" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search animals..." />
@@ -266,7 +266,12 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField
+                    autoFocus
+                    aria-label="Search options"
+                    name="search"
+                    variant="secondary"
+                  >
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -300,7 +305,12 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField
+                    autoFocus
+                    aria-label="Search options"
+                    name="search"
+                    variant="secondary"
+                  >
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -365,7 +375,12 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField
+                    autoFocus
+                    aria-label="Search options"
+                    name="search"
+                    variant="secondary"
+                  >
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -425,7 +440,12 @@ export const Variants: Story = {
               </Autocomplete.Trigger>
               <Autocomplete.Popover>
                 <Autocomplete.Filter filter={contains}>
-                  <SearchField autoFocus name="search" variant="secondary">
+                  <SearchField
+                    autoFocus
+                    aria-label="Search options"
+                    name="search"
+                    variant="secondary"
+                  >
                     <SearchField.Group>
                       <SearchField.SearchIcon />
                       <SearchField.Input placeholder="Search..." />
@@ -510,7 +530,7 @@ export const MultipleSelect: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search options" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search..." />
@@ -564,7 +584,7 @@ export const FullWidth: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -617,7 +637,7 @@ export const WithDescription: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -661,7 +681,7 @@ export const WithSections: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search countries" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search countries..." />
@@ -758,7 +778,7 @@ export const WithDisabledOptions: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search animals" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search animals..." />
@@ -830,7 +850,7 @@ export const CustomIndicator: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search states..." />
@@ -904,7 +924,7 @@ export const Required: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -938,7 +958,12 @@ export const Required: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField
+                autoFocus
+                aria-label="Search countries"
+                name="search"
+                variant="secondary"
+              >
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search countries..." />
@@ -996,7 +1021,7 @@ export const Controlled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1051,7 +1076,7 @@ export const ControlledOpenState: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1111,7 +1136,13 @@ export const AsynchronousFiltering: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter inputValue={list.filterText} onInputChange={list.setFilterText}>
-            <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+            <SearchField
+              autoFocus
+              aria-label="Search characters"
+              className="sticky top-0 z-10"
+              name="search"
+              variant="secondary"
+            >
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search characters..." />
@@ -1246,7 +1277,13 @@ export const Virtualization: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter inputValue={searchQuery} onInputChange={setSearchQuery}>
-            <SearchField autoFocus className="sticky top-0 z-10" name="search" variant="secondary">
+            <SearchField
+              autoFocus
+              aria-label="Search users"
+              className="sticky top-0 z-10"
+              name="search"
+              variant="secondary"
+            >
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1315,7 +1352,7 @@ export const Disabled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField autoFocus aria-label="Search states" name="search" variant="secondary">
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search states..." />
@@ -1348,7 +1385,12 @@ export const Disabled: Story = {
           </Autocomplete.Trigger>
           <Autocomplete.Popover>
             <Autocomplete.Filter filter={contains}>
-              <SearchField autoFocus name="search" variant="secondary">
+              <SearchField
+                autoFocus
+                aria-label="Search countries"
+                name="search"
+                variant="secondary"
+              >
                 <SearchField.Group>
                   <SearchField.SearchIcon />
                   <SearchField.Input placeholder="Search countries..." />
@@ -1458,7 +1500,7 @@ export const UserSelection: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search users" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1583,7 +1625,7 @@ export const UserSelectionMultiple: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search users" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search users..." />
@@ -1661,7 +1703,7 @@ export const LocationSearch: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={customFilter}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search cities" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search cities..." />
@@ -1752,7 +1794,7 @@ export const TagGroupSelection: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search tags" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search tags..." />
@@ -1833,7 +1875,7 @@ export const EmailRecipients: Story = {
         </Autocomplete.Trigger>
         <Autocomplete.Popover>
           <Autocomplete.Filter filter={contains}>
-            <SearchField autoFocus name="search" variant="secondary">
+            <SearchField autoFocus aria-label="Search emails" name="search" variant="secondary">
               <SearchField.Group>
                 <SearchField.SearchIcon />
                 <SearchField.Input placeholder="Search emails..." />

--- a/packages/react/tests/components/autocomplete/autocomplete.test.tsx
+++ b/packages/react/tests/components/autocomplete/autocomplete.test.tsx
@@ -114,7 +114,7 @@ describe("Autocomplete", () => {
 
     expect(tester.getListbox()).not.toBeNull();
     expect(document.querySelector('[data-slot="autocomplete-popover"]')).not.toBeNull();
-    expect(screen.getByPlaceholderText("Search animals...")).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", {name: "Search animals"})).toBeInTheDocument();
     expect(tester.getOptions()).toHaveLength(3);
 
     await tester.toggleOptionSelection({option: "Dog"});


### PR DESCRIPTION
Closes #6691

## 📝 Description

Adds contextual accessible names to all 82 Autocomplete search fields across the English and Chinese documentation demos and Storybook. The Autocomplete behavior test now queries the search input by role and accessible name.

The nested Dialog warning from the original report no longer reproduces after the Dialog wrapper was removed in v3.2.3. This fixes the remaining unlabeled SearchField warning on the current `v3` branch and follows the review feedback in #6692 to cover every demo and Storybook case.

## ⛳️ Current behavior (updates)

Autocomplete examples rely on placeholder text for their internal SearchField. A placeholder is not an accessible name, so React Aria warns that the search field needs a visible label, `aria-label`, or `aria-labelledby`.

## 🚀 New behavior

Each example provides a localized, context-specific `aria-label`, such as `Search animals`, `Search states`, or `搜索选项`. Screen readers receive a stable name even when the placeholder disappears after typing.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally (119 files, 560 tests, including Chromium browser suites)
- [x] `pnpm lint:react` and `pnpm lint:docs`
- [x] `pnpm typecheck:react` and `pnpm typecheck:docs`
- [x] `pnpm build --filter=@heroui/react`

## 📝 Additional Information

No runtime API or dependency changes.
