### PR TITLE
docs(releases): correct the v3.2.5 release date

### DIFF
--- a/apps/docs/content/docs/cn/react/releases/index.mdx
+++ b/apps/docs/content/docs/cn/react/releases/index.mdx
@@ -11,7 +11,7 @@ description: HeroUI v3 的所有更新与变更，包含新功能、修复以及
 
 ### v3.2.5
 
-**2026 年 8 月 13 日**
+**2026 年 9 月 8 日**
 
 补丁版本：React Aria 升级到 `1.21.0`（`react-aria@3.52.0`），`@heroui/react` 再导出 `Pressable`、`Focusable`、`OverlayTriggerStateContext` 与 `DisclosureStateContext`，[Toast](/docs/components/toast) 支持堆叠并在悬停时展开，[Select](/docs/components/select) 新增 `ClearButton`，[Tabs](/docs/components/tabs) 新增 `align` 变体，[Accordion](/docs/components/accordion) 自定义悬停背景不再被默认触发器悬停色闪一下；嵌套 `data-theme` 作用域会级联 overlay 与表单 token，导出的变体也会应用原生 `:focus-visible` 焦点环；[Checkbox](/docs/components/checkbox)、[Switch](/docs/components/switch) 与 [Radio](/docs/components/radio) 内容中的 [Label](/docs/components/label) 会渲染为 `span`；Modal 级浮层会保持在关闭中的 Popover 之上，[Tag](/docs/components/tag) 的移除目标达到 24px，[ScrollShadow](/docs/components/scroll-shadow) 通过滚动时间线驱动淡出以避免 SSR 闪烁，并在内容尺寸变化时保持滚动属性同步；[Button](/docs/components/button)、Menu 和 Dropdown 仅在动画期间应用合成器提示，使 [Modal](/docs/components/modal) 重新打开后文本依然清晰；嵌套 [Drawer](/docs/components/drawer) 的把手现在只会关闭自身抽屉；[Table](/docs/components/table) 也会保留嵌套可编辑控件的按键输入；[NumberField](/docs/components/number-field) 在没有步进按钮时也不再预留侧栏空间；Toast 在传入自定义样式时也会保留区域 CSS 变量。
 

--- a/apps/docs/content/docs/cn/react/releases/v3-2-5.mdx
+++ b/apps/docs/content/docs/cn/react/releases/v3-2-5.mdx
@@ -6,7 +6,7 @@ github:
 ---
 
 <div className="flex items-center gap-3 mb-6">
-  <span className="text-sm text-muted">2026 年 8 月 13 日</span>
+  <span className="text-sm text-muted">2026 年 9 月 8 日</span>
 </div>
 
 补丁版本：React Aria 升级到 `1.21.0`（`react-aria@3.52.0`），`@heroui/react` 再导出 `Pressable`、`Focusable`、`OverlayTriggerStateContext` 与 `DisclosureStateContext`，[Toast](/docs/components/toast) 支持堆叠并在悬停时展开，[Select](/docs/components/select) 新增 `ClearButton`，[Tabs](/docs/components/tabs) 新增 `align` 变体，[Accordion](/docs/components/accordion) 自定义悬停背景不再被默认触发器悬停色闪一下；嵌套 `data-theme` 作用域会级联 overlay 与表单 token，导出的变体也会应用原生 `:focus-visible` 焦点环；[Checkbox](/docs/components/checkbox)、[Switch](/docs/components/switch) 与 [Radio](/docs/components/radio) 内容中的 [Label](/docs/components/label) 会渲染为 `span`；Modal 级浮层会保持在关闭中的 Popover 之上，[Tag](/docs/components/tag) 的移除目标达到 24px，[ScrollShadow](/docs/components/scroll-shadow) 通过滚动时间线驱动淡出以避免 SSR 闪烁，并在内容尺寸变化时保持滚动属性同步；[Button](/docs/components/button)、Menu 和 Dropdown 仅在动画期间应用合成器提示，使 [Modal](/docs/components/modal) 重新打开后文本依然清晰；嵌套 [Drawer](/docs/components/drawer) 的把手现在只会关闭自身抽屉；[Table](/docs/components/table) 也会保留嵌套可编辑控件的按键输入；[NumberField](/docs/components/number-field) 在没有步进按钮时也不再预留侧栏空间；Toast 在传入自定义样式时也会保留区域 CSS 变量。

--- a/apps/docs/content/docs/en/react/releases/index.mdx
+++ b/apps/docs/content/docs/en/react/releases/index.mdx
@@ -11,7 +11,7 @@ description: All updates and changes to HeroUI v3, including new features, fixes
 
 ### v3.2.5
 
