### PR TITLE
docs(table): update Tanstack Table to V9

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -32,7 +32,7 @@
     "@react-stately/data": "3.16.1",
     "@t3-oss/env-nextjs": "0.13.10",
     "@tailwindcss/typography": "0.5.19",
-    "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-table": "9.2.4",
     "@vercel/analytics": "1.6.1",
     "@vercel/og": "0.8.6",
     "calligraph": "1.3.0",

--- a/apps/docs/src/demos/cn/table/tanstack-table.tsx
+++ b/apps/docs/src/demos/cn/table/tanstack-table.tsx
@@ -66,10 +66,10 @@ const features = tableFeatures({
   paginatedRowModel: createPaginatedRowModel(),
   rowPaginationFeature,
   rowSortingFeature,
-  sortedRowModel: createSortedRowModel(),
   sortFns: {
     alphanumeric: sortFn_alphanumeric,
   },
+  sortedRowModel: createSortedRowModel(),
 });
 
 const columnHelper = createColumnHelper<typeof features, User>();

--- a/apps/docs/src/demos/cn/table/tanstack-table.tsx
+++ b/apps/docs/src/demos/cn/table/tanstack-table.tsx
@@ -6,11 +6,14 @@ import type {SortingState} from "@tanstack/react-table";
 import {Chip, Pagination, Table} from "@heroui/react";
 import {
   createColumnHelper,
+  createPaginatedRowModel,
+  createSortedRowModel,
   flexRender,
-  getCoreRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  useReactTable,
+  rowPaginationFeature,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  tableFeatures,
+  useTable,
 } from "@tanstack/react-table";
 import {useMemo, useState} from "react";
 
@@ -58,10 +61,20 @@ const users: User[] = [
   },
 ];
 
-// --- TanStack Column Definitions ------------------------------------------
-const columnHelper = createColumnHelper<User>();
+// --- TanStack Features & Column Definitions -------------------------------
+const features = tableFeatures({
+  paginatedRowModel: createPaginatedRowModel(),
+  rowPaginationFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+  },
+});
 
