### PR TITLE
test(toast): guard the private react-stately update hook

### DIFF
--- a/packages/react/tests/components/toast/toast.test.tsx
+++ b/packages/react/tests/components/toast/toast.test.tsx
@@ -360,6 +360,16 @@ describe("Toast", () => {
     expect(region).not.toHaveFocus();
   });
 
+  it("exposes the react-stately method that in-place updates notify through", () => {
+    const inner = new ToastQueue().getQueue() as unknown as Record<string, unknown>;
+
+    // update() mutates a queued toast and then calls this method so React
+    // re-reads the queue. It is TypeScript-private and unstable upstream, and
+    // losing it silently downgrades updates to a partial re-render, so fail on
+    // the next React Aria bump rather than in a consumer's app.
+    expect(typeof inner["updateVisibleToasts"]).toBe("function");
+  });
+
   it("exposes data-swapped on the indicator after a promise-style update", () => {
     const queue = new ToastQueue();
 


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

Adds a drift alarm for the react-stately internal that `toast.update` depends on.

## ⛳️ Current behavior (updates)

In-place updates work by mutating a queued toast and then poking react-stately to re-read the queue:

```ts
const notify = (this as unknown as {updateVisibleToasts?: () => void}).updateVisibleToasts;

if (typeof notify === "function") {
  notify.call(this);
} else if (process.env.NODE_ENV !== "production") {
  console.warn("[HeroUI] ToastQueue.updateVisibleToasts is unavailable ...");
}
```

`updateVisibleToasts` is TypeScript-private and not part of react-stately's public surface. The cast plus soft fallback is the pragmatic call — but it means that if upstream renames or removes the method, the whole suite still passes and updates quietly degrade to a partial re-render. The failure surfaces in a consumer's app, behind a dev-only warning, after release.

## 🚀 New behavior

No source changes. One test asserting the method exists:

```ts
it("exposes the react-stately method that in-place updates notify through", () => {
  const inner = new ToastQueue().getQueue() as unknown as Record<string, unknown>;

  expect(typeof inner["updateVisibleToasts"]).toBe("function");
});
```

CI now fails on the react-aria bump that breaks the assumption, at the line that documents why it matters.

## 💣 Is this a breaking change (Yes/No):

No.

## ✅ Testing

- [x] Interactive / a11y contract changes include or update `*.test.tsx` coverage
- [x] `pnpm test` passes locally

Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (608 passed), browser (42 passed).
