### PR TITLE
fix(toast): stop naming toasts for view transitions

### DIFF
--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -275,11 +275,14 @@ const Toast = <T extends object = ToastContentValue>({
       heightsBefore += (key ? heightsByKey?.[key] : undefined) ?? frontHeight;
     }
 
+    // Deliberately unnamed for view transitions: stacking is animated with CSS
+    // transitions, so a name would only opt toasts into unrelated document-level
+    // transitions with no animation of their own. Consumers who set `wrapUpdate`
+    // can supply a `viewTransitionName` through the `style` prop, which merges.
     return {
       "--offset-collapsed": `${index * gap}px`,
       "--offset-expanded": `${heightsBefore + index * gap}px`,
       "--scale-collapsed": `${1 - index * finalScaleFactor}`,
-      viewTransitionName: `toast-${String(toast.key).replace(/[^a-zA-Z0-9]/g, "-")}`,
       zIndex: isExiting ? 0 : visibleToasts.length - fullIndex,
 
       ...(frontHeight != null
@@ -302,7 +305,6 @@ const Toast = <T extends object = ToastContentValue>({
     index,
     isExiting,
     layoutToasts,
-    toast,
     toastHeight,
     visibleToasts.length,
   ]);


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

Every toast sets a `viewTransitionName`, but nothing in the library uses it.

## ⛳️ Current behavior (updates)

```ts
viewTransitionName: `toast-${String(toast.key).replace(/[^a-zA-Z0-9]/g, "-")}`,
```

`wrapUpdate` has no default, so the queue never calls `document.startViewTransition` on its own, and `@heroui/styles` has no `::view-transition-*` rules for these names — only the global `:root { view-transition-name: none }` and `::view-transition { pointer-events: none }`. Stacking is animated with CSS transitions on `--offset-*` / `--scale-*`.

The cost isn't neutral. A named element participates in *any* view transition on the document, so an app that calls `startViewTransition` for its own routing gets every mounted toast snapshotted and cross-faded with no animation defined for it. `:root { view-transition-name: none }` exists specifically to keep page content out of that, and this puts toasts back in. It also forces each toast onto its own compositing layer for a name nothing reads.

The regex is a hint that this was written for a since-removed feature: it exists to sanitize keys into valid custom-ident values.

## 🚀 New behavior

Dropped the property, and `toast` with it from the memo's dependencies — it was only there for this. A comment records why toasts are deliberately unnamed, and that consumers who opt into `wrapUpdate` can still supply a `viewTransitionName` via the `style` prop, which merges over the memo.

## 💣 Is this a breaking change (Yes/No):

No. It's unreleased, and no CSS or JS in-tree references the names.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

No new test — this removes a property with no behavior attached, and jsdom doesn't implement view transitions. The existing stacking tests confirm the offset and scale variables the memo actually drives are unchanged.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (607 passed), browser (42 passed).
