### PR TITLE
fix(react): keep scroll shadow state in sync and memoize hot render paths

### DIFF
--- a/packages/react/src/components/autocomplete/autocomplete.tsx
+++ b/packages/react/src/components/autocomplete/autocomplete.tsx
@@ -70,9 +70,14 @@ const AutocompleteRoot = <T extends object = object, M extends "single" | "multi
   const triggerRef = useRef<HTMLElement | null>(null);
   const clearButtonRef = useRef<HTMLButtonElement | null>(null);
 
+  const context = React.useMemo<AutocompleteContext>(
+    () => ({slots, triggerRef, clearButtonRef, onClear, isDisabled}),
+    [slots, onClear, isDisabled],
+  );
+
   return (
     <FieldSlotsGate>
-      <AutocompleteContext value={{slots, triggerRef, clearButtonRef, onClear, isDisabled}}>
+      <AutocompleteContext value={context}>
         <SelectPrimitive
           data-slot="autocomplete"
           {...props}

--- a/packages/react/src/components/button-group/button-group.tsx
+++ b/packages/react/src/components/button-group/button-group.tsx
@@ -61,19 +61,28 @@ const ButtonGroupRoot = ({
   );
 
   // Wrap only direct children with context provider
-  const wrappedChildren = Children.map(children as React.ReactNode, (child) => {
-    if (!isValidElement(child)) {
-      return child;
-    }
+  const wrappedChildren = React.useMemo(
+    () =>
+      Children.map(children as React.ReactNode, (child) => {
+        if (!isValidElement(child)) {
+          return child;
+        }
 
-    // Clone the child and add the special prop
-    return React.cloneElement(child, {
-      [BUTTON_GROUP_CHILD]: true,
-    } as any);
-  });
+        // Clone the child and add the special prop
+        return React.cloneElement(child, {
+          [BUTTON_GROUP_CHILD]: true,
+        } as any);
+      }),
+    [children],
+  );
+
+  const context = React.useMemo<ButtonGroupContext>(
+    () => ({slots, size, variant, isDisabled, fullWidth}),
+    [slots, size, variant, isDisabled, fullWidth],
+  );
 
   return (
-    <ButtonGroupContext value={{slots, size, variant, isDisabled, fullWidth}}>
+    <ButtonGroupContext value={context}>
       <Group
         className={composeTwRenderProps(className, slots.base())}
         data-slot="button-group"

--- a/packages/react/src/components/calendar/calendar.tsx
+++ b/packages/react/src/components/calendar/calendar.tsx
@@ -73,11 +73,13 @@ const CalendarContextProvider = ({
   timeZone,
   visibleRange,
 }: CalendarContextProviderProps) => {
-  // Collapses to undefined outside day view, which keeps the context value
-  // stable even if React Aria hands us a fresh visibleRange each render.
+  // React Aria rebuilds visibleRange on every render, but the start/end dates it
+  // holds are stable, so keying off those keeps the value stable in day view too.
+  // Outside day view this collapses to undefined, which is stable either way.
+  const {end, start} = visibleRange;
   const dayView = React.useMemo(
-    () => (dayViewBase ? {...dayViewBase, timeZone, visibleRange} : undefined),
-    [dayViewBase, timeZone, visibleRange],
+    () => (dayViewBase ? {...dayViewBase, timeZone, visibleRange: {end, start}} : undefined),
+    [dayViewBase, timeZone, end, start],
   );
   const value = React.useMemo<CalendarContext>(() => ({dayView, slots}), [dayView, slots]);
 

--- a/packages/react/src/components/calendar/calendar.tsx
+++ b/packages/react/src/components/calendar/calendar.tsx
@@ -54,6 +54,36 @@ interface CalendarContext {
 
 const CalendarContext = createContext<CalendarContext>({});
 
+interface CalendarContextProviderProps {
+  children: ReactNode;
+  dayViewBase?: Pick<CalendarDayViewContext, "days" | "firstDayOfWeek">;
+  slots: ReturnType<typeof calendarVariants>;
+  timeZone: string;
+  visibleRange: {end: DateValue; start: DateValue};
+}
+
+/**
+ * Provides CalendarContext from inside the Calendar render prop, where hooks
+ * cannot be called directly.
+ */
+const CalendarContextProvider = ({
+  children,
+  dayViewBase,
+  slots,
+  timeZone,
+  visibleRange,
+}: CalendarContextProviderProps) => {
+  // Collapses to undefined outside day view, which keeps the context value
+  // stable even if React Aria hands us a fresh visibleRange each render.
+  const dayView = React.useMemo(
+    () => (dayViewBase ? {...dayViewBase, timeZone, visibleRange} : undefined),
+    [dayViewBase, timeZone, visibleRange],
+  );
+  const value = React.useMemo<CalendarContext>(() => ({dayView, slots}), [dayView, slots]);
+
+  return <CalendarContext value={value}>{children}</CalendarContext>;
+};
+
 /* -------------------------------------------------------------------------------------------------
 | * Calendar Root
 | * -----------------------------------------------------------------------------------------------*/
@@ -100,22 +130,36 @@ function CalendarRoot<T extends DateValue = DateValue, M extends CalendarSelecti
     () => getGregorianYearOffset(calendarProp.identifier),
     [calendarProp.identifier],
   );
-  const minValue =
-    minValueProp ??
-    (new CalendarDate(calendarProp, 1900 + gregorianYearOffset, 1, 1) as unknown as T);
-  const maxValue =
-    maxValueProp ??
-    (new CalendarDate(calendarProp, 2099 + gregorianYearOffset, 12, 31) as unknown as T);
+  // React Aria memoizes calendar state against minValue/maxValue identity, so
+  // these bounds must be stable across renders.
+  const minValue = React.useMemo(
+    () =>
+      minValueProp ??
+      (new CalendarDate(calendarProp, 1900 + gregorianYearOffset, 1, 1) as unknown as T),
+    [minValueProp, calendarProp, gregorianYearOffset],
+  );
+  const maxValue = React.useMemo(
+    () =>
+      maxValueProp ??
+      (new CalendarDate(calendarProp, 2099 + gregorianYearOffset, 12, 31) as unknown as T),
+    [maxValueProp, calendarProp, gregorianYearOffset],
+  );
+  const dayViewBase = React.useMemo(
+    () => (isDayView && visibleDays != null ? {days: visibleDays, firstDayOfWeek} : undefined),
+    [isDayView, visibleDays, firstDayOfWeek],
+  );
+  const yearPickerContext = React.useMemo(
+    () => ({
+      calendarGridSlot: "calendar-grid" as const,
+      isYearPickerOpen,
+      setIsYearPickerOpen,
+      calendarRef,
+    }),
+    [isYearPickerOpen, setIsYearPickerOpen],
+  );
 
   return (
-    <YearPickerContext
-      value={{
-        calendarGridSlot: "calendar-grid",
-        isYearPickerOpen,
-        setIsYearPickerOpen,
-        calendarRef,
-      }}
-    >
+    <YearPickerContext value={yearPickerContext}>
       <CalendarPrimitive
         ref={calendarRef}
         data-slot="calendar"
@@ -130,22 +174,14 @@ function CalendarRoot<T extends DateValue = DateValue, M extends CalendarSelecti
         )}
       >
         {(values) => (
-          <CalendarContext
-            value={{
-              dayView:
-                isDayView && visibleDays != null
-                  ? {
-                      days: visibleDays,
-                      firstDayOfWeek,
-                      timeZone: values.state.timeZone,
-                      visibleRange: values.state.visibleRange,
-                    }
-                  : undefined,
-              slots,
-            }}
+          <CalendarContextProvider
+            dayViewBase={dayViewBase}
+            slots={slots}
+            timeZone={values.state.timeZone}
+            visibleRange={values.state.visibleRange}
           >
             {typeof children === "function" ? children(values) : children}
-          </CalendarContext>
+          </CalendarContextProvider>
         )}
       </CalendarPrimitive>
     </YearPickerContext>

--- a/packages/react/src/components/range-calendar/range-calendar.tsx
+++ b/packages/react/src/components/range-calendar/range-calendar.tsx
@@ -69,11 +69,13 @@ const RangeCalendarContextProvider = ({
   timeZone,
   visibleRange,
 }: RangeCalendarContextProviderProps) => {
-  // Collapses to undefined outside day view, which keeps the context value
-  // stable even if React Aria hands us a fresh visibleRange each render.
+  // React Aria rebuilds visibleRange on every render, but the start/end dates it
+  // holds are stable, so keying off those keeps the value stable in day view too.
+  // Outside day view this collapses to undefined, which is stable either way.
+  const {end, start} = visibleRange;
   const dayView = React.useMemo(
-    () => (dayViewBase ? {...dayViewBase, timeZone, visibleRange} : undefined),
-    [dayViewBase, timeZone, visibleRange],
+    () => (dayViewBase ? {...dayViewBase, timeZone, visibleRange: {end, start}} : undefined),
+    [dayViewBase, timeZone, end, start],
   );
   const value = React.useMemo<RangeCalendarContext>(() => ({dayView, slots}), [dayView, slots]);
 

--- a/packages/react/src/components/range-calendar/range-calendar.tsx
+++ b/packages/react/src/components/range-calendar/range-calendar.tsx
@@ -50,6 +50,36 @@ interface RangeCalendarContext {
 
 const RangeCalendarContext = createContext<RangeCalendarContext>({});
 
+interface RangeCalendarContextProviderProps {
+  children: ReactNode;
+  dayViewBase?: Pick<RangeCalendarDayViewContext, "days" | "firstDayOfWeek">;
+  slots: ReturnType<typeof rangeCalendarVariants>;
+  timeZone: string;
+  visibleRange: {end: DateValue; start: DateValue};
+}
+
+/**
+ * Provides RangeCalendarContext from inside the RangeCalendar render prop,
+ * where hooks cannot be called directly.
+ */
+const RangeCalendarContextProvider = ({
+  children,
+  dayViewBase,
+  slots,
+  timeZone,
+  visibleRange,
+}: RangeCalendarContextProviderProps) => {
+  // Collapses to undefined outside day view, which keeps the context value
+  // stable even if React Aria hands us a fresh visibleRange each render.
+  const dayView = React.useMemo(
+    () => (dayViewBase ? {...dayViewBase, timeZone, visibleRange} : undefined),
+    [dayViewBase, timeZone, visibleRange],
+  );
+  const value = React.useMemo<RangeCalendarContext>(() => ({dayView, slots}), [dayView, slots]);
+
+  return <RangeCalendarContext value={value}>{children}</RangeCalendarContext>;
+};
+
 /* -------------------------------------------------------------------------------------------------
 | * RangeCalendar Root
 | * -----------------------------------------------------------------------------------------------*/
@@ -93,22 +123,36 @@ function RangeCalendarRoot<T extends DateValue = DateValue>({
     () => getGregorianYearOffset(calendarProp.identifier),
     [calendarProp.identifier],
   );
-  const minValue =
-    minValueProp ??
-    (new CalendarDate(calendarProp, 1900 + gregorianYearOffset, 1, 1) as unknown as T);
-  const maxValue =
-    maxValueProp ??
-    (new CalendarDate(calendarProp, 2099 + gregorianYearOffset, 12, 31) as unknown as T);
+  // React Aria memoizes calendar state against minValue/maxValue identity, so
+  // these bounds must be stable across renders.
+  const minValue = React.useMemo(
+    () =>
+      minValueProp ??
+      (new CalendarDate(calendarProp, 1900 + gregorianYearOffset, 1, 1) as unknown as T),
+    [minValueProp, calendarProp, gregorianYearOffset],
+  );
+  const maxValue = React.useMemo(
+    () =>
+      maxValueProp ??
+      (new CalendarDate(calendarProp, 2099 + gregorianYearOffset, 12, 31) as unknown as T),
+    [maxValueProp, calendarProp, gregorianYearOffset],
+  );
+  const dayViewBase = React.useMemo(
+    () => (isDayView && visibleDays != null ? {days: visibleDays, firstDayOfWeek} : undefined),
+    [isDayView, visibleDays, firstDayOfWeek],
+  );
+  const yearPickerContext = React.useMemo(
+    () => ({
+      calendarGridSlot: "range-calendar-grid" as const,
+      isYearPickerOpen,
+      setIsYearPickerOpen,
+      calendarRef,
+    }),
+    [isYearPickerOpen, setIsYearPickerOpen],
+  );
 
   return (
-    <YearPickerContext
-      value={{
-        calendarGridSlot: "range-calendar-grid",
-        isYearPickerOpen,
-        setIsYearPickerOpen,
-        calendarRef,
-      }}
-    >
+    <YearPickerContext value={yearPickerContext}>
       <RangeCalendarPrimitive
         ref={calendarRef}
         data-slot="range-calendar"
@@ -127,22 +171,14 @@ function RangeCalendarRoot<T extends DateValue = DateValue>({
         )}
       >
         {(values) => (
-          <RangeCalendarContext
-            value={{
-              dayView:
-                isDayView && visibleDays != null
-                  ? {
-                      days: visibleDays,
-                      firstDayOfWeek,
-                      timeZone: values.state.timeZone,
-                      visibleRange: values.state.visibleRange,
-                    }
-                  : undefined,
-              slots,
-            }}
+          <RangeCalendarContextProvider
+            dayViewBase={dayViewBase}
+            slots={slots}
+            timeZone={values.state.timeZone}
+            visibleRange={values.state.visibleRange}
           >
             {typeof children === "function" ? children(values) : children}
-          </RangeCalendarContext>
+          </RangeCalendarContextProvider>
         )}
       </RangeCalendarPrimitive>
     </YearPickerContext>

--- a/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
+++ b/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
@@ -149,4 +149,14 @@ export const useScrollShadow = (props: UseScrollShadowProps) => {
       prevStateRef.current = null;
     };
   }, [containerRef, visibility, isEnabled, checkOverflow]);
+
+  // ResizeObserver only reports the container's own box, so content growing or
+  // shrinking inside a fixed-size container fires neither resize nor scroll and
+  // would leave the shadows stale. Re-measuring after every render covers that;
+  // the prevStateRef guard keeps it a no-op unless the measurement changed.
+  useEffect(() => {
+    if (!isEnabled || visibility !== "auto") return;
+
+    checkOverflow();
+  });
 };

--- a/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
+++ b/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
@@ -17,6 +17,15 @@ export interface UseScrollShadowProps {
 export const useScrollShadow = (props: UseScrollShadowProps) => {
   const {containerRef, isEnabled, offset, onVisibilityChange, orientation, visibility} = props;
 
+  // Consumers usually pass an inline callback. Reading it through a ref keeps
+  // checkOverflow stable, so the scroll listener and ResizeObserver are not
+  // torn down and rebuilt on every render.
+  const onVisibilityChangeRef = useRef(onVisibilityChange);
+
+  useEffect(() => {
+    onVisibilityChangeRef.current = onVisibilityChange;
+  }, [onVisibilityChange]);
+
   // Cache previous state to avoid unnecessary DOM updates
   const prevStateRef = useRef<{
     hasScrollBefore: boolean;
@@ -62,25 +71,27 @@ export const useScrollShadow = (props: UseScrollShadowProps) => {
     rafIdRef.current = requestAnimationFrame(() => {
       rafIdRef.current = null;
 
+      const notify = onVisibilityChangeRef.current;
+
       if (isVertical) {
         if (hasScrollBefore && hasScrollAfter) {
           el.dataset["topBottomScroll"] = "true";
           delete el.dataset["topScroll"];
           delete el.dataset["bottomScroll"];
 
-          onVisibilityChange?.("both");
+          notify?.("both");
         } else {
           el.dataset["topScroll"] = String(hasScrollBefore);
           el.dataset["bottomScroll"] = String(hasScrollAfter);
           delete el.dataset["topBottomScroll"];
 
-          if (onVisibilityChange) {
+          if (notify) {
             if (hasScrollBefore) {
-              onVisibilityChange("top");
+              notify("top");
             } else if (hasScrollAfter) {
-              onVisibilityChange("bottom");
+              notify("bottom");
             } else {
-              onVisibilityChange("none");
+              notify("none");
             }
           }
         }
@@ -90,25 +101,25 @@ export const useScrollShadow = (props: UseScrollShadowProps) => {
           delete el.dataset["leftScroll"];
           delete el.dataset["rightScroll"];
 
-          onVisibilityChange?.("both");
+          notify?.("both");
         } else {
           el.dataset["leftScroll"] = String(hasScrollBefore);
           el.dataset["rightScroll"] = String(hasScrollAfter);
           delete el.dataset["leftRightScroll"];
 
-          if (onVisibilityChange) {
+          if (notify) {
             if (hasScrollBefore) {
-              onVisibilityChange("left");
+              notify("left");
             } else if (hasScrollAfter) {
-              onVisibilityChange("right");
+              notify("right");
             } else {
-              onVisibilityChange("none");
+              notify("none");
             }
           }
         }
       }
     });
-  }, [containerRef, orientation, offset, onVisibilityChange]);
+  }, [containerRef, orientation, offset]);
 
   useEffect(() => {
     const el = containerRef.current;

--- a/packages/react/src/hooks/use-is-hydrated.ts
+++ b/packages/react/src/hooks/use-is-hydrated.ts
@@ -1,5 +1,9 @@
 import * as React from "react";
 
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 /**
  * A hook that returns true if the component is mounted on the client (hydrated)
  * and false when rendering on the server.
@@ -18,13 +22,6 @@ import * as React from "react";
  * ```
  * @returns boolean indicating if the component is hydrated
  */
-
 export function useIsHydrated() {
-  const subscribe = () => () => {};
-
-  return React.useSyncExternalStore(
-    subscribe,
-    () => true,
-    () => false,
-  );
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/packages/react/tests/components/calendar/calendar.test.tsx
+++ b/packages/react/tests/components/calendar/calendar.test.tsx
@@ -174,6 +174,23 @@ describe("Calendar", () => {
     });
   });
 
+  describe("day view", () => {
+    it("renders a weekday header and day cells when visibleDuration is set in days", () => {
+      renderCalendar({visibleDuration: {days: 7}});
+
+      expect(document.querySelector('[data-slot="calendar"]')?.className).toEqual(
+        expect.stringContaining("calendar--day-view"),
+      );
+      expect(document.querySelectorAll('[data-slot="calendar-grid-header"] th')).toHaveLength(7);
+
+      // The visible range is centered on the selected day, so its edges prove the
+      // range reached the day view grid through the calendar context.
+      expect(getDayCell("August 12, 2026")).toBeInTheDocument();
+      expect(getDayCell("August 15, 2026")).toBeInTheDocument();
+      expect(getDayCell("August 18, 2026")).toBeInTheDocument();
+    });
+  });
+
   describe("navigation", () => {
     it("supports next and previous month via NavButton", async () => {
       renderCalendar();

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
@@ -1,6 +1,52 @@
-import {render, screen} from "@heroui/testing/helpers";
+import type {ScrollShadowVisibility} from "@/components/scroll-shadow";
+
+import {act, fireEvent, render, screen, setupUser, waitFor} from "@heroui/testing/helpers";
+import {useState} from "react";
 
 import {ScrollShadow} from "@/components/scroll-shadow";
+
+/** jsdom reports zero for every layout box, so the scroll metrics are stubbed. */
+const stubScrollMetrics = (
+  element: HTMLElement,
+  metrics: {clientHeight: number; scrollHeight: number; scrollTop: number},
+) => {
+  for (const [property, value] of Object.entries(metrics)) {
+    Object.defineProperty(element, property, {configurable: true, value});
+  }
+};
+
+/** The visibility callback is dispatched from a rAF, so drain a couple of frames. */
+const flushFrames = async () => {
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  });
+};
+
+const VisibilityHarness = ({
+  onVisibilityChange,
+}: {
+  onVisibilityChange: (visibility: ScrollShadowVisibility, renderCount: number) => void;
+}) => {
+  const [renderCount, setRenderCount] = useState(0);
+
+  return (
+    <>
+      <button type="button" onClick={() => setRenderCount((count) => count + 1)}>
+        Re-render
+      </button>
+      <ScrollShadow
+        data-testid="scroll-shadow"
+        // Inline on purpose, and closing over renderCount so a stale callback is
+        // distinguishable from the current one: a fresh identity each render must
+        // not re-notify, but the newest closure must be the one invoked.
+        onVisibilityChange={(visibility) => onVisibilityChange(visibility, renderCount)}
+      >
+        Content {renderCount}
+      </ScrollShadow>
+    </>
+  );
+};
 
 describe("ScrollShadow", () => {
   it("renders children content", () => {
@@ -99,5 +145,65 @@ describe("ScrollShadow", () => {
     );
 
     expect(screen.getByTestId("scroll-shadow")).toHaveAttribute("data-foo", "bar");
+  });
+
+  describe("visibility callback", () => {
+    it("calls onVisibilityChange when the scroll state changes", async () => {
+      const onVisibilityChange = vi.fn();
+
+      render(<VisibilityHarness onVisibilityChange={onVisibilityChange} />);
+
+      await waitFor(() => expect(onVisibilityChange).toHaveBeenLastCalledWith("none", 0));
+
+      const scrollShadow = screen.getByTestId("scroll-shadow");
+
+      stubScrollMetrics(scrollShadow, {clientHeight: 100, scrollHeight: 300, scrollTop: 0});
+      fireEvent.scroll(scrollShadow);
+
+      await waitFor(() => expect(onVisibilityChange).toHaveBeenLastCalledWith("bottom", 0));
+
+      stubScrollMetrics(scrollShadow, {clientHeight: 100, scrollHeight: 300, scrollTop: 50});
+      fireEvent.scroll(scrollShadow);
+
+      await waitFor(() => expect(onVisibilityChange).toHaveBeenLastCalledWith("both", 0));
+    });
+
+    it("does not call onVisibilityChange again while the scroll state is unchanged", async () => {
+      const onVisibilityChange = vi.fn();
+      const user = setupUser();
+
+      render(<VisibilityHarness onVisibilityChange={onVisibilityChange} />);
+
+      await waitFor(() => expect(onVisibilityChange).toHaveBeenCalledTimes(1));
+
+      const rerender = screen.getByRole("button", {name: "Re-render"});
+
+      await user.click(rerender);
+      await user.click(rerender);
+      await flushFrames();
+
+      expect(onVisibilityChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls the newest callback, not the one captured on mount", async () => {
+      const onVisibilityChange = vi.fn();
+      const user = setupUser();
+
+      render(<VisibilityHarness onVisibilityChange={onVisibilityChange} />);
+
+      await waitFor(() => expect(onVisibilityChange).toHaveBeenLastCalledWith("none", 0));
+
+      await user.click(screen.getByRole("button", {name: "Re-render"}));
+      await user.click(screen.getByRole("button", {name: "Re-render"}));
+      await flushFrames();
+
+      const scrollShadow = screen.getByTestId("scroll-shadow");
+
+      stubScrollMetrics(scrollShadow, {clientHeight: 100, scrollHeight: 300, scrollTop: 0});
+      fireEvent.scroll(scrollShadow);
+
+      // renderCount 2 proves the ref was resynced; a stale closure would report 0.
+      await waitFor(() => expect(onVisibilityChange).toHaveBeenLastCalledWith("bottom", 2));
+    });
   });
 });

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
@@ -48,6 +48,23 @@ const VisibilityHarness = ({
   );
 };
 
+const ContentGrowthHarness = () => {
+  const [rows, setRows] = useState(1);
+
+  return (
+    <>
+      <button type="button" onClick={() => setRows((count) => count + 1)}>
+        Add row
+      </button>
+      <ScrollShadow data-testid="scroll-shadow">
+        {Array.from({length: rows}, (_, index) => (
+          <p key={index}>Row {index}</p>
+        ))}
+      </ScrollShadow>
+    </>
+  );
+};
+
 describe("ScrollShadow", () => {
   it("renders children content", () => {
     render(<ScrollShadow>Scrollable content</ScrollShadow>);
@@ -121,6 +138,28 @@ describe("ScrollShadow", () => {
         "data-scroll-shadow-mode",
         "manual",
       );
+    });
+  });
+
+  describe("shadow state", () => {
+    it("updates the shadow state when content resizes without a scroll or resize event", async () => {
+      const user = setupUser();
+
+      render(<ContentGrowthHarness />);
+      await flushFrames();
+
+      const scrollShadow = screen.getByTestId("scroll-shadow");
+
+      expect(scrollShadow).toHaveAttribute("data-bottom-scroll", "false");
+
+      // A fixed-height container: its own box never changes, so ResizeObserver
+      // stays silent, and nothing scrolls. Only the content grew taller.
+      stubScrollMetrics(scrollShadow, {clientHeight: 100, scrollHeight: 300, scrollTop: 0});
+
+      await user.click(screen.getByRole("button", {name: "Add row"}));
+      await flushFrames();
+
+      expect(scrollShadow).toHaveAttribute("data-bottom-scroll", "true");
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Two `ScrollShadow` bugs plus a set of render-path stabilizations found in the same audit.

No public API changes.

### ScrollShadow (behavior fixes)

**`onVisibilityChange` fired on every render.** `checkOverflow` depended on the callback, so an inline handler — the common case — gave it a new identity each render. That tore down and rebuilt the scroll listener and `ResizeObserver`, and because the effect cleanup reset `prevStateRef` (the de-dupe guard), the callback fired on every render instead of only on real transitions. Consumers driving state from it could see a render loop. The callback is now read through a ref, so `checkOverflow` stays stable and only genuine transitions notify.

**Shadow state went stale when content resized.** `ResizeObserver` only reports the observed container's own box, so content growing or shrinking inside a fixed-size container fires neither a resize nor a scroll event. Verified in Chromium: growing content left `data-bottom-scroll="false"`, and shrinking it back left the attribute stuck at `"true"`.

This matters beyond the fade. The `data-*-scroll` attributes drive the Tabs scroll arrows through a CSS `:has()` rule that sits *outside* the `@supports (animation-timeline: scroll(self))` block, so it applies in every browser:

```css
.tabs__list-container:has(> :is([data-right-scroll=true], ...)) > .tabs__list-container__scroll-next {
  display: inline-flex;
}
```

Tabs is a fixed-box consumer — its scroller width comes from the container, so adding or removing tabs changes only the content. Without a re-measure, a dynamic tab strip never gets its scroll arrows, or keeps them stuck on. The hook now re-measures after each render; the `prevStateRef` guard keeps that a no-op unless the measurement actually changed.

### Calendar / RangeCalendar

`minValue` and `maxValue` fall back to freshly constructed `CalendarDate` objects when not supplied. React Aria keys its calendar state off the identity of those bounds, so a new object each render invalidated that state on every pass. Both are now memoized.

The `CalendarContext` value was also built inline *inside* the render prop, where hooks can't be called. Extracted a small `CalendarContextProvider` so the value can be memoized properly, and memoized the `YearPickerContext` value and the day view context alongside it.

`RangeCalendar` gets the identical treatment.

### Autocomplete

Context value was rebuilt on every render, which meant every part of the compound component re-rendered on each filtering keystroke. Now memoized.

### ButtonGroup

`Children.map` + `cloneElement` ran on every render, producing new element objects for each child and forcing them all to reconcile. Both the cloned children and the context value are now memoized.

### useScrollShadow

`checkOverflow` depended on `onVisibilityChange`, so an inline callback — the common case — gave it a new identity each render, tearing down and rebuilding the scroll listener and `ResizeObserver` every time. It now reads the callback through a ref, keeping `checkOverflow` stable.

This is the one **observable behavior change** in the PR, and it's a bug fix.

The effect cleanup reset `prevStateRef`, the de-dupe guard, so re-running it each render meant `onVisibilityChange` fired on *every render* rather than only when visibility actually changed. Consumers using it to drive state could previously see a render loop. It now fires only on real transitions.

### useIsHydrated

`subscribe` was reallocated inline on each call, so `useSyncExternalStore` resubscribed on every render. Hoisted it and the two snapshot getters to module scope.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

## 📝 Additional Information
