### PR TITLE
fix(styles): resolve theme tokens inside shadow DOM

### DIFF
--- a/packages/styles/themes/default/variables.css
+++ b/packages/styles/themes/default/variables.css
@@ -1,14 +1,13 @@
 @layer base {
   /* HeroUI Default Theme */
+
+  /*
+   * == Common Variables ==
+   * Identical in every theme, so they are also declared on `:host`: `:root` matches
+   * nothing inside a shadow tree, and the theme blocks below never re-declare these.
+   */
   :root,
-  .light,
-  .default,
-  [data-theme="light"],
-  [data-theme="default"] {
-    color-scheme: light;
-
-    /* == Common Variables == */
-
+  :host {
     /* Primitive Colors (Do not change between light and dark) */
     --white: oklch(100% 0 0);
     --black: oklch(0% 0 0);
@@ -33,6 +32,35 @@
     /* Radius */
     --radius: 0.5rem;
     --field-radius: calc(var(--radius) * 1.5);
+
+    /* Accent and status hues (shared with the dark theme) */
+    --accent: oklch(0.6204 0.195 253.83);
+    --accent-foreground: var(--snow);
+
+    --success: oklch(0.7329 0.1935 150.81);
+    --success-foreground: var(--eclipse);
+
+    /* no border by default on form fields */
+    --field-border: transparent;
+
+    /* Skeleton Default Global Animation */
+    --skeleton-animation: shimmer; /* shimmer, pulse, none */
+
+    /* Tooltip Default Delays */
+    --tooltip-delay: 1500ms;
+    --tooltip-close-delay: 500ms;
+  }
+
+  :root,
+  .light,
+  .default,
+  [data-theme="light"],
+  [data-theme="default"],
+  :host(.light),
+  :host(.default),
+  :host([data-theme="light"]),
+  :host([data-theme="default"]) {
+    color-scheme: light;
 
     /* == Light Theme Variables == */
 
@@ -66,19 +94,12 @@
     --default: oklch(94% 0.001 286.375);
     --default-foreground: var(--eclipse);
 
-    --accent: oklch(0.6204 0.195 253.83);
-    --accent-foreground: var(--snow);
-
     /* Form Fields */
     --field-background: var(--white);
     --field-foreground: oklch(0.2103 0.0059 285.89);
     --field-placeholder: var(--muted);
-    --field-border: transparent; /* no border by default on form fields */
 
     /* Status Colors */
-    --success: oklch(0.7329 0.1935 150.81);
-    --success-foreground: var(--eclipse);
-
     --warning: oklch(0.7819 0.1585 72.33);
     --warning-foreground: var(--eclipse);
 
@@ -166,16 +187,12 @@
     --field-shadow:
       0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
       0 0 1px 0 rgba(0, 0, 0, 0.06);
-    /* Skeleton Default Global Animation */
-    --skeleton-animation: shimmer; /* shimmer, pulse, none */
-
-    /* Tooltip Default Delays */
-    --tooltip-delay: 1500ms;
-    --tooltip-close-delay: 500ms;
   }
 
   .dark,
-  [data-theme="dark"] {
+  [data-theme="dark"],
+  :host(.dark),
+  :host([data-theme="dark"]) {
     color-scheme: dark;
     /* == Dark Theme Variables == */
 


### PR DESCRIPTION
Closes #6530

## 📝 Description

`:root` never matches inside a shadow tree, so a stylesheet adopted into a ShadowRoot lost every theme token that was only declared in the `:root, .light, .default, [data-theme=…]` block. This hoists the mode-independent tokens into a `:root, :host` block and gives the light and dark blocks host-scoped selectors.

One file changed: `packages/styles/themes/default/variables.css` (+39 / -22). No component, JS, or public API changes.

## ⛳️ Current behavior (updates)

In a normal page the theme class sits on `<html>`, which *is* `:root`, so the light block and the dark override both apply and everything resolves. Inside a ShadowRoot, `:root` matches nothing, which breaks two ways:

- **`.dark` on a wrapper inside the shadow root** — 60 of 89 tokens go unresolved: `--radius`, `--border-width`, the accent/success hues, `--white`/`--snow`, and therefore the dark `--foreground` (defined as  `var(--snow)`). Result: **black text on dark surfaces** and 0px radii.
- **Theme class on the shadow host** — 88 of 89 tokens unresolved. Nothing was themed at all, since no `:host(...)` selectors existed.

This also silently broke **light** mode. Eleven components read `var(--radius-3xl)` directly in CSS rather than through a utility, and that Tailwind alias is declared at `:host`, where it resolved against an undefined `--radius`. `alert`, `accordion`, `alert-dialog`, `autocomplete`, `card`, `combo-box`, `dropdown`, `modal`, `popover`, `select`, and `toast` all rendered with **0px radius in both themes**.

## 🚀 New behavior

With the stylesheet adopted only into a ShadowRoot, all 89 tokens resolve in every layout:

| Layout | Unresolved tokens | Button radius |
| --- | --- | --- |
| `.dark` on inner wrapper | 60 → **0** | 0px → **24px** |
| `.dark` on host | 88 → **0** | 0px → **24px** |
| `[data-theme="dark"]` on host | 88 → **0** | 0px → **24px** |
| `.light` on host | 88 → **0** | 0px → **24px** |

All 11 components above now measure 24px radius in both themes.

A light baseline is deliberately **not** placed on bare `:host`. A declaration on the host would override the page theme inherited through it, breaking web components in themed documents. A ShadowRoot therefore still needs an explicit `.light`, `.dark`, or `data-theme` on the host or a wrapper — which is what the theming docs already ask for.

## 💣 Is this a breaking change (Yes/No):

**No.** `:host` rules are inert in a normal document. Verified by building the same commit with and without the patch and diffing rendered screenshots: the document cases (light, dark, and shadow-inherits-page-theme) are **byte-for-byte pixel-identical**. Token accounting is also unchanged at 89 before and after, with the light and dark blocks now holding exactly 68 each.

Cost: **+178 bytes gzipped** (+0.46%); +7.4 KB uncompressed, which gzip absorbs since it is repeated selector text.

## ✅ Testing

- [ ] Interactive / a11y contract changes include or update `*.test.tsx` coverage — N/A, CSS-only with no interactive or a11y contract change
- [x] Scenarios cover roles, `data-*` states, keyboard, disabled, and callbacks as applicable — N/A for this change
- [x] `pnpm test` passes locally — 656 tests across 124 files
- [x] Prettier clean

Verified with a Playwright harness that adopts the built stylesheet into a real ShadowRoot via `adoptedStyleSheets` and reads computed styles across seven host/document layouts, comparing builds of the same commit with and without the patch.

## 📝 Additional Information

[PR #6646](https://github.com/heroui-inc/heroui/pull/6646) targeted the same issue but patched the v2 `@heroui/theme` Tailwind plugin, which does not exist in v3; it was closed.

The originally reported symptom — components reading `var(--color-*)` and freezing at the document root — was real in 3.0.4 and was fixed separately by `15cd8b054e`, released in v3.0.5. This PR fixes the remaining `:root`-versus-shadow-tree gap that kept dark mode broken in a ShadowRoot on 3.2.x.

Two related gaps left out of scope, as neither affects HeroUI's own components: the `dark:` utility variant uses `.dark *`, which cannot cross a shadow boundary, so consumer `dark:` classes will not fire when the theme class is on the host; and `--z-index-overlay` in `base/base.css` is `:root`-only.