### PR TITLE
fix(toast): require an exact modifier match for the region hotkey

### DIFF
--- a/apps/docs/content/docs/cn/react/components/(overlays)/toast.mdx
+++ b/apps/docs/content/docs/cn/react/components/(overlays)/toast.mdx
@@ -180,7 +180,7 @@ Toast 使用以下 CSS 类（[查看源码样式](https://github.com/heroui-inc/
 | `gap` | `number` | `12` | Toast 之间的间距（像素） |
 | `isExpanded` | `boolean` | `false` | 强制堆叠保持展开布局（不会暂停计时器） |
 | `maxVisibleToasts` | `number` | `3` | 同时最多显示的 Toast 数量 |
-| `hotkey` | `string[]` | `["altKey", "KeyT"]` | 将焦点移入 Toast 区域并展开堆叠的快捷键。修饰键使用 `KeyboardEvent` 布尔属性名（如 `"altKey"`），其他按键使用 `event.code`（如 `"KeyT"`）；传 `[]` 可禁用 |
+| `hotkey` | `string[]` | `["altKey", "KeyT"]` | 将焦点移入 Toast 区域并展开堆叠的快捷键。修饰键使用 `KeyboardEvent` 布尔属性名（如 `"altKey"`），其他按键使用 `event.code`（如 `"KeyT"`）。未列出的修饰键必须处于松开状态，因此 `Alt`+`T` 不会在 `Ctrl`+`Alt`+`T` 时触发。传 `[]` 可禁用 |
 | `scaleFactor` | `number` | `0.05` | 堆叠 Toast 的缩放系数（0–1） |
 | `width` | `number \| string` | `460` | Toast 宽度（像素或 CSS 值） |
 | `queue` | `ToastQueue<T>` | - | 自定义 Toast 队列实例 |

--- a/apps/docs/content/docs/en/react/components/(overlays)/toast.mdx
+++ b/apps/docs/content/docs/en/react/components/(overlays)/toast.mdx
@@ -181,7 +181,7 @@ The component supports various states:
 | `gap` | `number` | `12` | The gap between toasts in pixels |
 | `isExpanded` | `boolean` | `false` | Force the stack into its expanded layout (does not pause timers) |
 | `maxVisibleToasts` | `number` | `3` | Maximum number of toasts to display at once |
-| `hotkey` | `string[]` | `["altKey", "KeyT"]` | Hotkey that moves focus to the toast region and expands the stack. Modifiers match `KeyboardEvent` boolean properties (e.g. `"altKey"`), other keys match `event.code` (e.g. `"KeyT"`); pass `[]` to disable |
+| `hotkey` | `string[]` | `["altKey", "KeyT"]` | Hotkey that moves focus to the toast region and expands the stack. Modifiers match `KeyboardEvent` boolean properties (e.g. `"altKey"`), other keys match `event.code` (e.g. `"KeyT"`). Modifiers you leave out must be up, so `Alt`+`T` does not also fire on `Ctrl`+`Alt`+`T`. Pass `[]` to disable |
 | `scaleFactor` | `number` | `0.05` | Scale factor for stacked toasts (0-1) |
 | `width` | `number \| string` | `460` | Width of the toast in pixels or CSS value |
 | `queue` | `ToastQueue<T>` | - | Custom toast queue instance |

--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -68,6 +68,9 @@ type ToastContext = {
 
 const ToastContext = createContext<ToastContext>({});
 
+// The KeyboardEvent boolean props a hotkey entry can name; anything else is an event.code.
+const MODIFIER_PROPS = ["altKey", "ctrlKey", "metaKey", "shiftKey"] as const;
+
 const EMPTY_EXITING_KEYS: ReadonlySet<string> = new Set();
 const getEmptyExitingKeys = (): ReadonlySet<string> => EMPTY_EXITING_KEYS;
 const subscribeToNothing = (): (() => void) => () => {};
@@ -533,7 +536,7 @@ interface ToastProviderProps<T extends object = ToastContentValue> extends Omit<
    */
   maxVisibleToasts?: number;
   /**
-   * Hotkey that focuses the toast region. Modifiers match KeyboardEvent boolean props, other keys match event.code. Pass [] to disable.
+   * Hotkey that focuses the toast region. Modifiers match KeyboardEvent boolean props, other keys match event.code. Modifiers left out must be up, so Alt+T does not fire on Ctrl+Alt+T. Pass [] to disable.
    * @default ["altKey", "KeyT"]
    */
   hotkey?: string[];
@@ -705,16 +708,29 @@ const ToastProvider = <T extends object = ToastContentValue>({
       const handleDocumentKeyDown = (event: KeyboardEvent) => {
         const hotkey = hotkeyRef.current;
 
-        // Modifiers match KeyboardEvent boolean props; other keys match event.code.
-        const isHotkeyPressed =
-          hotkey.length > 0 &&
-          hotkey.every(
-            (key) => (event as unknown as Record<string, unknown>)[key] || event.code === key,
-          );
-
-        if (isHotkeyPressed) {
-          node.focus();
+        if (hotkey.length === 0) {
+          return;
         }
+
+        // Modifiers match KeyboardEvent boolean props; other keys match event.code.
+        // Modifiers left out of the hotkey have to be up, so Alt+T does not also
+        // fire on Ctrl+Alt+T or Shift+Alt+T.
+        const hasExpectedModifiers = MODIFIER_PROPS.every(
+          (modifier) => event[modifier] === hotkey.includes(modifier),
+        );
+        const hasExpectedCodes = hotkey.every(
+          (key) =>
+            MODIFIER_PROPS.includes(key as (typeof MODIFIER_PROPS)[number]) || event.code === key,
+        );
+
+        if (!hasExpectedModifiers || !hasExpectedCodes) {
+          return;
+        }
+
+        // Claim the combination so the browser doesn't also act on it (Alt+letter
+        // opens the menu bar on Windows and Linux).
+        event.preventDefault();
+        node.focus();
       };
 
       node.addEventListener("pointerenter", handlePointerEnterOrMove);

--- a/packages/react/tests/components/toast/toast.test.tsx
+++ b/packages/react/tests/components/toast/toast.test.tsx
@@ -501,6 +501,26 @@ describe("Toast", () => {
     expect(screen.getByRole("region")).toHaveAttribute("data-expanded", "true");
   });
 
+  it("does not focus the region when extra modifiers are held", async () => {
+    const queue = new ToastQueue();
+
+    render(<Toast.Provider queue={queue} />);
+
+    act(() => {
+      queue.add({title: "First"});
+      queue.add({title: "Second"});
+    });
+
+    await user.keyboard("{Control>}{Alt>}t{/Alt}{/Control}");
+    expect(screen.getByRole("region")).not.toHaveFocus();
+
+    await user.keyboard("{Shift>}{Alt>}t{/Alt}{/Shift}");
+    expect(screen.getByRole("region")).not.toHaveFocus();
+
+    await user.keyboard("{Alt>}t{/Alt}");
+    expect(screen.getByRole("region")).toHaveFocus();
+  });
+
   it("does not focus the region when the hotkey is disabled", async () => {
     const queue = new ToastQueue();
 


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

The toast region hotkey fired on modifier combinations it shouldn't, and never claimed the key event.

## ⛳️ Current behavior (updates)

```ts
const isHotkeyPressed =
  hotkey.length > 0 &&
  hotkey.every((key) => (event as unknown as Record<string, unknown>)[key] || event.code === key);
```

`every` only checks that each *listed* key is satisfied, so any superset matches too. With the default `["altKey", "KeyT"]`:

- `Ctrl` + `Alt` + `T` focuses the region
- `Shift` + `Alt` + `T` focuses the region

There is also no `preventDefault()`, so the browser still acts on the same combination — `Alt` + letter opens the menu bar on Windows and Linux.

## 🚀 New behavior

Unlisted modifiers must now be up, and the event is claimed once matched:

```ts
const hasExpectedModifiers = MODIFIER_PROPS.every(
  (modifier) => event[modifier] === hotkey.includes(modifier),
);
```

`MODIFIER_PROPS` is the set of `KeyboardEvent` boolean props a hotkey entry can name (`altKey`, `ctrlKey`, `metaKey`, `shiftKey`); everything else is still matched against `event.code`. Passing `[]` still disables the hotkey entirely.

Docs updated in both locales, plus the `hotkey` JSDoc, to state that omitted modifiers must be up.

## 💣 Is this a breaking change (Yes/No):

No, unless someone was relying on `Ctrl`+`Alt`+`T` also opening the toast region, which was not intended or documented.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

New test `does not focus the region when extra modifiers are held` covers `Ctrl`+`Alt`+`T` and `Shift`+`Alt`+`T` not focusing, then plain `Alt`+`T` focusing. Confirmed failing on `v3.2.5`. The existing `supports a configurable hotkey` and `does not focus the region when the hotkey is disabled` tests still pass.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (608 passed), browser (42 passed).
