### PR TITLE
fix(toast): keep options that toast.update omits

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(overlays)/toast.mdx
+++ b/apps/docs/content/docs/cn/react/components/(overlays)/toast.mdx
@@ -288,9 +288,10 @@ const eventId = toast("Event has been created", {
   indicator: <CustomIcon />,
 });
 
-// 原地更新已有 Toast（保持其在堆叠中的位置）
+// 原地更新已有 Toast（保持其在堆叠中的位置）。
+// 省略的选项会被继承，因此若原 Toast 是持久的，需要显式传入 `timeout` 才会开始倒计时。
 const id = toast("Saving…", { timeout: 0 });
-toast.update(id, "Saved", { variant: "success" });
+toast.update(id, "Saved", { variant: "success", timeout: 4000 });
 
 // Promise 支持（自动显示加载指示）。Promise 结束时加载 Toast 会原地更新 —
 // 同一个 Toast、同一个堆叠位置；自动关闭倒计时从这一刻开始。
@@ -309,8 +310,8 @@ const loadingId = toast("Creating event...", {
   timeout: 0, // 持久 toast：不自动消失
 });
 
-// 随后原地更新
-toast.update(loadingId, "Event created", { variant: "success" });
+// 随后原地更新，并开始自动关闭倒计时
+toast.update(loadingId, "Event created", { variant: "success", timeout: 4000 });
 
 // 队列方法
 toast.close(key);

--- a/apps/docs/content/docs/en/react/components/(overlays)/toast.mdx
+++ b/apps/docs/content/docs/en/react/components/(overlays)/toast.mdx
@@ -296,9 +296,11 @@ const eventId = toast("Event has been created", {
   indicator: <CustomIcon />,
 });
 
-// Update an existing toast in place (keeps its position in the stack)
+// Update an existing toast in place (keeps its position in the stack).
+// Options you omit are inherited, so pass `timeout` to start a countdown
+// on a toast that was created persistent.
 const id = toast("Saving…", { timeout: 0 });
-toast.update(id, "Saved", { variant: "success" });
+toast.update(id, "Saved", { variant: "success", timeout: 4000 });
 
 // Promise support (automatically shows loading spinner). The loading toast
 // updates in place when the promise settles — same toast, same stack
@@ -318,8 +320,8 @@ const loadingId = toast("Creating event...", {
   timeout: 0, // Persistent toast that doesn't auto-dismiss
 });
 
-// Later, update in place
-toast.update(loadingId, "Event created", { variant: "success" });
+// Later, update in place and start the auto-dismiss countdown
+toast.update(loadingId, "Event created", { variant: "success", timeout: 4000 });
 
 // Queue methods
 toast.close(key);

--- a/packages/react/src/components/toast/toast-queue.ts
+++ b/packages/react/src/components/toast/toast-queue.ts
@@ -458,13 +458,22 @@ function createToastFunction(queue: ToastQueue<ToastContentValue>) {
     isLoading: options?.isLoading,
   });
 