-**August 13, 2026**
+**September 8, 2026**
 
 Patch release: React Aria is upgraded to `1.21.0` (`react-aria@3.52.0`), `@heroui/react` re-exports `Pressable`, `Focusable`, `OverlayTriggerStateContext`, and `DisclosureStateContext`, [Toast](/docs/components/toast) stacks notifications and expands on hover, [Select](/docs/components/select) gains a `ClearButton`, [Tabs](/docs/components/tabs) adds an `align` variant, [Accordion](/docs/components/accordion) no longer flashes the default trigger hover over a custom hover background, nested `data-theme` scopes cascade overlay and field tokens, native `:focus-visible` rings apply to exported variants, [Label](/docs/components/label) inside [Checkbox](/docs/components/checkbox), [Switch](/docs/components/switch), and [Radio](/docs/components/radio) content renders as a `span`, modal-level overlays stay above closing popovers, [Tag](/docs/components/tag) remove targets meet the 24px floor, [ScrollShadow](/docs/components/scroll-shadow) derives its fade from the scroll timeline to avoid SSR flicker and keeps scroll attributes in sync when content resizes, [Button](/docs/components/button), Menu, and Dropdown apply compositor hints only while animating so labels stay sharp after a [Modal](/docs/components/modal) reopens, a nested [Drawer](/docs/components/drawer) handle now closes only its own drawer, [Table](/docs/components/table) preserves keystrokes in nested editable controls, [NumberField](/docs/components/number-field) no longer reserves stepper columns when buttons are absent, and Toast keeps region CSS variables when custom styles are passed.
 

--- a/apps/docs/content/docs/en/react/releases/v3-2-5.mdx
+++ b/apps/docs/content/docs/en/react/releases/v3-2-5.mdx
@@ -6,7 +6,7 @@ github:
 ---
 
 <div className="flex items-center gap-3 mb-6">
-  <span className="text-sm text-muted">August 13, 2026</span>
+  <span className="text-sm text-muted">September 8, 2026</span>
 </div>
 
 Patch release: React Aria is upgraded to `1.21.0` (`react-aria@3.52.0`), `@heroui/react` re-exports `Pressable`, `Focusable`, `OverlayTriggerStateContext`, and `DisclosureStateContext`, [Toast](/docs/components/toast) stacks notifications and expands on hover, [Select](/docs/components/select) gains a `ClearButton`, [Tabs](/docs/components/tabs) adds an `align` variant, [Accordion](/docs/components/accordion) no longer flashes the default trigger hover over a custom hover background, nested `data-theme` scopes cascade overlay and field tokens, native `:focus-visible` rings apply to exported variants, [Label](/docs/components/label) inside [Checkbox](/docs/components/checkbox), [Switch](/docs/components/switch), and [Radio](/docs/components/radio) content renders as a `span`, modal-level overlays stay above closing popovers, [Tag](/docs/components/tag) remove targets meet the 24px floor, [ScrollShadow](/docs/components/scroll-shadow) derives its fade from the scroll timeline to avoid SSR flicker and keeps scroll attributes in sync when content resizes, [Button](/docs/components/button), Menu, and Dropdown apply compositor hints only while animating so labels stay sharp after a [Modal](/docs/components/modal) reopens, a nested [Drawer](/docs/components/drawer) handle now closes only its own drawer, [Table](/docs/components/table) preserves keystrokes in nested editable controls, [NumberField](/docs/components/number-field) no longer reserves stepper columns when buttons are absent, and Toast keeps region CSS variables when custom styles are passed.

--- a/apps/docs/src/lib/dictionaries/cn.json
+++ b/apps/docs/src/lib/dictionaries/cn.json
@@ -4,7 +4,7 @@
       {
         "label": "HeroUI React v3.2.5 — React Aria 1.21.0",
         "href": "/docs/react/releases/v3-2-5",
-        "date": "2026-08-13"
+        "date": "2026-09-08"
       },
       {
         "label": "HeroUI Native v1.0.9 — 补丁版本",

--- a/apps/docs/src/lib/dictionaries/en.json
+++ b/apps/docs/src/lib/dictionaries/en.json
@@ -4,7 +4,7 @@
       {
         "label": "HeroUI React v3.2.5 — React Aria 1.21.0",
         "href": "/docs/react/releases/v3-2-5",
-        "date": "2026-08-13"
+        "date": "2026-09-08"
       },
       {
         "label": "HeroUI Native v1.0.9 — patch release",


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

The `v3.2.5` release notes are dated **August 13, 2026**, which is roughly a month before the release actually ships. Updated to **September 8, 2026** across all six places the date is duplicated:

- `apps/docs/content/docs/{en,cn}/react/releases/v3-2-5.mdx` — the release page frontmatter
- `apps/docs/content/docs/{en,cn}/react/releases/index.mdx` — the release index card
- `apps/docs/src/lib/dictionaries/{en,cn}.json` — the dictionary entry

The date is hand-maintained in three pairs of files, so it's easy for one to drift; this keeps all six in sync.

## ⛳️ Current behavior (updates)

Docs advertise a release date about a month earlier than the release.

## 🚀 New behavior

All six occurrences read September 8, 2026.

If the release slips again, this is the set of files to touch.

## 💣 Is this a breaking change (Yes/No):

No, docs only.

## ✅ Testing

- [x] `pnpm test` passes locally

No code change. Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (607 passed), browser (42 passed).
