### PR TITLE
fix(toast): make timer reset restart a running countdown

### DIFF
--- a/packages/react/src/components/toast/toast-queue.ts
+++ b/packages/react/src/components/toast/toast-queue.ts
@@ -40,7 +40,7 @@ export interface ToastQueueOptions {
 // The underlying react-stately queue passed to ToastRegion (not the HeroUI wrapper).
 export type StatelyToastQueue<T extends object = ToastContentValue> = ToastQueuePrimitiveType<T>;
 
-// Runtime shape of react-stately's unexported Timer. Its resume() has no running guard, which guardTimerResume() compensates for.
+// Runtime shape of react-stately's unexported Timer. Neither resume() nor reset() guards against an already-running timeout, which guardTimer() compensates for.
 type StatelyTimer = {
   pause(): void;
   reset(delay: number): void;
@@ -149,7 +149,7 @@ class ExitAwareToastQueue<T extends object> extends ToastQueuePrimitive<T> {
 
   // React Aria starts timers itself (useToast calls timer.reset on mount).
   // The wrap parks a timer while suspended and stops a resume-while-running from scheduling a second, orphaned timeout.
-  private guardTimerResume(timer: StatelyTimer): void {
+  private guardTimer(timer: StatelyTimer): void {
     if (guardedTimers.has(timer)) {
       return;
     }
@@ -157,6 +157,7 @@ class ExitAwareToastQueue<T extends object> extends ToastQueuePrimitive<T> {
     guardedTimers.add(timer);
 
     const originalResume = timer.resume.bind(timer);
+    const originalReset = timer.reset.bind(timer);
 
     timer.resume = () => {
       if (this.suspensions.size > 0 || timer.timerId != null) {
@@ -165,6 +166,14 @@ class ExitAwareToastQueue<T extends object> extends ToastQueuePrimitive<T> {
 
       originalResume();
     };
+
+    // reset() ends with resume(), but it does not clear a running timeout first,
+    // so the guard above would refuse to start the new delay and the old one would
+    // stick. Pausing makes reset mean "restart on this delay" in every case.
+    timer.reset = (delay: number) => {
+      timer.pause();
+      originalReset(delay);
+    };
   }
 
   override add(content: T, options?: RACToastOptions): string {
@@ -172,7 +181,7 @@ class ExitAwareToastQueue<T extends object> extends ToastQueuePrimitive<T> {
     const timer = this.visibleToasts.find((t) => t.key === key)?.timer as StatelyTimer | undefined;
 
     if (timer) {
-      this.guardTimerResume(timer);
+      this.guardTimer(timer);
     }
 
     return key;
@@ -209,7 +218,7 @@ class ExitAwareToastQueue<T extends object> extends ToastQueuePrimitive<T> {
       if (options.timeout > 0) {
         const timer = new ManagedToastTimer(() => this.close(key), options.timeout);
 
-        this.guardTimerResume(timer);
+        this.guardTimer(timer);
         // Stately's Timer type is unexported and nominally typed.
         queuedToast.timer = timer as unknown as typeof queuedToast.timer;
       } else {

--- a/packages/react/tests/components/toast/toast.test.tsx
+++ b/packages/react/tests/components/toast/toast.test.tsx
@@ -280,6 +280,40 @@ describe("Toast", () => {
     expect(screen.queryByRole("alertdialog", {hidden: true})).toBeNull();
   });
 
+  it("supports restarting a running timer through reset", () => {
+    const queue = new ToastQueue();
+
+    render(<Toast.Provider queue={queue} />);
+
+    act(() => {
+      queue.add({title: "Auto dismiss"}, {timeout: 1_000});
+    });
+
+    // React Aria owns the timers and calls reset() whenever the timeout changes,
+    // so reset has to restart the countdown even while one is already running.
+    const {timer} = queue.getQueue().visibleToasts[0]! as unknown as {
+      timer: {reset: (delay: number) => void};
+    };
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+      timer.reset(4_000);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    advanceTimersByTime(DEFAULT_EXIT_DURATION);
+
+    expect(screen.queryByRole("alertdialog", {hidden: true})).toBeNull();
+  });
+
   it("calls each onClose at dismissal and removes all toasts after clear", () => {
     const queue = new ToastQueue();
     const onCloseA = vi.fn();


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

`timer.reset(delay)` could silently keep the old countdown instead of restarting on the new one.

## ⛳️ Current behavior (updates)

`guardTimerResume` wraps `resume` so a resume-while-running cannot schedule a second, orphaned timeout:

```ts
timer.resume = () => {
  if (this.suspensions.size > 0 || timer.timerId != null) {
    return;
  }

  originalResume();
};
```

But react-stately's `reset` is just `remaining = delay; this.resume()` — it never clears a pending timeout first. `ManagedToastTimer` faithfully replicates that. So calling `reset` while a countdown is running hits the `timerId != null` early return, and the new delay is dropped while the old one keeps ticking.

Nothing in-tree reaches this today: `updateToast` mints a fresh timer identity whenever the timeout changes, which is what makes React Aria's `[timer, timeout]` effect restart cleanly. But React Aria owns the timers and calls `reset` on every timeout change, so this is a live trap for any future change that adjusts `timeout` without replacing the timer.

## 🚀 New behavior

Renamed `guardTimerResume` to `guardTimer` and wrapped `reset` alongside `resume` so it pauses first:

```ts
timer.reset = (delay: number) => {
  timer.pause();
  originalReset(delay);
};
```

`reset` now means "restart on this delay" in every case. Wrapping in the guard rather than in `ManagedToastTimer.reset` covers react-stately's own timers too, and keeps `ManagedToastTimer` the faithful replica its comment claims it is.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

New test `supports restarting a running timer through reset` advances halfway through a 1s countdown, resets to 4s, and asserts the toast is still there at the old deadline and gone at the new one. Confirmed failing on `v3.2.5`.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (608 passed), browser (42 passed).
