### PR TITLE
refactor(toast): drop the unreachable frontHeight branch

### DIFF
--- a/packages/react/src/components/toast/toast.tsx
+++ b/packages/react/src/components/toast/toast.tsx
@@ -282,11 +282,8 @@ const Toast = <T extends object = ToastContentValue>({
       viewTransitionName: `toast-${String(toast.key).replace(/[^a-zA-Z0-9]/g, "-")}`,
       zIndex: isExiting ? 0 : visibleToasts.length - fullIndex,
 
-      ...(frontHeight != null
-        ? ({
-            "--front-height": `${frontHeight}px`,
-          } as CSSProperties)
-        : null),
+      // frontHeight always resolves to a number, so this is unconditional.
+      "--front-height": `${frontHeight}px`,
 
       ...(typeof toastHeight === "number"
         ? ({


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

Removes an unreachable branch in `Toast`'s `stackingStyle` memo.

## ⛳️ Current behavior (updates)

```ts
const frontHeight = (frontKey ? heightsByKey?.[frontKey] : undefined) ?? 0;

// ...

...(frontHeight != null
  ? ({"--front-height": `${frontHeight}px`} as CSSProperties)
  : null),
```

The `?? 0` fallback means `frontHeight` is always a `number`, so the null branch can never be taken — and the sibling `typeof toastHeight === "number"` check right below it is the shape this one is imitating, but `toastHeight` genuinely can be `undefined`.

## 🚀 New behavior

`--front-height` is set unconditionally, with a comment noting why. Same emitted style object, one less branch to reason about.

## 💣 Is this a breaking change (Yes/No):

No — the emitted styles are identical.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable
- [x] `pnpm test` passes locally

No new test: this is a no-op refactor, and the existing stacking tests already assert on `--front-height`.

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (607 passed), browser (42 passed).
