### PR TITLE
fix(docs): repair legacy component and GSC docs redirects

### DIFF
--- a/apps/docs/next-redirects.ts
+++ b/apps/docs/next-redirects.ts
@@ -329,6 +329,25 @@ export async function getRedirects(): Promise<Redirect[]> {
 
   redirects.push(...generateRedirects(components, "components"));
 
+  // Legacy v2 component URLs should prefer a current React component page.
+  // If no current component uses that slug, route to its v2 migration guide.
+  // Keep this after the component redirects so current pages win when both exist.
+  const migrationComponentsDir = join(rootDir, "migration/(components)");
+  const migrationComponents = await getMdxFiles(migrationComponentsDir);
+  const currentComponents = new Set(components);
+  const migrationOnlyComponents = migrationComponents.filter(
+    (component) => !currentComponents.has(component),
+  );
+
+  redirects.push(
+    ...localizedDocsRedirects(
+      migrationOnlyComponents.map((component) => ({
+        destination: `/docs/react/migration/${component}`,
+        source: `/docs/components/${component}`,
+      })),
+    ),
+  );
+
   // Component name redirects - backward compatibility for renamed components
   redirects.push(
     ...localizedDocsRedirects([
@@ -361,6 +380,18 @@ export async function getRedirects(): Promise<Redirect[]> {
         source: "/docs/components/taggroup",
       },
     ]),
+  );
+
+  // The beta docs exposed source MDX URLs. Point the indexed calendar URL to
+  // its current canonical page rather than allowing the raw path to 404.
+  redirects.push(
+    ...localizedDocsRedirect("/docs/components/calendar.mdx", "/docs/react/components/calendar"),
+  );
+
+  // Unknown legacy component slugs should fail in the current React namespace,
+  // never under the removed `/docs/components/*` namespace.
+  redirects.push(
+    ...localizedDocsRedirect("/docs/components/:path*", "/docs/react/components/:path*"),
   );
 
   // Handbook migration: redirect old handbook paths to new getting-started paths

--- a/apps/docs/next-redirects.ts
+++ b/apps/docs/next-redirects.ts
@@ -82,7 +82,7 @@ function localizedDocsRedirect(source: string, destination: string): Redirect[] 
     );
   }
 
