### PR TITLE
fix(scroll-shadow): observe content instead of measuring per render

### DIFF
--- a/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
+++ b/packages/react/src/components/scroll-shadow/use-scroll-shadow.ts
@@ -137,9 +137,26 @@ export const useScrollShadow = (props: UseScrollShadowProps) => {
 
     resizeObserver.observe(el);
 
+    // The observer above only reports the container's own box, so content growing
+    // or shrinking inside a fixed-size container fires neither resize nor scroll
+    // and would leave the shadows stale. Watch the subtree for the DOM and style
+    // changes that cause it. Measuring on every render would also cover this, but
+    // it forces a layout read per render and lets an onVisibilityChange handler
+    // that shifts the container's own metrics drive an unbounded render loop.
+    const mutationObserver = new MutationObserver(checkOverflow);
+
+    mutationObserver.observe(el, {
+      attributeFilter: ["class", "style"],
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+
     return () => {
       el.removeEventListener("scroll", checkOverflow);
       resizeObserver.disconnect();
+      mutationObserver.disconnect();
 
       // Cancel pending RAF and cleanup cache
       if (rafIdRef.current !== null) {
@@ -149,14 +166,4 @@ export const useScrollShadow = (props: UseScrollShadowProps) => {
       prevStateRef.current = null;
     };
   }, [containerRef, visibility, isEnabled, checkOverflow]);
-
-  // ResizeObserver only reports the container's own box, so content growing or
-  // shrinking inside a fixed-size container fires neither resize nor scroll and
-  // would leave the shadows stale. Re-measuring after every render covers that;
-  // the prevStateRef guard keeps it a no-op unless the measurement changed.
-  useEffect(() => {
-    if (!isEnabled || visibility !== "auto") return;
-
-    checkOverflow();
-  });
 };

--- a/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
+++ b/packages/react/tests/components/scroll-shadow/scroll-shadow.test.tsx
@@ -48,6 +48,23 @@ const VisibilityHarness = ({
   );
 };
 
+/** Re-renders without touching anything inside the scroll container. */
+const InertRerenderHarness = () => {
+  const [renderCount, setRenderCount] = useState(0);
+
+  return (
+    <>
+      <button type="button" onClick={() => setRenderCount((count) => count + 1)}>
+        Re-render
+      </button>
+      <span data-testid="render-count">{renderCount}</span>
+      <ScrollShadow data-testid="scroll-shadow">
+        <p>Static content</p>
+      </ScrollShadow>
+    </>
+  );
+};
+
 const ContentGrowthHarness = () => {
   const [rows, setRows] = useState(1);
 
@@ -160,6 +177,34 @@ describe("ScrollShadow", () => {
       await flushFrames();
 
       expect(scrollShadow).toHaveAttribute("data-bottom-scroll", "true");
+    });
+
+    it("does not measure the container on a render that leaves the content alone", async () => {
+      const user = setupUser();
+
+      render(<InertRerenderHarness />);
+      await flushFrames();
+
+      const scrollShadow = screen.getByTestId("scroll-shadow");
+      let scrollHeightReads = 0;
+
+      Object.defineProperty(scrollShadow, "scrollHeight", {
+        configurable: true,
+        get() {
+          scrollHeightReads += 1;
+
+          return 300;
+        },
+      });
+
+      await user.click(screen.getByRole("button", {name: "Re-render"}));
+      await flushFrames();
+
+      expect(screen.getByTestId("render-count")).toHaveTextContent("1");
+      // Measuring per render forces a layout read on every unrelated update, and
+      // lets an onVisibilityChange handler that shifts the container's own
+      // metrics drive an unbounded render loop.
+      expect(scrollHeightReads).toBe(0);
     });
   });
 


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

`useScrollShadow` covered content-size changes with a dependency-less effect, so every render of the subtree forced a layout read — and could feed a render loop.

## ⛳️ Current behavior (updates)

```ts
useEffect(() => {
  if (!isEnabled || visibility !== "auto") return;

  checkOverflow();
});
```

`checkOverflow` reads `scrollHeight`, `clientHeight`, and `scrollTop`, so this forces a synchronous layout on every commit anywhere in the subtree, whether or not the content changed. `prevStateRef` dedupes the *state update*, not the measurement.

It also opens a loop: `onVisibilityChange` is a user callback, so if a consumer's handler renders something that shifts the container's own metrics, the resulting render re-measures, which can fire the callback again with no bound. The `prevStateRef` guard only stops it if the measurement settles.

## 🚀 New behavior

A `MutationObserver` in the existing effect, next to the `ResizeObserver`:

```ts
mutationObserver.observe(el, {
  attributeFilter: ["class", "style"],
  attributes: true,
  characterData: true,
  childList: true,
  subtree: true,
});
```

That covers the same cases the per-render effect was there for — children added or removed, text changing, styles toggled — but only when the DOM actually changes. `attributeFilter` keeps unrelated attribute churn (`data-*`, `aria-*`) from triggering measurements. Both observers share the same `checkOverflow` and rAF path, and the observer is torn down with the rest of the effect.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

New test `does not measure the container on a render that leaves the content alone` instruments `scrollHeight` with a counting getter, triggers a re-render from a sibling, and asserts zero reads. Confirmed failing on `v3.2.5` (2 reads).

The existing `ContentGrowthHarness` test — which adds rows inside the container — is what proves the `MutationObserver` picks up the case the removed effect was covering; it still passes.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (608 passed), browser (42 passed).
