### PR TITLE
fix(docs): reveal sidebar scrollbar on hover

### DIFF
--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -314,13 +314,6 @@
   }
 }
 
-/* Fumadocs paints the scroll thumb with `bg-fd-border`, which is too faint to notice on hover.
-   `--scrollbar` is the theme-aware thumb color the rest of the docs already scroll with. */
-#nd-sidebar [data-radix-scroll-area-viewport] ~ [data-orientation="vertical"] > *,
-#nd-sidebar-mobile [data-radix-scroll-area-viewport] ~ [data-orientation="vertical"] > * {
-  background-color: var(--scrollbar, var(--color-fd-border));
-}
-
 /* Keep CJK phrases together so they wrap as a whole word instead of breaking between characters. 
    Safe for non-CJK locales since `keep-all` behaves like `normal` for non-CJK text. */
 #nd-sidebar a,

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -314,6 +314,13 @@
   }
 }
 
+/* Fumadocs paints the scroll thumb with `bg-fd-border`, which is too faint to notice on hover.
+   `--scrollbar` is the theme-aware thumb color the rest of the docs already scroll with. */
+#nd-sidebar [data-radix-scroll-area-viewport] ~ [data-orientation="vertical"] > *,
+#nd-sidebar-mobile [data-radix-scroll-area-viewport] ~ [data-orientation="vertical"] > * {
+  background-color: var(--scrollbar, var(--color-fd-border));
+}
+
 /* Keep CJK phrases together so they wrap as a whole word instead of breaking between characters. 
    Safe for non-CJK locales since `keep-all` behaves like `normal` for non-CJK text. */
 #nd-sidebar a,

--- a/apps/docs/src/components/fumadocs/layouts/notebook/index.tsx
+++ b/apps/docs/src/components/fumadocs/layouts/notebook/index.tsx
@@ -143,7 +143,10 @@ export function DocsLayout(props: DocsLayoutProps) {
         ? (nav.title({} as ComponentProps<"a">) as ReactNode)
         : nav.title;
     const viewport = (
-      <SidebarViewport>
+      // Fumadocs defaults the scroll area to `type="scroll"`, which only reveals the thumb while
+      // the user is actively scrolling. `hover` matches the v2 docs sidebar so the scrollbar is
+      // discoverable by pointing at the nav.
+      <SidebarViewport area={{type: "hover"}}>
         {links
           .filter((item) => item.type !== "icon")
           .map((item, i, arr) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6825

## 📝 Description

The docs sidebar scrolls, but the scrollbar was undiscoverable — pointing at the nav revealed nothing, so there was no affordance telling readers the list continues below the fold. In the v2 docs, hovering the sidebar revealed the scrollbar.

Root cause is in the vendored Fumadocs notebook layout. `SidebarViewport` wraps the nav in a Radix `ScrollArea`, and Fumadocs hardcodes `type="scroll"` on the Radix root. In that mode Radix keeps the thumb **unmounted** unless a scroll event is in flight, then fades it out shortly after scrolling stops — so hovering does nothing. The v2 docs sidebar (`apps/docs/components/scroll-area.tsx` on the `v2` branch) built its Radix root without a `type` prop and therefore got Radix's default `type="hover"`, which is the behavior readers remember.

## ⛳️ Current behavior (updates)

Hovering the component sidebar shows no scrollbar; the thumb only flashes while the wheel is actively turning. Confirmed against the live site on `https://heroui.com/en/docs/react/components/tag-group`: with the pointer held over the sidebar nav, no Radix scrollbar element is mounted at all.

## 🚀 New behavior

`SidebarViewport` is passed `area={{type: "hover"}}`, restoring the v2 hover-reveal: the thumb mounts on pointer enter and unmounts after Radix's `scrollHideDelay` once the pointer leaves. `area` is Fumadocs' documented passthrough to the Radix root, and `type` is spread after Fumadocs' own default, so this needs no fork of the Fumadocs base component and no CSS.

One line in one file. The same `viewport` element backs the mobile drawer (`#nd-sidebar-mobile`), so it inherits the change; verified below that touch interaction still reveals the thumb there, so there is no mobile regression. The thumb keeps Fumadocs' default `bg-fd-border`, so the sidebar stays visually consistent with the other Fumadocs scroll areas.

No package source or release notes are touched.

## 💣 Is this a breaking change (Yes/No):

No. Docs-only presentation change.

## ✅ Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only pre-existing `import/order` warnings in `src/lib/source.ts` and `tests/agent-readiness.test.ts`)
- [x] `pnpm --filter @heroui/docs test` passes (27 tests)
- [x] `next build` of `apps/docs` succeeds

No behavioral test suite is added: the change is a single prop on a docs-app layout, and the docs app has no component test harness (`packages/react/tests/` covers library components only).

Verified in Chromium by driving a real pointer and reading the mounted Radix scrollbar element, against both the live site and this branch's Vercel preview (a real production build):

| Pointer state | `heroui.com` (current) | This branch's preview |
|---|---|---|
| Idle, pointer on main content | not mounted | not mounted |
| **Hovering the sidebar nav** | **not mounted** | **mounted, `data-state="visible"`, 6×201px thumb** |
| Pointer left the sidebar | not mounted | not mounted, after `scrollHideDelay` |

Also confirmed the thumb renders in both light and dark themes, and that the mobile drawer still reveals its thumb on touch interaction.

Before/after, hovering the sidebar in the same position:

![Side by side crop of the docs sidebar while hovered: before the fix no scrollbar is visible, after the fix a vertical scrollbar thumb is visible on the right edge](https://cursor.com/artifacts/c/art-5131fb21-2313-49e8-aeff-218fd8b70f4a)

Full interaction — pointer off the sidebar (no scrollbar), pointer moves on (scrollbar appears), scrolling, pointer moves off (scrollbar disappears), and hovering again:

<a href="https://cursor.com/agents/bc-3fde72c3-d274-4490-9033-6408895b5617/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_sidebar_scrollbar_hover_reveal.mp4"><img src="https://cursor.com/artifacts/c/art-d4e7673d-94d8-4a4c-9c21-b842eeab38e7" alt="docs_sidebar_scrollbar_hover_reveal.mp4" /></a>

## 📝 Additional Information

`type="hover"` is the same Radix mode the v2 docs used, so this restores prior behavior rather than introducing a new interaction pattern.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fde72c3-d274-4490-9033-6408895b5617?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fde72c3-d274-4490-9033-6408895b5617&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

