### PR TITLE
docs(releases): note the react-aria peer bump in v3.2.5

### DIFF
--- a/apps/docs/content/docs/cn/react/releases/v3-2-5.mdx
+++ b/apps/docs/content/docs/cn/react/releases/v3-2-5.mdx
@@ -38,6 +38,10 @@ github:
   </Tab>
 </Tabs>
 
+<Callout type="warning">
+  **对等依赖已变更。** 本次发布要求 `react-aria-components@^1.21.0` 与 `react-aria@^3.52.0`。若你锁定了这两个包的版本，请在同一次安装中一并升级，否则包管理器会报对等依赖冲突。
+</Callout>
+
 <Callout type="info">
   **正在使用 AI 助手？** 对它说「Hey Cursor，把 HeroUI 升级到最新版本」。它会自动对比版本并应用必要变更。了解更多请参阅 [HeroUI MCP 服务器](/docs/ui-for-agents/mcp-server)。
 </Callout>

--- a/apps/docs/content/docs/en/react/releases/v3-2-5.mdx
+++ b/apps/docs/content/docs/en/react/releases/v3-2-5.mdx
@@ -38,6 +38,10 @@ Update to the latest version:
   </Tab>
 </Tabs>
 
+<Callout type="warning">
+  **Peer dependencies changed.** This release requires `react-aria-components@^1.21.0` and `react-aria@^3.52.0`. If you pin either package, update it in the same install or your package manager will report a peer dependency conflict.
+</Callout>
+
 <Callout type="info">
   **Using AI assistants?** Simply prompt "Hey Cursor, update HeroUI to the latest version" and your AI assistant will automatically compare versions and apply the necessary changes. Learn more about the [HeroUI MCP Server](/docs/ui-for-agents/mcp-server).
 </Callout>


### PR DESCRIPTION
Found while reviewing #6792. Targets `v3.2.5`.

## 📝 Description

`v3.2.5` raises the `react-aria-components` peer range to `^1.21.0` and `react-aria` to `^3.52.0`, but the release notes don't mention it. The Installation section is just the `pnpm add @heroui/react@latest` tabs.

## ⛳️ Current behavior (updates)

Anyone pinning either package — a lockfile-committed app, a library re-exporting HeroUI — hits a peer dependency conflict on install, or worse, an `npm install --legacy-peer-deps` that resolves to an older `react-aria` and then fails at runtime inside code that assumes the new version. Nothing in the notes tells them what to do about it.

This isn't incidental to the release: the toast changes depend on newer react-aria internals, so the bump is load-bearing.

## 🚀 New behavior

A warning callout above the existing info callout in the Installation section, in both locales, naming both versions and saying to update them in the same install.

## 💣 Is this a breaking change (Yes/No):

No — this documents a change already in the release.

## ✅ Testing

- [x] `pnpm test` passes locally

Docs only. Verified on this branch: `pnpm lint`, `pnpm typecheck`, jsdom (607 passed), browser (42 passed).
