### PR TITLE
docs(agents): correct stale .styles.ts and CSS paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,9 @@ HeroUI v3 is a modern React UI library built with **Tailwind CSS v4**, organized
 │   │   ├── src/utils/       # Shared utilities
 │   │   └── scripts/         # Build & codegen scripts
 │   ├── styles/            # CSS styles & variants (@heroui/styles)
-│   │   └── src/components/  # Per-component .css files
+│   │   ├── components/      # Per-component .css files (flat, e.g. button.css)
+│   │   ├── themes/          # Theme variables
+│   │   └── src/components/  # Per-component .styles.ts (tailwind-variants)
 │   ├── standard/          # Shared ESLint, Prettier, TS configs
 │   ├── storybook/         # Storybook configuration
 │   └── testing/           # Shared test harness (@heroui/testing)
@@ -106,12 +108,18 @@ Each component lives in `packages/react/src/components/<component-name>/`:
 ```
 component-name/
 ├── component-name.tsx          # Component implementation (uses React Aria)
-├── component-name.styles.ts    # Tailwind Variants styling
 ├── component-name.stories.tsx  # Storybook stories
 └── index.ts                    # Barrel exports
 ```
 
-CSS styles live in `packages/styles/src/components/<component-name>/`.
+Styling lives in `@heroui/styles`, split across two locations:
+
+| Path | Contents |
+|---|---|
+| `packages/styles/src/components/<component-name>/<component-name>.styles.ts` | The `tv()` map from variant props to BEM class names |
+| `packages/styles/components/<component-name>.css` | The BEM class definitions (flat directory, one file per component) |
+
+Note that `.styles.ts` files do **not** live alongside the component in `packages/react`.
 
 ### Creating a New Component
 
@@ -127,6 +135,8 @@ Then build to update package.json exports:
 ```bash
 pnpm build
 ```
+
+The scaffold still emits a `<component-name>.styles.ts` into `packages/react/src/components/<component-name>/`, which no longer matches the layout above. Move it to `packages/styles/src/components/<component-name>/` and add the matching `packages/styles/components/<component-name>.css`.
 
 ### Compound Component Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,9 @@ git commit -m "ci: add Claude Code GitHub Action workflow"
 ├── packages/
 │   ├── react/         # Main UI component library (@heroui/react)
 │   ├── styles/        # CSS styles & variants (@heroui/styles)
+│   │   ├── components/     # Per-component .css files (flat, e.g. button.css)
+│   │   ├── themes/         # Theme variables
+│   │   └── src/components/ # Per-component .styles.ts (tailwind-variants)
 │   ├── standard/      # Shared ESLint, Prettier, TypeScript configs
 │   ├── storybook/     # Storybook configuration
 │   └── testing/       # Shared test harness (@heroui/testing)
@@ -131,9 +134,15 @@ Each component in `packages/react/src/components/` follows this structure:
 ```
 component-name/
 ├── component-name.tsx      # Main component (uses React Aria)
-├── component-name.styles.ts # Tailwind Variants styling
 ├── component-name.stories.tsx # Storybook stories (title: "Components/ComponentName")
 └── index.ts               # Barrel exports
+```
+
+Styling lives in `@heroui/styles`, not next to the component:
+
+```
+packages/styles/src/components/component-name/component-name.styles.ts  # tv() props → BEM class names
+packages/styles/components/component-name.css                           # BEM class definitions
 ```
 
 **IMPORTANT**: All Storybook stories must use the "Components" group in their title. For example: `title: "Components/Card"`, `title: "Components/Button"`, etc.
@@ -148,7 +157,7 @@ component-name/
 
 **Migration to CSS-based Styling**:
 
-- The `button` component has been migrated to use CSS styles from `@heroui/styles/src/components/button.css`
+- The `button` component has been migrated to use CSS styles from `packages/styles/components/button.css`
 - This approach allows for better customization through CSS utilities and `@utility` directives
 - Other components will gradually be migrated to follow this CSS-based pattern
 - Components use `tv()` from `tailwind-variants` to map variant props to BEM class names
@@ -264,7 +273,7 @@ export {ComponentRoot as Root, ComponentItem as Item, ...};
    - Styles defined in `.styles.ts` files using `tv()` function from `tailwind-variants`
    - **IMPORTANT**: Always import from `tailwind-variants`, never from `@heroui/standard` (which doesn't exist)
    - **CRITICAL**: tailwind-variants already includes `twMerge` functionality, so NEVER manually use `twMerge`
-   - **RULE**: All component styles MUST be defined in separate `.styles.ts` files, NOT in the component implementation files
+   - **RULE**: All component styles MUST be defined in separate `.styles.ts` files under `packages/styles/src/components/`, NOT in the component implementation files
    - Component implementation files (`.tsx`) should only contain logic and React Aria primitives
    - Example imports:
      ```typescript
@@ -471,6 +480,8 @@ This workflow ensures thorough understanding, proper planning, and high-quality 
    - Add the export to `src/components/index.ts`
    - Generate boilerplate following HeroUI patterns
    - Set up the component with TypeScript and proper exports
+
+   The scaffold still emits a `<component-name>.styles.ts` into `packages/react/src/components/<component-name>/`, which no longer matches the layout. Move it to `packages/styles/src/components/<component-name>/` and add the matching `packages/styles/components/<component-name>.css`.
 
    After creating the component:
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

This pull request updates the documentation to clarify and standardize the organization of component styles in the HeroUI project. The main focus is on separating styling files from component implementations, detailing the new directory structure, and providing migration instructions for the new CSS-based styling approach.

**Documentation updates for style organization:**

* Updated the directory structure in both `AGENTS.md` and `CLAUDE.md` to show that per-component `.styles.ts` files now live in `packages/styles/src/components/`, and per-component `.css` files live in `packages/styles/components/` (flat), rather than alongside the React components. Also introduced a `themes/` directory for theme variables. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L36-R38) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R120-R122)
* Revised component scaffolding and migration instructions to reflect that the scaffold still emits `.styles.ts` files into the React package, but these should be moved to the correct location in `@heroui/styles`, and a matching `.css` file should be added. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R139-R140) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R484-R485)
* Clarified that styling logic should not be colocated with component logic; all styles must be defined in `.styles.ts` files under `packages/styles/src/components/`, not in the component implementation files.
* Updated the description of the styling system to explain how `tv()` maps variant props to BEM class names, and that BEM class definitions live in the flat `components/` directory. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L109-R122) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L134-R147)
* Fixed migration notes and examples to reference the correct new file paths for CSS files and clarified the migration plan for other components.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## ✅ Testing

- [ ] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [ ] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [ ] `pnpm test` passes locally

## 📝 Additional Information