-  return [
+  const redirects: Redirect[] = [
     // Locale-prefixed (preserves the visitor's current language).
     {
       destination: `/:lang${destination}`,
@@ -96,6 +96,30 @@ function localizedDocsRedirect(source: string, destination: string): Redirect[] 
       source,
     },
   ];
+
+  // Beta and crawler URLs often append `.mdx`. Send those to the HTML page,
+  // never to a locale-prefixed copy of the removed path.
+  if (!source.includes(":") && !source.endsWith(".mdx")) {
+    redirects.push(...localizedDocsRedirect(`${source}.mdx`, destination));
+  }
+
+  return redirects;
+}
+
+function compactSlug(slug: string): string {
+  return slug.replace(/-/g, "");
+}
+
+const COMPOUND_SUFFIXES = ["input", "box", "group", "field", "button", "picker"] as const;
+
+function hyphenatedSuffixAliases(slug: string): string[] {
+  if (slug.includes("-")) return [];
+
+  return COMPOUND_SUFFIXES.flatMap((suffix) =>
+    slug.endsWith(suffix) && slug.length > suffix.length
+      ? [`${slug.slice(0, -suffix.length)}-${suffix}`]
+      : [],
+  );
 }
 
 /**
@@ -335,16 +359,41 @@ export async function getRedirects(): Promise<Redirect[]> {
   const migrationComponentsDir = join(rootDir, "migration/(components)");
   const migrationComponents = await getMdxFiles(migrationComponentsDir);
   const currentComponents = new Set(components);
+  const currentByCompact = new Map(
+    components.map((component) => [compactSlug(component), component]),
+  );
   const migrationOnlyComponents = migrationComponents.filter(
-    (component) => !currentComponents.has(component),
+    (component) =>
+      !currentComponents.has(component) && !currentByCompact.has(compactSlug(component)),
   );
 
   redirects.push(
     ...localizedDocsRedirects(
-      migrationOnlyComponents.map((component) => ({
-        destination: `/docs/react/migration/${component}`,
-        source: `/docs/components/${component}`,
-      })),
+      migrationOnlyComponents.flatMap((component) => {
+        const destination = `/docs/react/migration/${component}`;
+
+        return [component, ...hyphenatedSuffixAliases(component)].map((source) => ({
+          destination,
+          source: `/docs/components/${source}`,
+        }));
+      }),
+    ),
+  );
+
+  // Compact legacy slugs whose hyphenated form is a live component
+  // (e.g. /docs/components/listbox -> /docs/react/components/list-box).
+  redirects.push(
+    ...localizedDocsRedirects(
+      [...currentByCompact.entries()].flatMap(([compact, current]) => {
+        if (compact === current || currentComponents.has(compact)) return [];
+
+        return [
+          {
+            destination: `/docs/react/components/${current}`,
+            source: `/docs/components/${compact}`,
+          },
+        ];
+      }),
     ),
   );
 
@@ -382,16 +431,62 @@ export async function getRedirects(): Promise<Redirect[]> {
     ]),
   );
 
-  // The beta docs exposed source MDX URLs. Point the indexed calendar URL to
-  // its current canonical page rather than allowing the raw path to 404.
-  redirects.push(
-    ...localizedDocsRedirect("/docs/components/calendar.mdx", "/docs/react/components/calendar"),
-  );
-
   // Unknown legacy component slugs should fail in the current React namespace,
   // never under the removed `/docs/components/*` namespace.
   redirects.push(
+    ...localizedDocsRedirect("/docs/components/:path*.mdx", "/docs/react/components/:path*"),
     ...localizedDocsRedirect("/docs/components/:path*", "/docs/react/components/:path*"),
+  );
+
+  // Pre-v3 docs namespaces that have no `/react` prefix. Catch-alls must come
+  // after more specific mappings (e.g. /docs/customization/colors).
+  redirects.push(
+    ...localizedDocsRedirects([
+      {
+        destination: "/docs/react/getting-started/frameworks",
+        source: "/docs/frameworks",
+      },
+      {
+        destination: "/docs/react/getting-started/frameworks",
+        source: "/docs/frameworks/vite",
+      },
+      {
+        destination: "/docs/react/getting-started/frameworks",
+        source: "/docs/frameworks/nextjs",
+      },
+      {
+        destination: "/docs/react/getting-started/theming",
+        source: "/docs/customization",
+      },
+      {
+        destination: "/docs/react/getting-started/theming",
+        source: "/docs/customization/create-theme",
+      },
+      {
+        destination: "/docs/react/getting-started/theming",
+        source: "/docs/customization/theme",
+      },
+      {
+        destination: "/docs/react/migration",
+        source: "/docs/guide",
+      },
+      {
+        destination: "/docs/react/migration",
+        source: "/docs/guide/nextui-to-heroui",
+      },
+    ]),
+    ...localizedDocsRedirect(
+      "/docs/frameworks/:path*.mdx",
+      "/docs/react/getting-started/frameworks",
+    ),
+    ...localizedDocsRedirect("/docs/frameworks/:path*", "/docs/react/getting-started/frameworks"),
+    ...localizedDocsRedirect(
+      "/docs/customization/:path*.mdx",
+      "/docs/react/getting-started/theming",
+    ),
+    ...localizedDocsRedirect("/docs/customization/:path*", "/docs/react/getting-started/theming"),
+    ...localizedDocsRedirect("/docs/guide/:path*.mdx", "/docs/react/migration"),
+    ...localizedDocsRedirect("/docs/guide/:path*", "/docs/react/migration"),
   );
 
   // Handbook migration: redirect old handbook paths to new getting-started paths

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -32,6 +32,7 @@ const PUBLIC_FILE_PATTERN = /\.[a-z0-9]+$/i;
 const UNRESOLVED_TEMPLATE_PATTERN = /(?:\{[^/{}]+\}|%7B[^/]+%7D)/i;
 const PERMANENT_LOCALIZED_PREFIXES = ["/blog", "/docs", "/showcase", "/themes"];
 const TRUST_PATHS = new Set(["/about", "/contact", "/privacy"]);
+const GONE_BUILD_PATHS = new Set(["/en/node_modules/heroui-native/lib", "/en/src/uniwind.d.ts"]);
 
 // Routes that live outside `app/[lang]` and must never receive a locale prefix.
 const LOCALE_REDIRECT_EXCLUDED_PREFIXES = [
@@ -91,6 +92,17 @@ function addHomepageDiscoveryHeaders(response: NextResponse, pathname: string): 
 
 export function proxy(request: NextRequest) {
   const {pathname} = request.nextUrl;
+
+  if (GONE_BUILD_PATHS.has(pathname.replace(/\/$/, ""))) {
+    return new NextResponse("Gone", {
+      headers: {
+        "Cache-Control": "public, max-age=0, s-maxage=86400",
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Robots-Tag": "noindex, nofollow",
+      },
+      status: 410,
+    });
+  }
 
   if (UNRESOLVED_TEMPLATE_PATTERN.test(pathname)) {
     return new NextResponse("Not Found", {

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -105,13 +105,13 @@ export function proxy(request: NextRequest) {
   }
 
   if (UNRESOLVED_TEMPLATE_PATTERN.test(pathname)) {
-    return new NextResponse("Not Found", {
+    return new NextResponse("Gone", {
       headers: {
-        "Cache-Control": "public, max-age=0, s-maxage=3600",
+        "Cache-Control": "public, max-age=0, s-maxage=86400",
         "Content-Type": "text/plain; charset=utf-8",
         "X-Robots-Tag": "noindex, nofollow",
       },
-      status: 404,
+      status: 410,
     });
   }
 

--- a/apps/docs/tests/redirects.test.ts
+++ b/apps/docs/tests/redirects.test.ts
@@ -1,0 +1,74 @@
+import {NextRequest} from "next/server";
+import {describe, expect, it} from "vitest";
+
+import {proxy} from "@/proxy";
+
+import {getRedirects} from "../next-redirects";
+
+type Redirect = Awaited<ReturnType<typeof getRedirects>>[number];
+
+function findRedirect(redirects: Redirect[], source: string): Redirect | undefined {
+  return redirects.find((redirect) => redirect.source === source);
+}
+
+describe("Docs redirects", () => {
+  it.each(["navbar", "progress"])(
+    "redirects the legacy %s component URL to its migration guide",
+    async (component) => {
+      const redirects = await getRedirects();
+      const destination = `/docs/react/migration/${component}`;
+
+      expect(findRedirect(redirects, `/docs/components/${component}`)).toMatchObject({
+        destination: `/en${destination}`,
+        permanent: true,
+      });
+      expect(findRedirect(redirects, `/:lang(en|cn)/docs/components/${component}`)).toMatchObject({
+        destination: `/:lang${destination}`,
+        permanent: true,
+      });
+    },
+  );
+
+  it("prefers an existing React component page over its migration guide", async () => {
+    const redirects = await getRedirects();
+
+    expect(findRedirect(redirects, "/docs/components/calendar")).toMatchObject({
+      destination: "/en/docs/react/components/calendar",
+      permanent: true,
+    });
+  });
+
+  it("redirects the leaked beta calendar MDX URL to the current component page", async () => {
+    const redirects = await getRedirects();
+
+    expect(findRedirect(redirects, "/docs/components/calendar.mdx")).toMatchObject({
+      destination: "/en/docs/react/components/calendar",
+      permanent: true,
+    });
+  });
+
+  it("maps unknown legacy component URLs into the current namespace", async () => {
+    const redirects = await getRedirects();
+
+    expect(findRedirect(redirects, "/docs/components/:path*")).toMatchObject({
+      destination: "/en/docs/react/components/:path*",
+      permanent: true,
+    });
+    expect(findRedirect(redirects, "/:lang(en|cn)/docs/components/:path*")).toMatchObject({
+      destination: "/:lang/docs/react/components/:path*",
+      permanent: true,
+    });
+  });
+});
+
+describe("Leaked build paths", () => {
+  it.each(["/en/src/uniwind.d.ts", "/en/node_modules/heroui-native/lib"])(
+    "returns 410 for %s",
+    (pathname) => {
+      const response = proxy(new NextRequest(`https://heroui.com${pathname}`));
+
+      expect(response.status).toBe(410);
+      expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+    },
+  );
+});

--- a/apps/docs/tests/redirects.test.ts
+++ b/apps/docs/tests/redirects.test.ts
@@ -11,57 +11,98 @@ function findRedirect(redirects: Redirect[], source: string): Redirect | undefin
   return redirects.find((redirect) => redirect.source === source);
 }
 
-describe("Docs redirects", () => {
-  it.each(["navbar", "progress"])(
-    "redirects the legacy %s component URL to its migration guide",
-    async (component) => {
-      const redirects = await getRedirects();
-      const destination = `/docs/react/migration/${component}`;
+function expectLegacyDocsRedirect(
+  redirects: Redirect[],
+  source: string,
+  destination: string,
+): void {
+  expect(findRedirect(redirects, source)).toMatchObject({
+    destination: `/en${destination}`,
+    permanent: true,
+  });
+  expect(findRedirect(redirects, `/:lang(en|cn)${source}`)).toMatchObject({
+    destination: `/:lang${destination}`,
+    permanent: true,
+  });
+}
 
-      expect(findRedirect(redirects, `/docs/components/${component}`)).toMatchObject({
-        destination: `/en${destination}`,
-        permanent: true,
-      });
-      expect(findRedirect(redirects, `/:lang(en|cn)/docs/components/${component}`)).toMatchObject({
-        destination: `/:lang${destination}`,
-        permanent: true,
-      });
+describe("Docs redirects", () => {
+  it.each([
+    ["navbar", "/docs/react/migration/navbar"],
+    ["progress", "/docs/react/migration/progress"],
+    ["divider", "/docs/react/migration/divider"],
+    ["snippet", "/docs/react/migration/snippet"],
+    ["date-input", "/docs/react/migration/dateinput"],
+    ["time-input", "/docs/react/migration/timeinput"],
+  ])(
+    "redirects the legacy %s component URL to its migration guide",
+    async (component, destination) => {
+      const redirects = await getRedirects();
+
+      expectLegacyDocsRedirect(redirects, `/docs/components/${component}`, destination);
     },
   );
 
   it("prefers an existing React component page over its migration guide", async () => {
     const redirects = await getRedirects();
 
-    expect(findRedirect(redirects, "/docs/components/calendar")).toMatchObject({
-      destination: "/en/docs/react/components/calendar",
-      permanent: true,
-    });
+    expectLegacyDocsRedirect(
+      redirects,
+      "/docs/components/calendar",
+      "/docs/react/components/calendar",
+    );
+    expectLegacyDocsRedirect(
+      redirects,
+      "/docs/components/listbox",
+      "/docs/react/components/list-box",
+    );
   });
 
-  it("redirects the leaked beta calendar MDX URL to the current component page", async () => {
+  it("redirects leaked component MDX URLs to the current HTML page", async () => {
     const redirects = await getRedirects();
 
-    expect(findRedirect(redirects, "/docs/components/calendar.mdx")).toMatchObject({
-      destination: "/en/docs/react/components/calendar",
-      permanent: true,
-    });
+    expectLegacyDocsRedirect(
+      redirects,
+      "/docs/components/calendar.mdx",
+      "/docs/react/components/calendar",
+    );
+    expectLegacyDocsRedirect(
+      redirects,
+      "/docs/components/alert-dialog.mdx",
+      "/docs/react/components/alert-dialog",
+    );
+    expectLegacyDocsRedirect(
+      redirects,
+      "/docs/components/skeleton.mdx",
+      "/docs/react/components/skeleton",
+    );
+  });
+
+  it.each([
+    ["/docs/frameworks/vite", "/docs/react/getting-started/frameworks"],
+    ["/docs/frameworks/nextjs", "/docs/react/getting-started/frameworks"],
+    ["/docs/customization/create-theme", "/docs/react/getting-started/theming"],
+    ["/docs/customization/theme", "/docs/react/getting-started/theming"],
+    ["/docs/guide/nextui-to-heroui", "/docs/react/migration"],
+  ])("maps legacy %s into the React docs namespace", async (source, destination) => {
+    const redirects = await getRedirects();
+
+    expectLegacyDocsRedirect(redirects, source, destination);
   });
 
   it("maps unknown legacy component URLs into the current namespace", async () => {
     const redirects = await getRedirects();
 
-    expect(findRedirect(redirects, "/docs/components/:path*")).toMatchObject({
-      destination: "/en/docs/react/components/:path*",
-      permanent: true,
-    });
-    expect(findRedirect(redirects, "/:lang(en|cn)/docs/components/:path*")).toMatchObject({
-      destination: "/:lang/docs/react/components/:path*",
-      permanent: true,
-    });
+    expectLegacyDocsRedirect(redirects, "/docs/components/:path*", "/docs/react/components/:path*");
+    expectLegacyDocsRedirect(
+      redirects,
+      "/docs/components/:path*.mdx",
+      "/docs/react/components/:path*",
+    );
   });
 });
 
-describe("Leaked build paths", () => {
+describe("Leaked and placeholder paths", () => {
   it.each(["/en/src/uniwind.d.ts", "/en/node_modules/heroui-native/lib"])(
     "returns 410 for %s",
     (pathname) => {
@@ -71,4 +112,15 @@ describe("Leaked build paths", () => {
       expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
     },
   );
+
+  it.each([
+    "/docs/react/getting-started/{topic}.mdx",
+    "/en/docs/react/getting-started/{topic}.mdx",
+    "/docs/react/getting-started/%7Btopic%7D.mdx",
+  ])("returns 410 for the unresolved template URL %s", (pathname) => {
+    const response = proxy(new NextRequest(`https://heroui.com${pathname}`));
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow");
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Google Search Console 404 validation failures caused by legacy docs URLs resolving under removed namespaces such as `/docs/components/*`, `/docs/frameworks/*`, `/docs/customization/*`, and `/docs/guide/*`.

Bare `/docs/...` links must never stay at `/en/docs/...` without `/react`. Permanent locale-aware redirects send them to a live React page, a v2 migration guide, or the current React namespace for a sensible 404.

## Mapped destinations

All of these are permanent (`308`/`permanent: true`) and also apply to `/en/...` and `/cn/...`. `.mdx` sources for the same slugs go to the HTML page, not a raw MDX URL.

### Components (GSC)

| Source | Destination |
| --- | --- |
| `/docs/components/navbar` | `/en/docs/react/migration/navbar` |
| `/docs/components/progress` | `/en/docs/react/migration/progress` |
| `/docs/components/date-input` | `/en/docs/react/migration/dateinput` |
| `/docs/components/time-input` | `/en/docs/react/migration/timeinput` |
| `/docs/components/divider` | `/en/docs/react/migration/divider` |
| `/docs/components/snippet` | `/en/docs/react/migration/snippet` |
| `/docs/components/listbox` | `/en/docs/react/components/list-box` |
| `/docs/components/:path*` (unknown slug) | `/en/docs/react/components/:path*` |

### Other legacy docs namespaces (GSC)

| Source | Destination |
| --- | --- |
| `/docs/frameworks/vite` | `/en/docs/react/getting-started/frameworks` |
| `/docs/frameworks/nextjs` | `/en/docs/react/getting-started/frameworks` |
| `/docs/customization/create-theme` | `/en/docs/react/getting-started/theming` |
| `/docs/customization/theme` | `/en/docs/react/getting-started/theming` |
| `/docs/guide/nextui-to-heroui` | `/en/docs/react/migration` |

`/docs/customization/colors` still maps to `/en/docs/react/getting-started/colors` (existing specific rule wins over the theming catch-all).

### Leaked / beta / placeholder URLs

| Source | Behavior |
| --- | --- |
| `/docs/components/calendar.mdx` | → `/en/docs/react/components/calendar` |
| `/docs/components/alert-dialog.mdx` (incl. `v3.heroui.com` if this app serves it) | → `/en/docs/react/components/alert-dialog` |
| `/docs/components/skeleton.mdx` | → `/en/docs/react/components/skeleton` |
| `/en/src/uniwind.d.ts` | `410 Gone` + `noindex, nofollow` |
| `/en/node_modules/heroui-native/lib` | `410 Gone` + `noindex, nofollow` |
| `/docs/react/getting-started/{topic}.mdx` (literal braces / `%7Btopic%7D`) | `410 Gone` + `noindex, nofollow` |

## Out of docs scope (needs Junior / infra)

These hosts are not owned by the docs app redirects in this PR:

- `staging-platform.heroui.com` (403)
- `staging-migration-mcp.heroui.com` (5xx)
- `migration-mcp.heroui.com` (5xx)

## Testing

- [x] `apps/docs/tests/redirects.test.ts` covers navbar/progress, the new GSC paths, MDX aliases, catch-alls, leaked build paths, and `{topic}.mdx` 410s
- [x] `pnpm --filter @heroui/docs exec vitest run tests/redirects.test.ts` — 19 passed
- [x] Docs lint on the touched files via lint-staged
- [x] Docs typecheck previously passed for this app

Docs-only / redirect-focused; no package changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ab4b226-77de-4cb3-8ccf-ed31da2b96c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ab4b226-77de-4cb3-8ccf-ed31da2b96c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

