### PR TITLE
feat(tabs): add align variant for flexible tab text alignment

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(navigation)/tabs.mdx
+++ b/apps/docs/content/docs/cn/react/components/(navigation)/tabs.mdx
@@ -91,6 +91,15 @@ export default () => (
   name="tabs-secondary-vertical"
 />
 
+### 对齐方式
+
+标签内容默认居中。使用 `align` 可将其对齐到 `start` 或 `end`，这在垂直的侧边栏式导航中尤其有用。单个标签仍可通过 `Tabs.Tab` 上的 `className` 覆盖。
+
+<ComponentPreview
+  isBgSolid
+  name="tabs-vertical-alignment"
+/>
+
 ### 渲染函数
 
 <ComponentPreview
@@ -158,6 +167,10 @@ Tabs 组件使用以下 CSS 类（[查看源码样式](https://github.com/heroui
 #### 变体类 [!toc]
 - `.tabs--secondary` - 次要类型变体，使用下划线指示器
 
+#### 对齐类 [!toc]
+- `.tabs--align-start` - 标签内容对齐到起始侧
+- `.tabs--align-end` - 标签内容对齐到结束侧
+
 ### 交互状态
 
 组件同时支持 CSS 伪类与 data 属性：
@@ -175,6 +188,7 @@ Tabs 组件使用以下 CSS 类（[查看源码样式](https://github.com/heroui
 |------|------|--------|------|
 | `variant` | `"primary" \| "secondary"` | `"primary"` | 视觉样式变体。Primary 使用填充指示器，Secondary 使用下划线指示器 |
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | 标签布局方向 |
+| `align` | `"start" \| "center" \| "end"` | `"center"` | 每个标签内部内容的对齐方式 |
 | `selectedKey` | `string` | - | 受控选中标签的 key |
 | `defaultSelectedKey` | `string` | - | 默认选中标签的 key |
 | `onSelectionChange` | `(key: Key) => void` | - | 选中变化回调 |

--- a/apps/docs/content/docs/en/react/components/(navigation)/tabs.mdx
+++ b/apps/docs/content/docs/en/react/components/(navigation)/tabs.mdx
@@ -89,6 +89,17 @@ Add `<Tabs.Separator />` inside each `<Tabs.Tab>` (except the first) to display 
   name="tabs-secondary-vertical"
 />
 
+### Alignment
+
+Tab content is centered by default. Use `align` to align it to the `start` or `end` instead, which is
+especially useful for vertical, sidebar-style navigation. Individual tabs can still be overridden with
+`className` on `Tabs.Tab`.
+
+<ComponentPreview
+  isBgSolid
+  name="tabs-vertical-alignment"
+/>
+
 ### Render Function
 
 <ComponentPreview
@@ -157,6 +168,10 @@ The Tabs component uses these CSS classes ([View source styles](https://github.c
 #### Variant Classes [!toc]
 - `.tabs--secondary` - Secondary variant with underline indicator
 
+#### Alignment Classes [!toc]
+- `.tabs--align-start` - Aligns tab content to the start
+- `.tabs--align-end` - Aligns tab content to the end
+
 ### Interactive States
 
 The component supports both CSS pseudo-classes and data attributes:
@@ -174,6 +189,7 @@ The component supports both CSS pseudo-classes and data attributes:
 |------|------|---------|-------------|
 | `variant` | `"primary" \| "secondary"` | `"primary"` | Visual style variant. Primary uses a filled indicator, secondary uses an underline indicator |
 | `orientation` | `"horizontal" \| "vertical"` | `"horizontal"` | Tab layout orientation |
+| `align` | `"start" \| "center" \| "end"` | `"center"` | Alignment of the content inside each tab |
 | `selectedKey` | `string` | - | Controlled selected tab key |
 | `defaultSelectedKey` | `string` | - | Default selected tab key |
 | `onSelectionChange` | `(key: Key) => void` | - | Selection change handler |

--- a/apps/docs/src/demos/cn/index.ts
+++ b/apps/docs/src/demos/cn/index.ts
@@ -2391,6 +2391,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./tabs/secondary-vertical").then((m) => m.SecondaryVertical),
     file: "cn/tabs/secondary-vertical.tsx",
   },
+  "tabs-vertical-alignment": {
+    loader: () => import("./tabs/vertical-alignment").then((m) => m.VerticalAlignment),
+    file: "cn/tabs/vertical-alignment.tsx",
+  },
   "tabs-render-function": {
     loader: () => import("./tabs/render-function").then((m) => m.RenderFunction),
     file: "cn/tabs/render-function.tsx",

--- a/apps/docs/src/demos/cn/tabs/index.ts
+++ b/apps/docs/src/demos/cn/tabs/index.ts
@@ -5,5 +5,6 @@ export {Disabled} from "./disabled";
 export {WithSeparator} from "./with-separator";
 export {Secondary} from "./secondary";
 export {SecondaryVertical} from "./secondary-vertical";
+export {VerticalAlignment} from "./vertical-alignment";
 export {RenderFunction} from "./render-function";
 export {CustomStyles} from "./custom-styles";

--- a/apps/docs/src/demos/cn/tabs/vertical-alignment.tsx
+++ b/apps/docs/src/demos/cn/tabs/vertical-alignment.tsx
@@ -1,0 +1,52 @@
+import {Tabs} from "@heroui/react";
+
+export function VerticalAlignment() {
+  return (
+    <Tabs align="start" className="w-full max-w-lg" orientation="vertical" variant="secondary">
+      <Tabs.ListContainer>
+        <Tabs.List aria-label="设置">
+          <Tabs.Tab id="general">
+            通用
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="billing">
+            订阅与账单
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="appearance">
+            外观
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="notifications">
+            通知
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="privacy">
+            隐私
+            <Tabs.Indicator />
+          </Tabs.Tab>
+        </Tabs.List>
+      </Tabs.ListContainer>
+      <Tabs.Panel className="px-4" id="general">
+        <h3 className="mb-2 font-semibold">通用</h3>
+        <p className="text-sm text-muted">管理你的账户信息与偏好设置。</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="billing">
+        <h3 className="mb-2 font-semibold">订阅与账单</h3>
+        <p className="text-sm text-muted">查看并管理你的套餐与支付方式。</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="appearance">
+        <h3 className="mb-2 font-semibold">外观</h3>
+        <p className="text-sm text-muted">选择主题并调整界面密度。</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="notifications">
+        <h3 className="mb-2 font-semibold">通知</h3>
+        <p className="text-sm text-muted">选择接收通知的方式与时间。</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="privacy">
+        <h3 className="mb-2 font-semibold">隐私</h3>
+        <p className="text-sm text-muted">控制你分享的内容以及谁可以查看你的动态。</p>
+      </Tabs.Panel>
+    </Tabs>
+  );
+}

--- a/apps/docs/src/demos/en/index.ts
+++ b/apps/docs/src/demos/en/index.ts
@@ -2450,6 +2450,10 @@ export const demos: Record<string, DemoItem> = {
     loader: () => import("./tabs/secondary-vertical").then((m) => m.SecondaryVertical),
     file: "en/tabs/secondary-vertical.tsx",
   },
+  "tabs-vertical-alignment": {
+    loader: () => import("./tabs/vertical-alignment").then((m) => m.VerticalAlignment),
+    file: "en/tabs/vertical-alignment.tsx",
+  },
   "tabs-render-function": {
     loader: () => import("./tabs/render-function").then((m) => m.RenderFunction),
     file: "en/tabs/render-function.tsx",

--- a/apps/docs/src/demos/en/tabs/index.ts
+++ b/apps/docs/src/demos/en/tabs/index.ts
@@ -5,5 +5,6 @@ export {Disabled} from "./disabled";
 export {WithSeparator} from "./with-separator";
 export {Secondary} from "./secondary";
 export {SecondaryVertical} from "./secondary-vertical";
+export {VerticalAlignment} from "./vertical-alignment";
 export {RenderFunction} from "./render-function";
 export {CustomStyles} from "./custom-styles";

--- a/apps/docs/src/demos/en/tabs/vertical-alignment.tsx
+++ b/apps/docs/src/demos/en/tabs/vertical-alignment.tsx
@@ -1,0 +1,52 @@
+import {Tabs} from "@heroui/react";
+
+export function VerticalAlignment() {
+  return (
+    <Tabs align="start" className="w-full max-w-lg" orientation="vertical" variant="secondary">
+      <Tabs.ListContainer>
+        <Tabs.List aria-label="Settings">
+          <Tabs.Tab id="general">
+            General
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="billing">
+            Subscription &amp; Billing
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="appearance">
+            Appearance
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="notifications">
+            Notifications
+            <Tabs.Indicator />
+          </Tabs.Tab>
+          <Tabs.Tab id="privacy">
+            Privacy
+            <Tabs.Indicator />
+          </Tabs.Tab>
+        </Tabs.List>
+      </Tabs.ListContainer>
+      <Tabs.Panel className="px-4" id="general">
+        <h3 className="mb-2 font-semibold">General</h3>
+        <p className="text-sm text-muted">Manage your account information and preferences.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="billing">
+        <h3 className="mb-2 font-semibold">Subscription &amp; Billing</h3>
+        <p className="text-sm text-muted">View and manage your plan and payment methods.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="appearance">
+        <h3 className="mb-2 font-semibold">Appearance</h3>
+        <p className="text-sm text-muted">Choose a theme and adjust the interface density.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="notifications">
+        <h3 className="mb-2 font-semibold">Notifications</h3>
+        <p className="text-sm text-muted">Choose how and when you want to receive notifications.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="px-4" id="privacy">
+        <h3 className="mb-2 font-semibold">Privacy</h3>
+        <p className="text-sm text-muted">Control what you share and who can see your activity.</p>
+      </Tabs.Panel>
+    </Tabs>
+  );
+}

--- a/packages/react/src/components/tabs/tabs.stories.tsx
+++ b/packages/react/src/components/tabs/tabs.stories.tsx
@@ -7,7 +7,12 @@ import {cn} from "tailwind-variants";
 import {Tabs} from "./index";
 
 const meta = {
-  argTypes: {},
+  argTypes: {
+    align: {
+      control: {type: "select"},
+      options: ["start", "center", "end"],
+    },
+  },
   component: Tabs,
   parameters: {
     layout: "centered",
@@ -503,6 +508,16 @@ export const Vertical: Story = {
   args: {
     children: null,
     orientation: "vertical",
+  },
+  render: VerticalTemplate,
+};
+
+export const VerticalAlign: Story = {
+  args: {
+    align: "end",
+    children: null,
+    orientation: "vertical",
+    variant: "secondary",
   },
   render: VerticalTemplate,
 };

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -49,13 +49,14 @@ interface TabsRootProps extends ComponentPropsWithRef<typeof TabsPrimitive>, Tab
 }
 
 const TabsRoot = ({
+  align,
   children,
   className,
   orientation = "horizontal",
   variant,
   ...props
 }: TabsRootProps) => {
-  const slots = React.useMemo(() => tabsVariants({variant}), [variant]);
+  const slots = React.useMemo(() => tabsVariants({align, variant}), [align, variant]);
 
   return (
     <TabsContext value={{orientation, slots}}>

--- a/packages/react/tests/components/tabs/tabs.test.tsx
+++ b/packages/react/tests/components/tabs/tabs.test.tsx
@@ -67,6 +67,22 @@ describe("Tabs", () => {
     );
   });
 
+  it("exposes align BEM modifier", async () => {
+    await renderTabs({align: "start"});
+
+    expect(screen.getByTestId("tabs").className).toEqual(
+      expect.stringContaining("tabs--align-start"),
+    );
+  });
+
+  it("omits the align BEM modifier when centered by default", async () => {
+    await renderTabs();
+
+    expect(screen.getByTestId("tabs").className).toEqual(
+      expect.not.stringContaining("tabs--align-"),
+    );
+  });
+
   it("supports selecting tabs via createTester", async () => {
     const onSelectionChange = vi.fn();
 

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -170,6 +170,18 @@
   }
 }
 
+/* Tab content alignment - center is the default, handled by .tabs__tab.
+   Scoped to the direct child holding the tab list (the list container, or the
+   list itself when Tabs.ListContainer is omitted) so a nested Tabs inside a
+   panel keeps its own alignment. */
+.tabs--align-start > :is(.tabs__list-container, .tabs__list) .tabs__tab {
+  @apply justify-start text-start;
+}
+
+.tabs--align-end > :is(.tabs__list-container, .tabs__list) .tabs__tab {
+  @apply justify-end text-end;
+}
+
 /* Tab separator */
 .tabs__separator {
   @apply pointer-events-none absolute rounded-sm bg-muted/25;

--- a/packages/styles/src/components/tabs/tabs.styles.ts
+++ b/packages/styles/src/components/tabs/tabs.styles.ts
@@ -4,6 +4,7 @@ import {tv} from "tailwind-variants";
 
 export const tabsVariants = tv({
   defaultVariants: {
+    align: "center",
     variant: "primary",
   },
   slots: {
@@ -19,6 +20,15 @@ export const tabsVariants = tv({
     tabPanel: "tabs__panel",
   },
   variants: {
+    align: {
+      center: {}, // No class as the base already centers tab content
+      end: {
+        base: "tabs--align-end",
+      },
+      start: {
+        base: "tabs--align-start",
+      },
+    },
     variant: {
       primary: {},
       secondary: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

From user feedback [here](https://herouiv3.featurebase.app/p/vertical-tabs-allow-for-more-flexible-text-alignment)

Adds an `align` variant to `Tabs` so the alignment of tab content can be set once for the whole list, instead of centering every tab.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

`.tabs__tab` hard-codes `justify-center text-center`. Vertical tab lists — settings-style sidebar navigation with uneven label lengths — are always centered, and the only escape is repeating a `className` override on each `Tabs.Tab`.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

- `Tabs` accepts `align="start" | "center" | "end"`, applied as the BEM modifiers `.tabs--align-start` / `.tabs--align-end` on the root, following the same path as the existing `variant` prop.
- Uses logical properties (`text-start` / `justify-start`), so RTL is correct without extra rules.
- The alignment rules are scoped to the direct child holding the tab list, so a nested `Tabs` inside a panel keeps its own alignment rather than inheriting the parent's.
- Per-tab `className` still wins, since component CSS lives in `layer(components)` and utilities in `layer(utilities)`.
- Adds a `VerticalAlignStart` story plus an `align` select control, a `tabs-vertical-alignment` demo for both en and cn docs, and documents the prop and the two new CSS classes.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

No. The default is `center`, which emits no class, so existing tabs render identically.

## ✅ Testing

- `tabs.test.tsx` asserts the `tabs--align-start` modifier is exposed and that no `tabs--align-` class is emitted by default.
- `pnpm --filter @heroui/react exec vitest run tabs` passes (8 tests), along with `pnpm lint`, `pnpm typecheck`, and Prettier.
- Verified computed styles in a real browser across vertical/horizontal, primary/secondary, all three `align` values, RTL, a `Tabs.List` without `Tabs.ListContainer`, nested tabs, and that overflow scroll chevrons still behave under `align="start"`.

## 📝 Additional Information
