### PR TITLE
fix(toast): re-measure toast height when its width changes

### DIFF
--- a/packages/react/src/hooks/use-measured-height.ts
+++ b/packages/react/src/hooks/use-measured-height.ts
@@ -56,18 +56,28 @@ export const useMeasuredHeight = (ref: RefObject<HTMLDivElement | null>) => {
       subtree: true,
     });
 
-    let resizeTimeoutId: ReturnType<typeof setTimeout> | undefined;
-    const handleWindowResize = () => {
-      clearTimeout(resizeTimeoutId);
-      resizeTimeoutId = setTimeout(calculateHeight, 150);
-    };
+    // Content reflowing at a new width changes the measured height without
+    // touching the DOM, so the mutation observer above cannot see it. Only the
+    // inline axis is watched: consumers transition the block axis, and reacting
+    // to it would re-measure on every frame of that animation.
+    let lastWidth = element.getBoundingClientRect().width;
 
-    window.addEventListener("resize", handleWindowResize);
+    const resizeObserver = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+
+      if (width === undefined || Math.abs(width - lastWidth) < 0.5) {
+        return;
+      }
+
+      lastWidth = width;
+      scheduleMeasure();
+    });
+
+    resizeObserver.observe(element);
 
     return () => {
       mutationObserver.disconnect();
-      window.removeEventListener("resize", handleWindowResize);
-      clearTimeout(resizeTimeoutId);
+      resizeObserver.disconnect();
       cancelAnimationFrame(measureFrame);
     };
   }, [ref, calculateHeight]);


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

`useMeasuredHeight` swapped its `ResizeObserver` for a `MutationObserver` plus a debounced `window.resize` listener, which leaves a gap: content reflowing at a new width changes the measured height without any DOM mutation and without the window resizing.

## ⛳️ Current behavior (updates)

The `MutationObserver` covers DOM and attribute changes, but not layout. `window.resize` only fires for the viewport, so a toast that narrows because a container, sidebar, or flex sibling changed — text rewrapping from one line to two — keeps reporting the old height, and stacked toasts behind it are offset wrong. The 150ms debounce also means the viewport case itself lands a frame or two late.

## 🚀 New behavior

A `ResizeObserver` on the element replaces the `window.resize` listener, which is redundant once the element's own box is observed.

Only the inline axis is acted on:

```ts
const width = entries[0]?.contentRect.width;

if (width === undefined || Math.abs(width - lastWidth) < 0.5) {
  return;
}
```

Consumers transition the block axis, so reacting to height would re-measure on every frame of that animation — the reason the observer was dropped in the first place. The 0.5px threshold absorbs subpixel jitter. Measurement still goes through the existing `scheduleMeasure` / rAF path, so it stays batched.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

No new test: jsdom doesn't implement layout, so a width change there produces no `ResizeObserver` entry to assert on, and a stubbed observer would only test the stub. The existing toast stacking tests cover that measurement still flows through correctly.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (607 passed), browser (42 passed).
