### PR TITLE
docs(toast): correct the exitDuration comments

### DIFF
--- a/packages/react/src/components/toast/constants.ts
+++ b/packages/react/src/components/toast/constants.ts
@@ -16,7 +16,9 @@ export const DEFAULT_TOAST_WIDTH = 460;
 // Auto-dismiss timeout in milliseconds.
 export const DEFAULT_TOAST_TIMEOUT = 4000;
 
-// How long a closing toast stays mounted for its exit animation, in milliseconds. Must match the transition-duration of the .toast[data-exiting="true"] rule in @heroui/styles.
+// How long a closing toast stays mounted for its exit animation, in milliseconds.
+// Must be at least the longest exit transition in @heroui/styles, which is the
+// frontmost toast's --toast-exit-duration (250ms); the rest is headroom.
 export const DEFAULT_EXIT_DURATION = 300;
 
 // Modifiers match KeyboardEvent boolean props; other keys match event.code.

--- a/packages/react/src/components/toast/toast-queue.ts
+++ b/packages/react/src/components/toast/toast-queue.ts
@@ -22,7 +22,7 @@ export interface ToastQueueOptions {
   /**
    * How long a closing toast stays mounted for its exit animation, in
    * milliseconds. Set to 0 to remove toasts immediately.
-   * @default 350
+   * @default 300
    */
   exitDuration?: number;
   /**


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

Two comments about `exitDuration` disagreed with the code.

## ⛳️ Current behavior (updates)

**`constants.ts`** claimed an exact match that doesn't hold:

```ts
// ... Must match the transition-duration of the .toast[data-exiting="true"] rule in @heroui/styles.
export const DEFAULT_EXIT_DURATION = 300;
```

The longest exit transition in `@heroui/styles` is 250ms (the frontmost toast's `--toast-exit-duration`); 300 is deliberately longer, so the toast stays mounted until the animation finishes. Read literally, the comment invites someone to "fix" the constant down to 250 and clip the tail of every exit animation.

**`toast-queue.ts`** documented a default that isn't the one applied:

```ts
/** @default 350 */
exitDuration?: number;
```

`ExitAwareToastQueue` falls back to `DEFAULT_EXIT_DURATION`, which is 300. `350` looks like a leftover from an earlier value, and it surfaces in IntelliSense and generated API docs.

## 🚀 New behavior

The constant's comment now states the real relationship — at least the longest CSS exit transition, with the rest as headroom — and the JSDoc says `300`.

## 💣 Is this a breaking change (Yes/No):

No, comments only.

## ✅ Testing

- [x] `pnpm test` passes locally

No behavior change; nothing to test. Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (607 passed), browser (42 passed).