-  const createQueueOptions = (options?: HeroUIToastOptions) => ({
+  const createAddOptions = (options?: HeroUIToastOptions) => ({
     timeout: options?.timeout ?? DEFAULT_TOAST_TIMEOUT,
     onClose: options?.onClose,
   });
 
+  // update() distinguishes an absent key from an explicit undefined: it keeps the
+  // current countdown and the current onClose for anything the caller left out. So
+  // only forward keys that were actually passed, rather than resolving defaults the
+  // way createAddOptions does.
+  const createUpdateOptions = (options?: HeroUIToastOptions) => ({
+    ...(options && "timeout" in options ? {timeout: options.timeout} : null),
+    ...(options && "onClose" in options ? {onClose: options.onClose} : null),
+  });
+
   const toastFn = (message: ReactNode, options?: HeroUIToastOptions): string => {
-    return queue.add(createContent(message, options), createQueueOptions(options));
+    return queue.add(createContent(message, options), createAddOptions(options));
   };
 
   toastFn.success = (message: ReactNode, options?: Omit<HeroUIToastOptions, "variant">): string => {
@@ -485,15 +494,16 @@ function createToastFunction(queue: ToastQueue<ToastContentValue>) {
   };
 
   // Updates a toast in place (same key, same stack position); falls back to a new toast when the id no longer exists.
+  // Omitting timeout keeps the existing countdown; omitting onClose keeps the existing handler.
   toastFn.update = (id: string, message: ReactNode, options?: HeroUIToastOptions): string => {
     const content = createContent(message, options);
-    const queueOptions = createQueueOptions(options);
 
-    if (queue.update(id, content, queueOptions)) {
+    if (queue.update(id, content, createUpdateOptions(options))) {
       return id;
     }
 
-    return queue.add(content, queueOptions);
+    // A brand new toast has nothing to inherit, so it resolves the defaults instead.
+    return queue.add(content, createAddOptions(options));
   };
 
   // Shows a loading toast that settles in place when the promise resolves or rejects; the auto-dismiss countdown starts at that point.
@@ -509,12 +519,22 @@ function createToastFunction(queue: ToastQueue<ToastContentValue>) {
         const message =
           typeof options.success === "function" ? options.success(data) : options.success;
 
-        return toastFn.update(loadingId, message, {isLoading: false, variant: "success"});
+        // The loading toast was added persistent, so settling has to start the
+        // countdown explicitly now that an omitted timeout is inherited.
+        return toastFn.update(loadingId, message, {
+          isLoading: false,
+          timeout: DEFAULT_TOAST_TIMEOUT,
+          variant: "success",
+        });
       })
       .catch((error: Error) => {
         const message = typeof options.error === "function" ? options.error(error) : options.error;
 
-        return toastFn.update(loadingId, message, {isLoading: false, variant: "danger"});
+        return toastFn.update(loadingId, message, {
+          isLoading: false,
+          timeout: DEFAULT_TOAST_TIMEOUT,
+          variant: "danger",
+        });
       });
 
     return loadingId;

--- a/packages/react/src/components/toast/toast.stories.tsx
+++ b/packages/react/src/components/toast/toast.stories.tsx
@@ -9,6 +9,7 @@ import {Button} from "../button";
 import {Modal} from "../modal";
 
 import {
+  DEFAULT_TOAST_TIMEOUT,
   Toast,
   ToastContent,
   ToastDescription,
@@ -395,6 +396,7 @@ const LoadingStateTemplate = () => {
             setTimeout(() => {
               toast.update(loadingId, "File uploaded", {
                 description: "Your file has been uploaded successfully",
+                timeout: DEFAULT_TOAST_TIMEOUT,
                 variant: "success",
               });
             }, 3000);
@@ -414,6 +416,7 @@ const LoadingStateTemplate = () => {
             setTimeout(() => {
               toast.update(loadingId, "Payment processed", {
                 description: "Your payment has been processed successfully",
+                timeout: DEFAULT_TOAST_TIMEOUT,
                 variant: "success",
               });
             }, 2500);
@@ -433,6 +436,7 @@ const LoadingStateTemplate = () => {
             setTimeout(() => {
               toast.update(loadingId, "Failed to save", {
                 description: "Please try again",
+                timeout: DEFAULT_TOAST_TIMEOUT,
                 variant: "danger",
               });
             }, 2000);

--- a/packages/react/tests/components/toast/toast.test.tsx
+++ b/packages/react/tests/components/toast/toast.test.tsx
@@ -10,7 +10,13 @@ import {
   setupUser,
 } from "@heroui/testing/helpers";
 
-import {DEFAULT_EXIT_DURATION, DEFAULT_TOAST_TIMEOUT, Toast, ToastQueue} from "@/components/toast";
+import {
+  DEFAULT_EXIT_DURATION,
+  DEFAULT_TOAST_TIMEOUT,
+  Toast,
+  ToastQueue,
+  toast,
+} from "@/components/toast";
 
 describe("Toast", () => {
   let user: ReturnType<typeof setupUser>;
@@ -202,6 +208,76 @@ describe("Toast", () => {
     });
 
     expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("supports updating a persistent toast without starting a countdown", () => {
+    render(<Toast.Provider />);
+
+    let id = "";
+
+    act(() => {
+      id = toast("Saving", {timeout: 0});
+    });
+
+    act(() => {
+      toast.update(id, "Saved", {variant: "success"});
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_TOAST_TIMEOUT * 2);
+    });
+
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("Saved");
+
+    act(() => {
+      toast.clear();
+    });
+    advanceTimersByTime(DEFAULT_EXIT_DURATION);
+  });
+
+  it("calls the original onClose when an update omits it", () => {
+    const onClose = vi.fn();
+
+    render(<Toast.Provider />);
+
+    let id = "";
+
+    act(() => {
+      id = toast("Saving", {onClose, timeout: 0});
+    });
+
+    act(() => {
+      toast.update(id, "Saved");
+    });
+
+    act(() => {
+      toast.close(id);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    advanceTimersByTime(DEFAULT_EXIT_DURATION);
+  });
+
+  it("supports auto-dismiss once a promise toast settles", async () => {
+    render(<Toast.Provider />);
+
+    await act(async () => {
+      toast.promise(Promise.resolve("ok"), {
+        error: "Failed",
+        loading: "Uploading",
+        success: "Uploaded",
+      });
+    });
+
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("Uploaded");
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_TOAST_TIMEOUT);
+    });
+    advanceTimersByTime(DEFAULT_EXIT_DURATION);
+
+    expect(screen.queryByRole("alertdialog", {hidden: true})).toBeNull();
   });
 
   it("calls each onClose at dismissal and removes all toasts after clear", () => {


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

`toast.update` overwrote two options the caller deliberately left out.

`createQueueOptions` was shared between `add` and `update` and materialized every key:

```ts
const createQueueOptions = (options?: HeroUIToastOptions) => ({
  timeout: options?.timeout ?? DEFAULT_TOAST_TIMEOUT,
  onClose: options?.onClose,
});
```

That is correct for `add` and wrong for `update`, because `ExitAwareToastQueue.updateToast` distinguishes an absent key from an explicit `undefined` — and after this builder, neither is ever absent.

## ⛳️ Current behavior (updates)

- **`timeout`** — `options?.timeout !== undefined` is always true, so the "omit it to keep the current countdown" path documented on `ToastQueue.update` is unreachable through the `toast.update` helper. A toast created with `timeout: 0` or `timeout: 10000` silently drops to the 4s default after an in-place update.
- **`onClose`** — `updateToast` guards with `if (options && "onClose" in options)`, and the object literal always *has* the key, so an omitted `onClose` assigns `undefined` and wipes the original callback. `close()` reads `queuedToast.onClose` at dismissal, so the user's cleanup never runs.

Given the pattern the docs themselves recommend:

```tsx
const id = toast("Saving…", {timeout: 0, onClose: cleanup});
toast.update(id, "Saved", {variant: "success"});
// before: auto-dismisses in 4s, and cleanup never fires
```

The lost timeout is visible; the lost callback is not.

## 🚀 New behavior

Split the builder in two:

- `createAddOptions` resolves defaults, as `add` needs.
- `createUpdateOptions` forwards only the keys actually present on the caller's options, so the queue's inherit path works.

`toast.promise` now passes `timeout` explicitly when the promise settles. Its loading toast is added with `timeout: 0`, and restarting the countdown at that point is its documented behavior — with inheritance working, that has to be stated rather than fall out of the bug.

Also updated so they don't become never-dismissing:

- the three `LoadingState` stories in `toast.stories.tsx`
- the `toast.update` examples in `toast.mdx` (en + cn), which now also say that omitted options are inherited

## 💣 Is this a breaking change (Yes/No):

No. `toast.update` is new in `v3.2.5` and unreleased, so there is no published behavior to preserve — this aligns the helper with the contract its own low-level API already documents.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

Two new regression tests, both confirmed failing on `v3.2.5`:

- `supports updating a persistent toast without starting a countdown`
- `calls the original onClose when an update omits it`

Plus `supports auto-dismiss once a promise toast settles`, which pins the `toast.promise` behavior that inheritance would otherwise have changed.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (610 passed), browser (42 passed).
