### PR TITLE
fix(styles): only ring list-box and menu items on real keyboard focus

### DIFF
--- a/packages/react/tests/components/select/select.browser.test.tsx
+++ b/packages/react/tests/components/select/select.browser.test.tsx
@@ -20,6 +20,9 @@ const disableTransitions = () => {
 const ringOf = (name: string) =>
   getComputedStyle(page.getByRole("option", {name}).element()).boxShadow;
 
+const triggerRing = () =>
+  getComputedStyle(page.getByRole("button", {name: "State"}).element()).boxShadow;
+
 describe("Select (browser)", () => {
   it("opens the listbox, shows options, and restores focus to the trigger after Escape", async () => {
     await renderSelect();
@@ -114,6 +117,56 @@ describe("Select (browser)", () => {
           .toHaveAttribute("data-focus-visible", "true");
         expect(ringOf("California")).not.toBe("none");
         expect(ringOf("Florida")).toBe("none");
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe("trigger focus ring", () => {
+    // Focus is restored to the trigger when the listbox closes, which is a
+    // second path into the browser's focus-visible heuristic.
+    it("supports selecting with the mouse without ringing the trigger", async () => {
+      const restore = disableTransitions();
+
+      try {
+        await render(<SelectFixture defaultValue="california" />);
+
+        const trigger = page.getByRole("button", {name: "State"});
+        const unringed = triggerRing();
+
+        await trigger.click();
+        await expect.element(page.getByRole("listbox")).toBeInTheDocument();
+
+        await page.getByRole("option", {name: "Texas"}).click();
+        await expect.element(page.getByRole("listbox")).not.toBeInTheDocument();
+
+        await expect.element(trigger).toHaveFocus();
+        await expect.element(trigger).not.toHaveAttribute("data-focus-visible");
+        expect(triggerRing()).toBe(unringed);
+      } finally {
+        restore();
+      }
+    });
+
+    it("supports selecting with the keyboard and rings the trigger", async () => {
+      const restore = disableTransitions();
+
+      try {
+        await render(<SelectFixture defaultValue="california" />);
+
+        const trigger = page.getByRole("button", {name: "State"});
+        const unringed = triggerRing();
+
+        await trigger.click();
+        await expect.element(page.getByRole("listbox")).toBeInTheDocument();
+
+        await userEvent.keyboard("{ArrowDown}");
+        await userEvent.keyboard("{Enter}");
+        await expect.element(page.getByRole("listbox")).not.toBeInTheDocument();
+
+        await expect.element(trigger).toHaveAttribute("data-focus-visible", "true");
+        expect(triggerRing()).not.toBe(unringed);
       } finally {
         restore();
       }

--- a/packages/react/tests/components/select/select.browser.test.tsx
+++ b/packages/react/tests/components/select/select.browser.test.tsx
@@ -3,7 +3,22 @@ import {page, userEvent} from "vitest/browser";
 
 import {SelectFixture} from "./fixtures";
 
+import "@/styles.css";
+
 const renderSelect = () => render(<SelectFixture />);
+
+/** The focus ring transitions in, so settle it to read a steady-state box-shadow. */
+const disableTransitions = () => {
+  const style = document.createElement("style");
+
+  style.textContent = "*, *::before, *::after { transition: none !important; }";
+  document.head.append(style);
+
+  return () => style.remove();
+};
+
+const ringOf = (name: string) =>
+  getComputedStyle(page.getByRole("option", {name}).element()).boxShadow;
 
 describe("Select (browser)", () => {
   it("opens the listbox, shows options, and restores focus to the trigger after Escape", async () => {
@@ -24,6 +39,85 @@ describe("Select (browser)", () => {
 
     await expect.element(listbox).not.toBeInTheDocument();
     await expect.element(trigger).toHaveFocus();
+  });
+
+  describe("focus ring", () => {
+    // React Aria restores focus to the selected option on open, so a native
+    // `:focus-visible` rule would paint a ring even for a mouse-driven open.
+    it("supports opening with the mouse without ringing the focused option", async () => {
+      const restore = disableTransitions();
+
+      try {
+        await render(<SelectFixture defaultValue="california" />);
+
+        await page.getByRole("button", {name: "State"}).click();
+        await expect.element(page.getByRole("listbox")).toBeInTheDocument();
+
+        const selected = page.getByRole("option", {name: "California"});
+
+        await expect.element(selected).toHaveFocus();
+        await expect.element(selected).not.toHaveAttribute("data-focus-visible");
+        expect(ringOf("California")).toBe("none");
+      } finally {
+        restore();
+      }
+    });
+
+    it("supports opening with the keyboard and rings the focused option", async () => {
+      const restore = disableTransitions();
+
+      try {
+        await render(<SelectFixture defaultValue="california" />);
+
+        const trigger = page.getByRole("button", {name: "State"});
+
+        // Open and dismiss with the mouse first, so the reopen below is the
+        // only keyboard-driven open in the test.
+        await trigger.click();
+        await expect.element(page.getByRole("listbox")).toBeInTheDocument();
+
+        await userEvent.keyboard("{Escape}");
+        await expect.element(page.getByRole("listbox")).not.toBeInTheDocument();
+        await expect.element(trigger).toHaveFocus();
+
+        await userEvent.keyboard("{Enter}");
+        await expect.element(page.getByRole("listbox")).toBeInTheDocument();
+
+        const selected = page.getByRole("option", {name: "California"});
+
+        await expect.element(selected).toHaveAttribute("data-focus-visible", "true");
+        expect(ringOf("California")).not.toBe("none");
+      } finally {
+        restore();
+      }
+    });
+
+    it("supports arrow navigation moving the ring to the newly focused option", async () => {
+      const restore = disableTransitions();
+
+      try {
+        await renderSelect();
+
+        await page.getByRole("button", {name: "State"}).click();
+        await expect.element(page.getByRole("listbox")).toBeInTheDocument();
+
+        await userEvent.keyboard("{ArrowDown}");
+
+        await expect
+          .element(page.getByRole("option", {name: "Florida"}))
+          .toHaveAttribute("data-focus-visible", "true");
+
+        await userEvent.keyboard("{ArrowDown}");
+
+        await expect
+          .element(page.getByRole("option", {name: "California"}))
+          .toHaveAttribute("data-focus-visible", "true");
+        expect(ringOf("California")).not.toBe("none");
+        expect(ringOf("Florida")).toBe("none");
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe("clear button", () => {

--- a/packages/styles/components/accordion.css
+++ b/packages/styles/components/accordion.css
@@ -89,7 +89,7 @@
   }
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/alert-dialog.css
+++ b/packages/styles/components/alert-dialog.css
@@ -21,7 +21,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/autocomplete.css
+++ b/packages/styles/components/autocomplete.css
@@ -37,7 +37,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
     border-color: var(--field-border-focus);
@@ -85,7 +85,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     background-color: var(--autocomplete-trigger-bg-focus);
   }
@@ -135,7 +135,7 @@
   box-shadow: var(--overlay-shadow);
 
   &:focus,
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/button-group.css
+++ b/packages/styles/components/button-group.css
@@ -61,7 +61,7 @@
 }
 
 /* Raise focused button so its outward focus ring + gap shows above adjacent buttons */
-.button-group .button:focus-visible,
+.button-group .button:focus-visible:not([data-focused]),
 .button-group .button[data-focus-visible="true"] {
   @apply z-10;
 }

--- a/packages/styles/components/button.css
+++ b/packages/styles/components/button.css
@@ -27,7 +27,7 @@
   color: var(--button-fg);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/calendar.css
+++ b/packages/styles/components/calendar.css
@@ -198,7 +198,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/close-button.css
+++ b/packages/styles/components/close-button.css
@@ -19,7 +19,7 @@
   @apply transform-gpu motion-reduce:transition-none;
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/color-picker.css
+++ b/packages/styles/components/color-picker.css
@@ -31,7 +31,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -56,7 +56,7 @@
   @apply flex flex-col gap-3;
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/combo-box.css
+++ b/packages/styles/components/combo-box.css
@@ -70,7 +70,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply rounded ring-2 ring-focus ring-offset-2 ring-offset-background outline-none;
   }
@@ -104,7 +104,7 @@
   box-shadow: var(--overlay-shadow);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/date-picker.css
+++ b/packages/styles/components/date-picker.css
@@ -23,7 +23,7 @@
   transition: box-shadow 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -46,7 +46,7 @@
   box-shadow: var(--overlay-shadow);
   border-radius: min(32px, calc(var(--radius) * 2.5));
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/date-range-picker.css
+++ b/packages/styles/components/date-range-picker.css
@@ -23,7 +23,7 @@
   transition: box-shadow 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -50,7 +50,7 @@
   box-shadow: var(--overlay-shadow);
   border-radius: min(32px, calc(var(--radius) * 2.5));
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/disclosure.css
+++ b/packages/styles/components/disclosure.css
@@ -12,7 +12,7 @@
   @apply inline-block no-highlight;
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/drawer.css
+++ b/packages/styles/components/drawer.css
@@ -20,7 +20,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/dropdown.css
+++ b/packages/styles/components/dropdown.css
@@ -24,7 +24,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }
@@ -54,7 +54,7 @@
   box-shadow: var(--overlay-shadow);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/input.css
+++ b/packages/styles/components/input.css
@@ -31,7 +31,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
   }
 
@@ -75,7 +75,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/link.css
+++ b/packages/styles/components/link.css
@@ -39,7 +39,7 @@
   }
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
 

--- a/packages/styles/components/list-box-item.css
+++ b/packages/styles/components/list-box-item.css
@@ -31,8 +31,10 @@
     @apply pe-7;
   }
 
-  /* Focus visible state (keyboard focus only) */
-  &:focus-visible,
+  /* Focus visible state (keyboard focus only).
+     React Aria always sets data-focused when it owns the item, so the native
+     fallback is scoped to consumers rendering this class outside React Aria. */
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/menu-item.css
+++ b/packages/styles/components/menu-item.css
@@ -40,8 +40,10 @@
     @apply ps-2 pe-7;
   }
 
-  /* Focus visible state (keyboard focus only) */
-  &:focus-visible,
+  /* Focus visible state (keyboard focus only).
+     React Aria always sets data-focused when it owns the item, so the native
+     fallback is scoped to consumers rendering this class outside React Aria. */
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/modal.css
+++ b/packages/styles/components/modal.css
@@ -20,7 +20,7 @@
   @apply motion-reduce:transition-none;
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/number-field.css
+++ b/packages/styles/components/number-field.css
@@ -152,7 +152,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/popover.css
+++ b/packages/styles/components/popover.css
@@ -86,7 +86,7 @@
   cursor: var(--cursor-interactive);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/range-calendar.css
+++ b/packages/styles/components/range-calendar.css
@@ -205,7 +205,7 @@
   }
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply z-2;
 

--- a/packages/styles/components/select.css
+++ b/packages/styles/components/select.css
@@ -48,7 +48,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
     border-color: var(--field-border-focus);
@@ -96,7 +96,7 @@
     }
   }
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     background-color: var(--select-trigger-bg-focus);
   }
@@ -186,7 +186,7 @@
   box-shadow: var(--overlay-shadow);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply outline-none;
   }

--- a/packages/styles/components/tabs.css
+++ b/packages/styles/components/tabs.css
@@ -164,7 +164,7 @@
   }
 
   /* Focus states - comprehensive fallback */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/textarea.css
+++ b/packages/styles/components/textarea.css
@@ -34,7 +34,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
   }
 
@@ -77,7 +77,7 @@
   }
 
   /* Focus visible state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
   }
 

--- a/packages/styles/components/toggle-button-group.css
+++ b/packages/styles/components/toggle-button-group.css
@@ -73,7 +73,7 @@
 }
 
 /* Override focus ring to use inset style so it stays within button bounds */
-.toggle-button-group .toggle-button:focus-visible,
+.toggle-button-group .toggle-button:focus-visible:not([data-focused]),
 .toggle-button-group .toggle-button[data-focus-visible="true"] {
   --tw-ring-offset-width: 0px;
   @apply ring-inset;

--- a/packages/styles/components/toggle-button.css
+++ b/packages/styles/components/toggle-button.css
@@ -35,7 +35,7 @@
   color: var(--toggle-button-fg);
 
   /* Focus state */
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }

--- a/packages/styles/components/tooltip.css
+++ b/packages/styles/components/tooltip.css
@@ -74,7 +74,7 @@
     box-shadow 150ms var(--ease-out);
   @apply motion-reduce:transition-none;
 
-  &:focus-visible,
+  &:focus-visible:not([data-focused]),
   &[data-focus-visible="true"] {
     @apply status-focused;
   }


### PR DESCRIPTION
## Problem

Since `@heroui/styles` 3.2.5, clicking a select or menu that has a current selection paints a focus ring on the auto-focused option. The ring should only appear during keyboard navigation.

Reported downstream on the dashboard product switcher ([heroui-pro#1214](https://github.com/heroui-inc/heroui-pro/pull/1214), which carries a local workaround).

## Cause

3.2.5 removed `:not(:focus)` from the focus rules across ~28 CSS files:

```diff
- &:focus-visible:not(:focus),
+ &:focus-visible,
  &[data-focus-visible="true"] {
```

`:focus-visible:not(:focus)` can never match — anything `:focus-visible` is also `:focus`. The guard made the native selector inert, so the ring had only ever been driven by React Aria's `data-focus-visible`. Removing it activated the native path for the first time.

React Aria restores DOM focus to the selected option when a listbox or menu opens, and Chromium treats that option as focus-visible even for a mouse-driven open — so the ring appears while `data-focus-visible` is absent.

Runtime A/B with identical DOM state on mouse open (`isActiveElement: true`, `matches(":focus-visible"): true`, `data-focus-visible: null`), changing only the selector:

| Selector | `box-shadow` on the focused option |
| --- | --- |
| `&:focus-visible` (3.2.5) | `oklab(0.6204 …) 0 0 0 0.76px` — ring rendering |
| `&:focus-visible:not(:focus)` (3.2.4) | `none` |

## Fix

Scope the native fallback to elements React Aria doesn't own. RAC always sets `data-focused` on items it focuses, so the ring comes solely from `data-focus-visible` there, while bare-class consumers outside RAC keep working.

```css
&:focus-visible:not([data-focused]),
&[data-focus-visible="true"] {
```

Reinstating `:not(:focus)` would restore the behaviour but keep a selector that can never match.

## Scope

The regression reaches any React Aria-managed element that receives focus programmatically, via two paths: focus moving **into** an overlay on open (list-box and menu items), and focus being **restored** to a trigger on close (select and dropdown triggers).

Enumerating the affected surfaces proved unreliable — whether Chromium grants focus-visible depends on the interaction path and can shift between versions. So this applies the guard mechanically wherever the 3.2.5 sweep landed: 37 selectors across 26 files.

The guard is safe by construction on React Aria elements: RAC always sets `data-focused` when it owns an element, and sets `data-focus-visible` when the focus genuinely is keyboard-driven. The attribute path therefore covers RAC fully, and the native path remains a fallback for bare-class consumers.

`calendar.css` and `range-calendar.css` nav buttons are excluded — they were already bare `:focus-visible` before 3.2.5 and are not part of this regression. `input.css`/`textarea.css` focus-visible blocks are empty; their ring comes from `:focus`/`[data-focused]` and is unchanged.

Evidence is Chromium-only; `:focus-visible` heuristics vary by engine.

## Tests

Three browser tests in the Select suite:

- mouse open → no ring, no `data-focus-visible`
- keyboard open → ring present on the focused option
- arrow navigation → ring follows focus

They disable transitions so assertions read a steady-state `box-shadow` rather than racing the 150ms animation. Verified as a real guard: reverting the CSS makes the mouse-open test fail. Full browser suite 45/45.

Note: these assert computed `box-shadow` against `none`, which brushes against the usual "don't assert on styles" guidance. It's the only way to catch this class of regression, since the `data-*` attributes were already correct in the broken build.