### PR TITLE
fix(react): re-export RAC primitives to share one react-aria instance (fix #6826)

### DIFF
--- a/packages/react/src/components/rac/components.tsx
+++ b/packages/react/src/components/rac/components.tsx
@@ -1,3 +1,12 @@
 "use client";
 
-export {Collection, ListBoxLoadMoreItem, RouterProvider, I18nProvider} from "react-aria-components";
+export {
+  Collection,
+  ListBoxLoadMoreItem,
+  RouterProvider,
+  I18nProvider,
+  Pressable,
+  Focusable,
+  OverlayTriggerStateContext,
+  DisclosureStateContext,
+} from "react-aria-components";

--- a/packages/react/src/components/rac/index.ts
+++ b/packages/react/src/components/rac/index.ts
@@ -7,7 +7,16 @@ export {
   ListLayout,
 } from "react-aria-components";
 export {getLocalizationScript} from "react-aria-components/i18n";
-export {Collection, ListBoxLoadMoreItem, RouterProvider, I18nProvider} from "./components";
+export {
+  Collection,
+  ListBoxLoadMoreItem,
+  RouterProvider,
+  I18nProvider,
+  Pressable,
+  Focusable,
+  OverlayTriggerStateContext,
+  DisclosureStateContext,
+} from "./components";
 export {parseColor} from "./utils";
 export type {
   Key,

--- a/packages/react/tests/components/rac/rac.test.tsx
+++ b/packages/react/tests/components/rac/rac.test.tsx
@@ -1,0 +1,25 @@
+import {
+  DisclosureStateContext as RacDisclosureStateContext,
+  Focusable as RacFocusable,
+  I18nProvider as RacI18nProvider,
+  OverlayTriggerStateContext as RacOverlayTriggerStateContext,
+  Pressable as RacPressable,
+} from "react-aria-components";
+
+import {
+  DisclosureStateContext,
+  Focusable,
+  I18nProvider,
+  OverlayTriggerStateContext,
+  Pressable,
+} from "@/components/rac";
+
+describe("RAC re-exports", () => {
+  it("exposes Pressable, Focusable, and overlay/disclosure state contexts from HeroUI's react-aria-components instance", () => {
+    expect(Pressable).toBe(RacPressable);
+    expect(Focusable).toBe(RacFocusable);
+    expect(OverlayTriggerStateContext).toBe(RacOverlayTriggerStateContext);
+    expect(DisclosureStateContext).toBe(RacDisclosureStateContext);
+    expect(I18nProvider).toBe(RacI18nProvider);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #6826

## 📝 Description

Libraries built on `@heroui/react` sometimes need RAC primitives that HeroUI did not re-export. Importing `react-aria-components` directly can produce a **second Vite-optimized instance** of the same package. Contexts then split: HeroUI writes into one object, the consumer reads another.

This is not a version or lockfile problem. Vite’s dependency optimizer can emit two chunks from the same file. The defect shows up in raw SSR HTML (e.g. disclosure `data-state="closed"` beside `aria-expanded="true"`). React then discards the server tree on hydrate.

HeroUI already re-exports `I18nProvider` and `useLocale` for this reason. This PR extends that surface with the four primitives requested in #6826:

- `Pressable`
- `Focusable`
- `OverlayTriggerStateContext`
- `DisclosureStateContext`

Consumers import them from `@heroui/react` and share HeroUI’s react-aria instance by construction.

## ⛳️ Current behavior (updates)

`Pressable`, `Focusable`, `OverlayTriggerStateContext`, and `DisclosureStateContext` are `undefined` on `@heroui/react`. Downstream libraries must import `react-aria-components` directly, which can split contexts under Vite.

## 🚀 New behavior

The four symbols are re-exported from `@heroui/react` via the existing RAC barrel (`packages/react/src/components/rac`), matching `I18nProvider`. A jsdom export test asserts they are the same references as `react-aria-components`.

## 💣 Is this a breaking change (Yes/No):

No. Additive public re-exports only.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable (N/A — export identity only)
- [x] `pnpm --filter @heroui/react exec vitest run rac --project react-jsdom` passes locally
- [x] `pnpm --filter @heroui/react typecheck` passes locally

## 📝 Additional Information

Packages-only patch against `v3.2.5`. See https://github.com/heroui-inc/heroui/issues/6826.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49bb16a7-419b-4eca-b17c-5dabecb2f5a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49bb16a7-419b-4eca-b17c-5dabecb2f5a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