-const columns = [
+const columnHelper = createColumnHelper<typeof features, User>();
+
+const columns = columnHelper.columns([
   columnHelper.accessor("name", {header: "姓名"}),
   columnHelper.accessor("role", {header: "角色"}),
   columnHelper.accessor("status", {
@@ -73,7 +86,7 @@ const columns = [
     header: "状态",
   }),
   columnHelper.accessor("email", {header: "邮箱"}),
-];
+]);
 
 // --- Sorting Bridge -------------------------------------------------------
 // Convert TanStack SortingState → React Aria SortDescriptor
@@ -99,21 +112,18 @@ const PAGE_SIZE = 4;
 export function TanstackTable() {
   const [sorting, setSorting] = useState<SortingState>([]);
 
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  const table = useTable({
     columns,
     data: users,
-    getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    initialState: {pagination: {pageSize: PAGE_SIZE}},
+    features,
+    initialState: {pagination: {pageIndex: 0, pageSize: PAGE_SIZE}},
     onSortingChange: setSorting,
     state: {sorting},
   });
 
   const sortDescriptor = useMemo(() => toSortDescriptor(sorting), [sorting]);
 
-  const {pageIndex} = table.getState().pagination;
+  const {pageIndex} = table.state.pagination;
   const pageCount = table.getPageCount();
   const pages = Array.from({length: pageCount}, (_, i) => i + 1);
   const start = pageIndex * PAGE_SIZE + 1;
@@ -129,7 +139,7 @@ export function TanstackTable() {
           onSortChange={(d) => setSorting(toSortingState(d))}
         >
           <Table.Header>
-            {table.getHeaderGroups()[0]!.headers.map((header) => (
+            {table.getHeaderGroups()[0]?.headers.map((header) => (
               <Table.Column
                 key={header.id}
                 allowsSorting={header.column.getCanSort()}
@@ -147,7 +157,7 @@ export function TanstackTable() {
           <Table.Body>
             {table.getRowModel().rows.map((row) => (
               <Table.Row key={row.id} id={row.id}>
-                {row.getVisibleCells().map((cell) => (
+                {row.getAllCells().map((cell) => (
                   <Table.Cell key={cell.id}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </Table.Cell>

--- a/apps/docs/src/demos/en/table/tanstack-table.tsx
+++ b/apps/docs/src/demos/en/table/tanstack-table.tsx
@@ -6,11 +6,14 @@ import type {SortingState} from "@tanstack/react-table";
 import {Chip, Pagination, Table} from "@heroui/react";
 import {
   createColumnHelper,
+  createPaginatedRowModel,
+  createSortedRowModel,
   flexRender,
-  getCoreRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  useReactTable,
+  rowPaginationFeature,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  tableFeatures,
+  useTable,
 } from "@tanstack/react-table";
 import {useMemo, useState} from "react";
 
@@ -58,10 +61,20 @@ const users: User[] = [
   },
 ];
 
-// --- TanStack Column Definitions ------------------------------------------
-const columnHelper = createColumnHelper<User>();
+// --- TanStack Features & Column Definitions -------------------------------
+const features = tableFeatures({
+  paginatedRowModel: createPaginatedRowModel(),
+  rowPaginationFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: {
+    alphanumeric: sortFn_alphanumeric,
+  },
+});
 
-const columns = [
+const columnHelper = createColumnHelper<typeof features, User>();
+
+const columns = columnHelper.columns([
   columnHelper.accessor("name", {header: "Name"}),
   columnHelper.accessor("role", {header: "Role"}),
   columnHelper.accessor("status", {
@@ -73,7 +86,7 @@ const columns = [
     header: "Status",
   }),
   columnHelper.accessor("email", {header: "Email"}),
-];
+]);
 
 // --- Sorting Bridge -------------------------------------------------------
 // Convert TanStack SortingState → React Aria SortDescriptor
@@ -99,21 +112,18 @@ const PAGE_SIZE = 4;
 export function TanstackTable() {
   const [sorting, setSorting] = useState<SortingState>([]);
 
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  const table = useTable({
     columns,
     data: users,
-    getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    initialState: {pagination: {pageSize: PAGE_SIZE}},
+    features,
+    initialState: {pagination: {pageIndex: 0, pageSize: PAGE_SIZE}},
     onSortingChange: setSorting,
     state: {sorting},
   });
 
   const sortDescriptor = useMemo(() => toSortDescriptor(sorting), [sorting]);
 
-  const {pageIndex} = table.getState().pagination;
+  const {pageIndex} = table.state.pagination;
   const pageCount = table.getPageCount();
   const pages = Array.from({length: pageCount}, (_, i) => i + 1);
   const start = pageIndex * PAGE_SIZE + 1;
@@ -129,7 +139,7 @@ export function TanstackTable() {
           onSortChange={(d) => setSorting(toSortingState(d))}
         >
           <Table.Header>
-            {table.getHeaderGroups()[0]!.headers.map((header) => (
+            {table.getHeaderGroups()[0]?.headers.map((header) => (
               <Table.Column
                 key={header.id}
                 allowsSorting={header.column.getCanSort()}
@@ -147,7 +157,7 @@ export function TanstackTable() {
           <Table.Body>
             {table.getRowModel().rows.map((row) => (
               <Table.Row key={row.id} id={row.id}>
-                {row.getVisibleCells().map((cell) => (
+                {row.getAllCells().map((cell) => (
                   <Table.Cell key={cell.id}>
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </Table.Cell>

--- a/apps/docs/src/demos/en/table/tanstack-table.tsx
+++ b/apps/docs/src/demos/en/table/tanstack-table.tsx
@@ -66,10 +66,10 @@ const features = tableFeatures({
   paginatedRowModel: createPaginatedRowModel(),
   rowPaginationFeature,
   rowSortingFeature,
-  sortedRowModel: createSortedRowModel(),
   sortFns: {
     alphanumeric: sortFn_alphanumeric,
   },
+  sortedRowModel: createSortedRowModel(),
 });
 
 const columnHelper = createColumnHelper<typeof features, User>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ importers:
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
       '@tanstack/react-table':
-        specifier: 8.21.3
-        version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 9.2.4
+        version: 9.2.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@vercel/analytics':
         specifier: 1.6.1
         version: 1.6.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -351,7 +351,7 @@ importers:
         version: 7.5.21
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10))(jsdom@30.0.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/react:
     dependencies:
@@ -3787,16 +3787,24 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
+  '@tanstack/react-table@9.2.4':
+    resolution: {integrity: sha512-Rzp1Q4e0/nIgEjmISYR5HeEgLTNtrG+C7NFZf/AbCxPO5hg+zC3yNGwcoECigUk8SFzzvhXbd2rFdtP2ZiGrfA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=18'
+
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==}
+
+  '@tanstack/table-core@9.2.4':
+    resolution: {integrity: sha512-GwdDyGGr6UXAtubF14yAwcXvdaogqfsQgIk89Suebjxob/Rjq2xvfmXsjDF1rQmKmhHsJm9TOY7myxv3i6geJw==}
+    engines: {node: '>=20'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -11825,13 +11833,26 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-store@0.11.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/store': 0.11.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/react-table@9.2.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/table-core': 9.2.4
+      react: 19.2.6
+    transitivePeerDependencies:
+      - react-dom
+
+  '@tanstack/store@0.11.1': {}
+
+  '@tanstack/table-core@9.2.4':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -12329,9 +12350,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.10(vite@7.3.5(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -17430,7 +17451,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.0.3)(@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.10))(@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10))(jsdom@30.0.1)(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@7.3.5(@types/node@25.0.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
## 📝 Description

Migrate TanStack Table demo in docs to TanStack Table V9.

## ⛳️ Current behavior (updates)

The table demo was using deprecated TanStack Table V8 APIs (`useReactTable`, `get*RowModel`, `getState()`).

## 🚀 New behavior

- Uses TanStack Table V9 `useTable` hook and `tableFeatures` with `createSortedRowModel` and `createPaginatedRowModel`.
- Configures individual `sortFn_alphanumeric` instead of the deprecated `sortFns` registry.
- Preserves type safety with `createColumnHelper<typeof features, User>()` and `columnHelper.columns()`.

## 💣 Is this a breaking change (Yes/No):

No

## ✅ Testing

- [x] `pnpm --filter @heroui/docs typecheck` passes cleanly.
- [x] `pnpm --filter @heroui/docs lint` passes cleanly.